### PR TITLE
feat(api): statut par API dans les réponses de lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Statut API dans les réponses de lookup** : Les endpoints `/api/isbn-lookup` et `/api/title-lookup` incluent désormais un objet `apiMessages` indiquant le statut de chaque API interrogée (success, not_found, error, rate_limited) avec des badges colorés dans l'interface
 - **Amélioration upload couverture** : Meilleure UX pour l'upload d'images
   - Activation de Symfony UX Dropzone avec prévisualisation du fichier sélectionné
   - Ajout checkbox "Supprimer" pour effacer l'image existante

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,9 +166,10 @@ tests/                        features/
 
 **CoverRemoverInterface**: `remove(ComicSeries): void` — Impl: `VichCoverRemover`
 
-**IsbnLookupService**: `lookup(isbn, ?type): ?array`, `lookupByTitle(title, ?type): ?array`
+**IsbnLookupService**: `lookup(isbn, ?type): ?array`, `lookupByTitle(title, ?type): ?array`, `getLastApiMessages(): array`
 - APIs: Google Books, Open Library, AniList (mangas)
 - Returns: `[title, authors, description, publishedDate, publisher, isbn, thumbnail, isOneShot, sources]`
+- `getLastApiMessages()`: statut de chaque API interrogée (`{api_name: {status, message}}`), utilise `ApiLookupStatus`
 
 ### DTOs
 

--- a/assets/controllers/comic_form_controller.js
+++ b/assets/controllers/comic_form_controller.js
@@ -24,6 +24,13 @@ export default class extends Controller {
         'type',
     ];
 
+    // Labels lisibles pour les APIs
+    static apiLabels = {
+        anilist: 'AniList',
+        google_books: 'Google Books',
+        open_library: 'Open Library',
+    };
+
     // Labels lisibles pour les champs
     static fieldLabels = {
         authors: 'Auteur(s)',
@@ -191,18 +198,14 @@ export default class extends Controller {
             }
 
             // Affiche les sources utilisées
-            const sourceLabels = {
-                'anilist': 'AniList',
-                'google_books': 'Google Books',
-                'open_library': 'Open Library',
-            };
-            const sourceNames = (data.sources || []).map(s => sourceLabels[s] || s);
+            const sourceNames = (data.sources || []).map(s => this.constructor.apiLabels[s] || s);
             const sourcesText = sourceNames.join(' + ');
+            const apiStatusHtml = this.buildApiStatusHtml(data.apiMessages);
 
             if (filledFields.length > 0) {
-                this.showFlashNotification(filledFields, sourcesText);
+                this.showFlashNotification(filledFields, sourcesText, apiStatusHtml);
             } else {
-                this.showFlashInfo(`Aucun nouveau champ à remplir (${sourcesText})`);
+                this.showFlashInfo(`Aucun nouveau champ à remplir (${sourcesText})` + apiStatusHtml);
             }
         } catch (error) {
             this.showFlashError('Erreur de connexion');
@@ -268,18 +271,14 @@ export default class extends Controller {
             }
 
             // Affiche les sources utilisées
-            const sourceLabels = {
-                'anilist': 'AniList',
-                'google_books': 'Google Books',
-                'open_library': 'Open Library',
-            };
-            const sourceNames = (data.sources || []).map(s => sourceLabels[s] || s);
+            const sourceNames = (data.sources || []).map(s => this.constructor.apiLabels[s] || s);
             const sourcesText = sourceNames.join(' + ');
+            const apiStatusHtml = this.buildApiStatusHtml(data.apiMessages);
 
             if (filledFields.length > 0) {
-                this.showFlashNotification(filledFields, sourcesText);
+                this.showFlashNotification(filledFields, sourcesText, apiStatusHtml);
             } else {
-                this.showFlashInfo(`Aucun nouveau champ à remplir (${sourcesText})`);
+                this.showFlashInfo(`Aucun nouveau champ à remplir (${sourcesText})` + apiStatusHtml);
             }
         } catch (error) {
             this.showFlashError('Erreur de connexion');
@@ -536,9 +535,30 @@ export default class extends Controller {
     }
 
     /**
+     * Construit le HTML des badges de statut API.
+     */
+    buildApiStatusHtml(apiMessages) {
+        if (!apiMessages || typeof apiMessages !== 'object') {
+            return '';
+        }
+
+        const badges = Object.entries(apiMessages).map(([api, info]) => {
+            const label = this.constructor.apiLabels[api] || api;
+            const status = info.status || 'error';
+            return `<span class="api-status-badge api-status-badge--${status}" title="${info.message || ''}">${label}</span>`;
+        });
+
+        if (badges.length === 0) {
+            return '';
+        }
+
+        return `<div class="api-status-badges">${badges.join('')}</div>`;
+    }
+
+    /**
      * Affiche une notification flash en haut de la page.
      */
-    showFlashNotification(filledFields, sources) {
+    showFlashNotification(filledFields, sources, apiStatusHtml = '') {
         // Supprime une notification existante
         const existing = document.querySelector('.api-lookup-flash');
         if (existing) {
@@ -555,6 +575,7 @@ export default class extends Controller {
             <div class="api-lookup-flash__content">
                 <strong>Champs préremplis via ${sources} :</strong>
                 <span class="api-lookup-flash__fields">${fieldLabels.join(', ')}</span>
+                ${apiStatusHtml}
             </div>
             <button type="button" class="api-lookup-flash__close" aria-label="Fermer">&times;</button>
         `;

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1445,6 +1445,43 @@ body[data-connection-status="OFFLINE"] .offline-indicator {
     color: #e65100;
 }
 
+/* Badges de statut API */
+.api-status-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-top: 0.375rem;
+    width: 100%;
+}
+
+.api-status-badge {
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    line-height: 1;
+    padding: 0.2rem 0.5rem;
+}
+
+.api-status-badge--success {
+    background-color: #c8e6c9;
+    color: #2e7d32;
+}
+
+.api-status-badge--not_found {
+    background-color: #fff3e0;
+    color: #e65100;
+}
+
+.api-status-badge--error {
+    background-color: #ffcdd2;
+    color: #c62828;
+}
+
+.api-status-badge--rate_limited {
+    background-color: #f3e5f5;
+    color: #7b1fa2;
+}
+
 @keyframes slideDown {
     from {
         opacity: 0;

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -38,10 +38,13 @@ class ApiController extends AbstractController
         }
 
         $result = $isbnLookupService->lookup($isbn, $type);
+        $apiMessages = $isbnLookupService->getLastApiMessages();
 
         if (null === $result) {
-            return $this->json(['error' => 'Aucun résultat trouvé'], 404);
+            return $this->json(['apiMessages' => $apiMessages, 'error' => 'Aucun résultat trouvé'], 404);
         }
+
+        $result['apiMessages'] = $apiMessages;
 
         return $this->json($result);
     }
@@ -61,10 +64,13 @@ class ApiController extends AbstractController
         }
 
         $result = $isbnLookupService->lookupByTitle($title, $type);
+        $apiMessages = $isbnLookupService->getLastApiMessages();
 
         if (null === $result) {
-            return $this->json(['error' => 'Aucun résultat trouvé'], 404);
+            return $this->json(['apiMessages' => $apiMessages, 'error' => 'Aucun résultat trouvé'], 404);
         }
+
+        $result['apiMessages'] = $apiMessages;
 
         return $this->json($result);
     }

--- a/src/Enum/ApiLookupStatus.php
+++ b/src/Enum/ApiLookupStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+/**
+ * Statut de réponse d'une API de lookup.
+ */
+enum ApiLookupStatus: string
+{
+    case ERROR = 'error';
+    case NOT_FOUND = 'not_found';
+    case RATE_LIMITED = 'rate_limited';
+    case SUCCESS = 'success';
+}

--- a/src/Service/IsbnLookupService.php
+++ b/src/Service/IsbnLookupService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Enum\ApiLookupStatus;
 use App\Enum\ComicType;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
@@ -23,10 +24,23 @@ class IsbnLookupService
     private const string GOOGLE_BOOKS_API = 'https://www.googleapis.com/books/v1/volumes';
     private const string OPEN_LIBRARY_API = 'https://openlibrary.org/isbn/';
 
+    /** @var array<string, array{status: string, message: string}> */
+    private array $apiMessages = [];
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         private readonly LoggerInterface $logger,
     ) {
+    }
+
+    /**
+     * Retourne les messages de statut des APIs du dernier appel lookup.
+     *
+     * @return array<string, array{status: string, message: string}>
+     */
+    public function getLastApiMessages(): array
+    {
+        return $this->apiMessages;
     }
 
     /**
@@ -40,6 +54,8 @@ class IsbnLookupService
      */
     public function lookup(string $isbn, ?ComicType $type = null): ?array
     {
+        $this->apiMessages = [];
+
         // Nettoie l'ISBN (supprime les tirets et espaces)
         $isbn = \preg_replace('/[\s-]/', '', $isbn) ?? '';
 
@@ -87,6 +103,8 @@ class IsbnLookupService
      */
     public function lookupByTitle(string $title, ?ComicType $type = null): ?array
     {
+        $this->apiMessages = [];
+
         $title = \trim($title);
 
         if ('' === $title) {
@@ -148,18 +166,30 @@ class IsbnLookupService
             $data = $response->toArray();
 
             if (empty($data['items'])) {
+                $this->recordApiMessage('google_books', ApiLookupStatus::NOT_FOUND, 'Aucun résultat');
+
                 return null;
             }
 
-            return $this->mergeGoogleBooksItems($data['items']);
+            $result = $this->mergeGoogleBooksItems($data['items']);
+            $this->recordApiMessage('google_books', ApiLookupStatus::SUCCESS, 'Données trouvées');
+
+            return $result;
         } catch (TransportExceptionInterface $e) {
             $this->logger->error('Erreur réseau lors de la recherche Google Books pour le titre "{title}": {error}', [
                 'error' => $e->getMessage(),
                 'title' => $title,
             ]);
+            $this->recordApiMessage('google_books', ApiLookupStatus::ERROR, 'Erreur de connexion');
 
             return null;
         } catch (ClientExceptionInterface|ServerExceptionInterface|RedirectionExceptionInterface $e) {
+            $code = $e->getResponse()->getStatusCode();
+            if (429 === $code) {
+                $this->recordApiMessage('google_books', ApiLookupStatus::RATE_LIMITED, 'Quota dépassé (429)');
+            } else {
+                $this->recordApiMessage('google_books', ApiLookupStatus::ERROR, \sprintf('Erreur HTTP (%d)', $code));
+            }
             $this->logger->warning('Erreur HTTP lors de la recherche Google Books pour le titre "{title}": {error}', [
                 'error' => $e->getMessage(),
                 'title' => $title,
@@ -171,6 +201,7 @@ class IsbnLookupService
                 'error' => $e->getMessage(),
                 'title' => $title,
             ]);
+            $this->recordApiMessage('google_books', ApiLookupStatus::ERROR, 'Réponse invalide');
 
             return null;
         }
@@ -246,19 +277,31 @@ class IsbnLookupService
             $data = $response->toArray();
 
             if (empty($data['items'])) {
+                $this->recordApiMessage('google_books', ApiLookupStatus::NOT_FOUND, 'Aucun résultat');
+
                 return null;
             }
 
             // Fusionne les informations de tous les résultats pour maximiser les données
-            return $this->mergeGoogleBooksItems($data['items']);
+            $result = $this->mergeGoogleBooksItems($data['items']);
+            $this->recordApiMessage('google_books', ApiLookupStatus::SUCCESS, 'Données trouvées');
+
+            return $result;
         } catch (TransportExceptionInterface $e) {
             $this->logger->error('Erreur réseau lors de la recherche Google Books pour ISBN {isbn}: {error}', [
                 'error' => $e->getMessage(),
                 'isbn' => $isbn,
             ]);
+            $this->recordApiMessage('google_books', ApiLookupStatus::ERROR, 'Erreur de connexion');
 
             return null;
         } catch (ClientExceptionInterface|ServerExceptionInterface|RedirectionExceptionInterface $e) {
+            $code = $e->getResponse()->getStatusCode();
+            if (429 === $code) {
+                $this->recordApiMessage('google_books', ApiLookupStatus::RATE_LIMITED, 'Quota dépassé (429)');
+            } else {
+                $this->recordApiMessage('google_books', ApiLookupStatus::ERROR, \sprintf('Erreur HTTP (%d)', $code));
+            }
             $this->logger->warning('Erreur HTTP lors de la recherche Google Books pour ISBN {isbn}: {error}', [
                 'error' => $e->getMessage(),
                 'isbn' => $isbn,
@@ -270,6 +313,7 @@ class IsbnLookupService
                 'error' => $e->getMessage(),
                 'isbn' => $isbn,
             ]);
+            $this->recordApiMessage('google_books', ApiLookupStatus::ERROR, 'Réponse invalide');
 
             return null;
         }
@@ -401,12 +445,16 @@ class IsbnLookupService
             ]);
 
             if (200 !== $response->getStatusCode()) {
+                $this->recordApiMessage('open_library', ApiLookupStatus::NOT_FOUND, 'Aucun résultat');
+
                 return null;
             }
 
             $data = $response->toArray();
 
             if (empty($data['title'])) {
+                $this->recordApiMessage('open_library', ApiLookupStatus::NOT_FOUND, 'Aucun résultat');
+
                 return null;
             }
 
@@ -441,6 +489,8 @@ class IsbnLookupService
                 $thumbnail = "https://covers.openlibrary.org/b/id/{$coverId}-M.jpg";
             }
 
+            $this->recordApiMessage('open_library', ApiLookupStatus::SUCCESS, 'Données trouvées');
+
             return [
                 'authors' => $authors,
                 'description' => null,
@@ -455,9 +505,16 @@ class IsbnLookupService
                 'error' => $e->getMessage(),
                 'isbn' => $isbn,
             ]);
+            $this->recordApiMessage('open_library', ApiLookupStatus::ERROR, 'Erreur de connexion');
 
             return null;
         } catch (ClientExceptionInterface|ServerExceptionInterface|RedirectionExceptionInterface $e) {
+            $code = $e->getResponse()->getStatusCode();
+            if (429 === $code) {
+                $this->recordApiMessage('open_library', ApiLookupStatus::RATE_LIMITED, 'Quota dépassé (429)');
+            } else {
+                $this->recordApiMessage('open_library', ApiLookupStatus::ERROR, \sprintf('Erreur HTTP (%d)', $code));
+            }
             $this->logger->warning('Erreur HTTP lors de la recherche Open Library pour ISBN {isbn}: {error}', [
                 'error' => $e->getMessage(),
                 'isbn' => $isbn,
@@ -469,6 +526,7 @@ class IsbnLookupService
                 'error' => $e->getMessage(),
                 'isbn' => $isbn,
             ]);
+            $this->recordApiMessage('open_library', ApiLookupStatus::ERROR, 'Réponse invalide');
 
             return null;
         }
@@ -509,6 +567,14 @@ class IsbnLookupService
 
             return null;
         }
+    }
+
+    /**
+     * Enregistre le message de statut d'une API.
+     */
+    private function recordApiMessage(string $apiName, ApiLookupStatus $status, string $message): void
+    {
+        $this->apiMessages[$apiName] = ['message' => $message, 'status' => $status->value];
     }
 
     /**
@@ -597,6 +663,8 @@ class IsbnLookupService
             $media = $data['data']['Media'] ?? null;
 
             if (null === $media) {
+                $this->recordApiMessage('anilist', ApiLookupStatus::NOT_FOUND, 'Aucun résultat');
+
                 return null;
             }
 
@@ -632,6 +700,8 @@ class IsbnLookupService
             $status = $media['status'] ?? null;
             $isOneShot = 'ONE_SHOT' === $format || (1 === $volumes && 'FINISHED' === $status);
 
+            $this->recordApiMessage('anilist', ApiLookupStatus::SUCCESS, 'Données trouvées');
+
             return [
                 'authors' => $authors,
                 'description' => $description,
@@ -647,9 +717,16 @@ class IsbnLookupService
                 'search' => $searchTitle,
                 'title' => $title,
             ]);
+            $this->recordApiMessage('anilist', ApiLookupStatus::ERROR, 'Erreur de connexion');
 
             return null;
         } catch (ClientExceptionInterface|ServerExceptionInterface|RedirectionExceptionInterface $e) {
+            $code = $e->getResponse()->getStatusCode();
+            if (429 === $code) {
+                $this->recordApiMessage('anilist', ApiLookupStatus::RATE_LIMITED, 'Quota dépassé (429)');
+            } else {
+                $this->recordApiMessage('anilist', ApiLookupStatus::ERROR, \sprintf('Erreur HTTP (%d)', $code));
+            }
             $this->logger->warning('Erreur HTTP lors de la recherche AniList pour le titre "{title}" (recherche: "{search}"): {error}', [
                 'error' => $e->getMessage(),
                 'search' => $searchTitle,
@@ -663,6 +740,7 @@ class IsbnLookupService
                 'search' => $searchTitle,
                 'title' => $title,
             ]);
+            $this->recordApiMessage('anilist', ApiLookupStatus::ERROR, 'Réponse invalide');
 
             return null;
         }

--- a/tests/Controller/ApiControllerTest.php
+++ b/tests/Controller/ApiControllerTest.php
@@ -292,4 +292,63 @@ class ApiControllerTest extends AuthenticatedWebTestCase
         // 404 est attendu (pas de résultat) mais pas 400 (mauvaise requête)
         self::assertResponseStatusCodeSame(404);
     }
+
+    /**
+     * Teste que l'API ISBN lookup inclut apiMessages en cas de 404.
+     */
+    public function testIsbnLookupIncludesApiMessagesOn404(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request(Request::METHOD_GET, '/api/isbn-lookup?isbn=0000000000000');
+
+        self::assertResponseStatusCodeSame(404);
+
+        $response = $client->getResponse();
+        $data = \json_decode($response->getContent(), true);
+
+        self::assertArrayHasKey('apiMessages', $data);
+        self::assertIsArray($data['apiMessages']);
+    }
+
+    /**
+     * Teste que l'API title lookup inclut apiMessages en cas de 404.
+     */
+    public function testTitleLookupIncludesApiMessagesOn404(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request(Request::METHOD_GET, '/api/title-lookup?title='.\urlencode('zzz###qqqxxx$$$777'));
+
+        self::assertResponseStatusCodeSame(404);
+
+        $response = $client->getResponse();
+        $data = \json_decode($response->getContent(), true);
+
+        self::assertArrayHasKey('apiMessages', $data);
+        self::assertIsArray($data['apiMessages']);
+    }
+
+    /**
+     * Teste que chaque entrée de apiMessages a la structure attendue (status + message).
+     */
+    public function testApiMessagesEntriesHaveExpectedStructure(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request(Request::METHOD_GET, '/api/isbn-lookup?isbn=0000000000000');
+
+        self::assertResponseStatusCodeSame(404);
+
+        $response = $client->getResponse();
+        $data = \json_decode($response->getContent(), true);
+
+        self::assertArrayHasKey('apiMessages', $data);
+
+        foreach ($data['apiMessages'] as $apiName => $entry) {
+            self::assertIsString($apiName);
+            self::assertArrayHasKey('message', $entry);
+            self::assertArrayHasKey('status', $entry);
+        }
+    }
 }

--- a/tests/Service/IsbnLookupServiceTest.php
+++ b/tests/Service/IsbnLookupServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Service;
 
+use App\Enum\ApiLookupStatus;
 use App\Enum\ComicType;
 use App\Service\IsbnLookupService;
 use PHPUnit\Framework\TestCase;
@@ -643,5 +644,320 @@ class IsbnLookupServiceTest extends TestCase
         self::assertNotNull($result);
         // Seuls Story et Art sont inclus, pas Editor
         self::assertSame('Writer Name, Artist Name', $result['authors']);
+    }
+
+    /**
+     * Teste que getLastApiMessages retourne un tableau vide initialement.
+     */
+    public function testGetLastApiMessagesReturnsEmptyArrayInitially(): void
+    {
+        $mockClient = new MockHttpClient([]);
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+
+        self::assertSame([], $service->getLastApiMessages());
+    }
+
+    /**
+     * Teste que les apiMessages sont réinitialisés à chaque appel de lookup.
+     */
+    public function testApiMessagesResetOnEachLookupCall(): void
+    {
+        // Premier appel : Google Books succès, Open Library 404
+        $googleResponse1 = new MockResponse(\json_encode([
+            'items' => [['volumeInfo' => ['title' => 'Book 1']]],
+        ]));
+        $openLibraryResponse1 = new MockResponse('', ['http_code' => 404]);
+
+        // Deuxième appel : Google Books vide, Open Library 404 → null
+        $googleResponse2 = new MockResponse(\json_encode(['items' => []]));
+        $openLibraryResponse2 = new MockResponse('', ['http_code' => 404]);
+
+        $mockClient = new MockHttpClient([
+            $googleResponse1, $openLibraryResponse1,
+            $googleResponse2, $openLibraryResponse2,
+        ]);
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+
+        // Premier lookup
+        $service->lookup('1111111111');
+        $messages1 = $service->getLastApiMessages();
+        self::assertArrayHasKey('google_books', $messages1);
+
+        // Deuxième lookup — les messages doivent être frais
+        $service->lookup('2222222222');
+        $messages2 = $service->getLastApiMessages();
+
+        // google_books doit être not_found (items vide)
+        self::assertSame(ApiLookupStatus::NOT_FOUND->value, $messages2['google_books']['status']);
+    }
+
+    /**
+     * Teste que Google Books succès est enregistré.
+     */
+    public function testRecordsGoogleBooksSuccess(): void
+    {
+        $googleResponse = new MockResponse(\json_encode([
+            'items' => [['volumeInfo' => ['title' => 'Test']]],
+        ]));
+        $openLibraryResponse = new MockResponse('', ['http_code' => 404]);
+
+        $mockClient = new MockHttpClient([$googleResponse, $openLibraryResponse]);
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+
+        $service->lookup('1234567890');
+        $messages = $service->getLastApiMessages();
+
+        self::assertSame(ApiLookupStatus::SUCCESS->value, $messages['google_books']['status']);
+        self::assertSame('Données trouvées', $messages['google_books']['message']);
+    }
+
+    /**
+     * Teste que Google Books not_found est enregistré.
+     */
+    public function testRecordsGoogleBooksNotFound(): void
+    {
+        $googleResponse = new MockResponse(\json_encode(['items' => []]));
+        $openLibraryResponse = new MockResponse('', ['http_code' => 404]);
+
+        $mockClient = new MockHttpClient([$googleResponse, $openLibraryResponse]);
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+
+        $service->lookup('0000000000');
+        $messages = $service->getLastApiMessages();
+
+        self::assertSame(ApiLookupStatus::NOT_FOUND->value, $messages['google_books']['status']);
+        self::assertSame('Aucun résultat', $messages['google_books']['message']);
+    }
+
+    /**
+     * Teste que Google Books erreur réseau est enregistrée.
+     */
+    public function testRecordsGoogleBooksError(): void
+    {
+        $googleResponse = new MockResponse('', ['error' => 'Connection refused']);
+        $openLibraryResponse = new MockResponse('', ['http_code' => 404]);
+
+        $mockClient = new MockHttpClient([$googleResponse, $openLibraryResponse]);
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+
+        $service->lookup('1234567890');
+        $messages = $service->getLastApiMessages();
+
+        self::assertSame(ApiLookupStatus::ERROR->value, $messages['google_books']['status']);
+        self::assertStringContainsString('Erreur de connexion', $messages['google_books']['message']);
+    }
+
+    /**
+     * Teste que Google Books rate limited (429) est enregistré.
+     */
+    public function testRecordsGoogleBooksRateLimited(): void
+    {
+        $googleResponse = new MockResponse('Rate limit exceeded', ['http_code' => 429]);
+        $openLibraryResponse = new MockResponse('', ['http_code' => 404]);
+
+        $mockClient = new MockHttpClient([$googleResponse, $openLibraryResponse]);
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+
+        $service->lookup('1234567890');
+        $messages = $service->getLastApiMessages();
+
+        self::assertSame(ApiLookupStatus::RATE_LIMITED->value, $messages['google_books']['status']);
+        self::assertSame('Quota dépassé (429)', $messages['google_books']['message']);
+    }
+
+    /**
+     * Teste que Open Library succès est enregistré.
+     */
+    public function testRecordsOpenLibrarySuccess(): void
+    {
+        $googleResponse = new MockResponse(\json_encode(['items' => []]));
+        $openLibraryResponse = new MockResponse(\json_encode([
+            'title' => 'OL Book',
+            'publishers' => ['OL Publisher'],
+        ]));
+
+        $mockClient = new MockHttpClient([$googleResponse, $openLibraryResponse]);
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+
+        $service->lookup('1234567890');
+        $messages = $service->getLastApiMessages();
+
+        self::assertSame(ApiLookupStatus::SUCCESS->value, $messages['open_library']['status']);
+        self::assertSame('Données trouvées', $messages['open_library']['message']);
+    }
+
+    /**
+     * Teste que Open Library not_found est enregistré.
+     */
+    public function testRecordsOpenLibraryNotFound(): void
+    {
+        $googleResponse = new MockResponse(\json_encode([
+            'items' => [['volumeInfo' => ['title' => 'Test']]],
+        ]));
+        $openLibraryResponse = new MockResponse('', ['http_code' => 404]);
+
+        $mockClient = new MockHttpClient([$googleResponse, $openLibraryResponse]);
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+
+        $service->lookup('1234567890');
+        $messages = $service->getLastApiMessages();
+
+        self::assertSame(ApiLookupStatus::NOT_FOUND->value, $messages['open_library']['status']);
+        self::assertSame('Aucun résultat', $messages['open_library']['message']);
+    }
+
+    /**
+     * Teste que Open Library erreur est enregistrée.
+     */
+    public function testRecordsOpenLibraryError(): void
+    {
+        $googleResponse = new MockResponse(\json_encode([
+            'items' => [['volumeInfo' => ['title' => 'Test']]],
+        ]));
+        $openLibraryResponse = new MockResponse('', ['error' => 'Connection refused']);
+
+        $mockClient = new MockHttpClient([$googleResponse, $openLibraryResponse]);
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+
+        $service->lookup('1234567890');
+        $messages = $service->getLastApiMessages();
+
+        self::assertSame(ApiLookupStatus::ERROR->value, $messages['open_library']['status']);
+    }
+
+    /**
+     * Teste que AniList succès est enregistré.
+     */
+    public function testRecordsAniListSuccess(): void
+    {
+        $googleResponse = new MockResponse(\json_encode([
+            'items' => [['volumeInfo' => ['title' => 'Manga Test']]],
+        ]));
+        $openLibraryResponse = new MockResponse('', ['http_code' => 404]);
+        $anilistResponse = new MockResponse(\json_encode([
+            'data' => [
+                'Media' => [
+                    'coverImage' => ['large' => 'https://anilist.co/cover.jpg'],
+                    'title' => ['english' => 'Manga Test'],
+                ],
+            ],
+        ]));
+
+        $mockClient = new MockHttpClient([$googleResponse, $openLibraryResponse, $anilistResponse]);
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+
+        $service->lookup('1234567890', ComicType::MANGA);
+        $messages = $service->getLastApiMessages();
+
+        self::assertSame(ApiLookupStatus::SUCCESS->value, $messages['anilist']['status']);
+        self::assertSame('Données trouvées', $messages['anilist']['message']);
+    }
+
+    /**
+     * Teste que AniList not_found est enregistré.
+     */
+    public function testRecordsAniListNotFound(): void
+    {
+        $googleResponse = new MockResponse(\json_encode([
+            'items' => [['volumeInfo' => ['title' => 'Manga Test']]],
+        ]));
+        $openLibraryResponse = new MockResponse('', ['http_code' => 404]);
+        $anilistResponse = new MockResponse(\json_encode([
+            'data' => ['Media' => null],
+        ]));
+
+        $mockClient = new MockHttpClient([$googleResponse, $openLibraryResponse, $anilistResponse]);
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+
+        $service->lookup('1234567890', ComicType::MANGA);
+        $messages = $service->getLastApiMessages();
+
+        self::assertSame(ApiLookupStatus::NOT_FOUND->value, $messages['anilist']['status']);
+        self::assertSame('Aucun résultat', $messages['anilist']['message']);
+    }
+
+    /**
+     * Teste que AniList erreur est enregistrée.
+     */
+    public function testRecordsAniListError(): void
+    {
+        $googleResponse = new MockResponse(\json_encode([
+            'items' => [['volumeInfo' => ['title' => 'Manga Test']]],
+        ]));
+        $openLibraryResponse = new MockResponse('', ['http_code' => 404]);
+        $anilistResponse = new MockResponse('', ['error' => 'Connection refused']);
+
+        $mockClient = new MockHttpClient([$googleResponse, $openLibraryResponse, $anilistResponse]);
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+
+        $service->lookup('1234567890', ComicType::MANGA);
+        $messages = $service->getLastApiMessages();
+
+        self::assertSame(ApiLookupStatus::ERROR->value, $messages['anilist']['status']);
+    }
+
+    /**
+     * Teste que AniList n'est pas enregistré quand le type n'est pas MANGA.
+     */
+    public function testAniListNotRecordedWhenNotManga(): void
+    {
+        $googleResponse = new MockResponse(\json_encode([
+            'items' => [['volumeInfo' => ['title' => 'BD Test']]],
+        ]));
+        $openLibraryResponse = new MockResponse('', ['http_code' => 404]);
+
+        $mockClient = new MockHttpClient([$googleResponse, $openLibraryResponse]);
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+
+        $service->lookup('1234567890', ComicType::BD);
+        $messages = $service->getLastApiMessages();
+
+        self::assertArrayNotHasKey('anilist', $messages);
+        self::assertArrayHasKey('google_books', $messages);
+    }
+
+    /**
+     * Teste que lookupByTitle enregistre aussi les apiMessages.
+     */
+    public function testLookupByTitleTracksApiMessages(): void
+    {
+        $googleResponse = new MockResponse(\json_encode([
+            'items' => [['volumeInfo' => ['title' => 'Found by Title']]],
+        ]));
+
+        $mockClient = new MockHttpClient([$googleResponse]);
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+
+        $service->lookupByTitle('Some Title');
+        $messages = $service->getLastApiMessages();
+
+        self::assertArrayHasKey('google_books', $messages);
+        self::assertSame(ApiLookupStatus::SUCCESS->value, $messages['google_books']['status']);
+    }
+
+    /**
+     * Teste que lookupByTitle pour manga enregistre AniList.
+     */
+    public function testLookupByTitleMangaTracksAniListMessages(): void
+    {
+        $anilistResponse = new MockResponse(\json_encode([
+            'data' => [
+                'Media' => [
+                    'coverImage' => ['large' => 'https://anilist.co/cover.jpg'],
+                    'title' => ['english' => 'Manga Title'],
+                ],
+            ],
+        ]));
+
+        $mockClient = new MockHttpClient([$anilistResponse]);
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+
+        $service->lookupByTitle('Manga Title', ComicType::MANGA);
+        $messages = $service->getLastApiMessages();
+
+        self::assertArrayHasKey('anilist', $messages);
+        self::assertSame(ApiLookupStatus::SUCCESS->value, $messages['anilist']['status']);
+        // google_books ne doit pas être présent car AniList a trouvé
+        self::assertArrayNotHasKey('google_books', $messages);
     }
 }


### PR DESCRIPTION
## Summary

- Ajout d'un objet `apiMessages` dans les réponses JSON de `/api/isbn-lookup` et `/api/title-lookup`, indiquant le statut de chaque API interrogée (success, not_found, error, rate_limited)
- Utilisation de l'enum `ApiLookupStatus` existant pour les valeurs de statut
- Badges colorés dans les notifications flash du formulaire pour visualiser le statut de chaque API

## Détails techniques

- `IsbnLookupService` : nouvelle propriété `$apiMessages` avec getter `getLastApiMessages()`, réinitialisée à chaque appel
- `ApiController` : inclusion de `apiMessages` dans toutes les réponses (200 et 404)
- JavaScript : `buildApiStatusHtml()`, `static apiLabels` (DRY : remplace 3 objets dupliqués), mise à jour de `showFlashNotification` avec 3e paramètre
- CSS : badges `.api-status-badge` avec variantes success/not_found/error/rate_limited

## Test plan

- [x] 18 nouveaux tests unitaires (`IsbnLookupServiceTest`) couvrant tous les statuts API
- [x] 3 nouveaux tests fonctionnels (`ApiControllerTest`) vérifiant la présence et structure de `apiMessages`
- [x] Suite complète : 345 tests, 872 assertions, tous passent

fixes #4