### PR TITLE
test(js): tests unitaires Vitest pour les modules JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Tests JavaScript (Vitest)** : Suite de tests unitaires pour tout le code JS du projet
+  - 139 tests couvrant 3 modules utilitaires et 6 contrôleurs Stimulus
+  - Framework Vitest avec jsdom (support ESM natif compatible AssetMapper)
+  - Helper Stimulus pour tester les contrôleurs sans bibliothèque tierce
+  - Mocks globaux (fetch, localStorage, Cache API, crypto) dans le setup
+  - Scripts npm : `npm test` (run) et `npm run test:watch` (watch)
+
 - **ISBN one-shot** : Champ ISBN virtuel affiché directement dans le formulaire quand one-shot est coché, avec masquage de la section tomes
 - **Recherche ISBN one-shot** : Bouton de recherche à côté du champ ISBN pour pré-remplir le formulaire via l'API
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,9 @@
 ddev start && ddev composer install && ddev exec bin/console doctrine:migrations:migrate -n
 ddev exec bin/console doctrine:migrations:diff -n   # Generate migration
 ddev exec bin/console cache:clear
-ddev exec bin/phpunit tests/PathToTest.php          # Tests
+ddev exec bin/phpunit tests/PathToTest.php          # PHP Tests
+ddev exec npm test                                  # JS Tests (Vitest)
+ddev exec npm run test:watch                        # JS Tests (watch mode)
 ```
 
 **PHP-CS-Fixer and PHPStan**: automated via PostToolUse hooks.
@@ -57,6 +59,18 @@ ddev exec bin/phpunit tests/PathToTest.php          # Tests
 **Test environment**: `db_test`, `https://test.bibliotheque.ddev.site`, `.env.test`
 
 **TDD exceptions**: Twig templates, YAML config, migrations, assets.
+
+## JavaScript Tests (Vitest)
+
+**Framework**: Vitest + jsdom (ESM natif, compatible AssetMapper).
+
+**Convention**: `assets/X/foo.js` → `tests/js/X/foo.test.js`
+
+**Helpers**:
+- `tests/js/setup.js` — mocks globaux (fetch, localStorage, Cache API, crypto)
+- `tests/js/helpers/stimulus-helper.js` — `startStimulusController()` / `stopStimulusController()`
+
+**Fake timers**: toujours activer `vi.useFakeTimers()` **APRÈS** `startStimulusController()` (sinon timeout Stimulus).
 
 ## Rector (occasional use)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,659 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.58.1"
+        "@hotwired/stimulus": "^3.2.2",
+        "@playwright/test": "^1.58.1",
+        "jsdom": "^28.0.0",
+        "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.8",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.8.tgz",
+      "integrity": "sha512-stisC1nULNc9oH5lakAj8MH88ZxeGxzyWNDfbdCxvJSJIvDsHNZqYvscGTgy/ysgXWLJPt6K/4t0/GjvtKcFJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
+      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
+      "integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
+      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.1",
+        "@csstools/css-calc": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
+      "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.11.0.tgz",
+      "integrity": "sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@hotwired/stimulus": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.2.tgz",
+      "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@playwright/test": {
       "version": "1.58.1",
@@ -28,6 +679,708 @@
         "node": ">=18"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -41,6 +1394,198 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.0.0.tgz",
+      "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^5.3.7",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.20.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/playwright": {
@@ -74,6 +1619,501 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.22.tgz",
+      "integrity": "sha512-nqpKFC53CgopKPjT6Wfb6tpIcZXHcI6G37hesvikhx0EmUGPkZrujRyAjgnmp1SHNgpQfKVanZ+KfpANFt2Hxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.22"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.22.tgz",
+      "integrity": "sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
+      "integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
+      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "repository": {
     "type": "git",
@@ -21,6 +22,9 @@
   },
   "homepage": "https://github.com/Soviann/bibliotheqe#readme",
   "devDependencies": {
-    "@playwright/test": "^1.58.1"
+    "@hotwired/stimulus": "^3.2.2",
+    "@playwright/test": "^1.58.1",
+    "jsdom": "^28.0.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/tests/js/controllers/cache_warmer_controller.test.js
+++ b/tests/js/controllers/cache_warmer_controller.test.js
@@ -1,0 +1,117 @@
+import CacheWarmerController from '../../../assets/controllers/cache_warmer_controller.js';
+
+/**
+ * Teste warmCache() directement plutôt que via Stimulus.
+ * Le connect() utilise setTimeout(1000) qui interagit mal avec vi.useFakeTimers()
+ * et le cycle de vie Stimulus. On teste la logique métier en isolation.
+ */
+describe('cache_warmer_controller', () => {
+    /**
+     * Crée une instance minimale du contrôleur avec les dépendances mockées.
+     */
+    function createController(urls = []) {
+        const controller = new CacheWarmerController();
+        // Simule Stimulus values
+        controller.urlsValue = urls;
+        return controller;
+    }
+
+    it('met les URLs API dans le cache api', async () => {
+        global.fetch = vi.fn().mockResolvedValue({ ok: true, clone: () => 'cloned-response' });
+
+        const controller = createController(['/api/comics']);
+        await controller.warmCache();
+
+        const apiCache = await caches.open('bibliotheque-api');
+        expect(apiCache.put).toHaveBeenCalledWith('/api/comics', 'cloned-response');
+    });
+
+    it('met les URLs pages dans le cache pages', async () => {
+        global.fetch = vi.fn().mockResolvedValue({ ok: true, clone: () => 'cloned-response' });
+
+        const controller = createController(['/wishlist']);
+        await controller.warmCache();
+
+        const pagesCache = await caches.open('bibliotheque-pages');
+        expect(pagesCache.put).toHaveBeenCalledWith('/wishlist', 'cloned-response');
+    });
+
+    it('route /api/* vers le cache api et les autres vers pages', async () => {
+        global.fetch = vi.fn().mockResolvedValue({ ok: true, clone: () => 'cloned-response' });
+
+        const controller = createController(['/api/comics', '/']);
+        await controller.warmCache();
+
+        const apiCache = await caches.open('bibliotheque-api');
+        const pagesCache = await caches.open('bibliotheque-pages');
+
+        expect(apiCache.put).toHaveBeenCalledWith('/api/comics', 'cloned-response');
+        expect(pagesCache.put).toHaveBeenCalledWith('/', 'cloned-response');
+    });
+
+    it('ne recharge pas une URL déjà en cache', async () => {
+        global.fetch = vi.fn();
+
+        // Pré-remplir le cache
+        const pagesCache = await caches.open('bibliotheque-pages');
+        pagesCache.match = vi.fn().mockResolvedValue('existing-response');
+
+        const controller = createController(['/']);
+        await controller.warmCache();
+
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('ignore silencieusement les erreurs fetch', async () => {
+        global.fetch = vi.fn().mockRejectedValue(new Error('network error'));
+
+        const controller = createController(['/api/comics']);
+
+        // Ne devrait pas lever d'erreur
+        await expect(controller.warmCache()).resolves.not.toThrow();
+    });
+
+    it('ne met pas en cache les réponses non-ok', async () => {
+        global.fetch = vi.fn().mockResolvedValue({ ok: false });
+
+        const controller = createController(['/api/comics']);
+        await controller.warmCache();
+
+        const apiCache = await caches.open('bibliotheque-api');
+        expect(apiCache.put).not.toHaveBeenCalled();
+    });
+
+    it('pré-charge plusieurs URLs en parallèle', async () => {
+        global.fetch = vi.fn().mockResolvedValue({ ok: true, clone: () => 'cloned' });
+
+        const controller = createController(['/api/comics', '/', '/wishlist']);
+        await controller.warmCache();
+
+        expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('envoie les credentials same-origin avec fetch', async () => {
+        global.fetch = vi.fn().mockResolvedValue({ ok: true, clone: () => 'cloned' });
+
+        const controller = createController(['/api/comics']);
+        await controller.warmCache();
+
+        expect(global.fetch).toHaveBeenCalledWith('/api/comics', { credentials: 'same-origin' });
+    });
+
+    it('ne fait rien si la Cache API n\'est pas disponible', async () => {
+        global.fetch = vi.fn();
+
+        // Supprime caches temporairement
+        const originalCaches = global.caches;
+        delete global.caches;
+
+        const controller = createController(['/api/comics']);
+        await controller.warmCache();
+
+        expect(global.fetch).not.toHaveBeenCalled();
+
+        // Restaure
+        Object.defineProperty(global, 'caches', { value: originalCaches });
+    });
+});

--- a/tests/js/controllers/comic_form_controller.test.js
+++ b/tests/js/controllers/comic_form_controller.test.js
@@ -1,0 +1,492 @@
+import ComicFormController from '../../../assets/controllers/comic_form_controller.js';
+import { startStimulusController, stopStimulusController } from '../helpers/stimulus-helper.js';
+
+const TOME_PROTOTYPE = `
+    <div data-tomes-collection-target="entry" class="tome-entry">
+        <input class="tome-number-input" name="tomes[__name__][number]" value="">
+        <input class="tome-isbn-input" name="tomes[__name__][isbn]" value="">
+        <button class="tome-remove">Supprimer</button>
+    </div>
+`;
+
+function buildHtml({ isOneShot = false, existingTome = false } = {}) {
+    const tomeEntry = existingTome ? `
+        <div data-tomes-collection-target="entry" class="tome-entry">
+            <input class="tome-number-input" name="tomes[0][number]" value="1">
+            <input class="tome-isbn-input" name="tomes[0][isbn]" value="">
+            <button class="tome-remove">Supprimer</button>
+        </div>
+    ` : '';
+
+    return `
+        <form data-controller="comic-form">
+            <select data-comic-form-target="type">
+                <option value="">--</option>
+                <option value="bd">BD</option>
+                <option value="comics">Comics</option>
+                <option value="manga">Manga</option>
+            </select>
+            <input data-comic-form-target="title" type="text" value="">
+            <input data-comic-form-target="isbn" type="text" value="">
+            <input data-comic-form-target="publisher" type="text" value="">
+            <input data-comic-form-target="publishedDate" type="text" value="">
+            <textarea data-comic-form-target="description"></textarea>
+            <input data-comic-form-target="coverUrl" type="text" value="">
+            <div data-comic-form-target="authorsWrapper">
+                <select multiple></select>
+            </div>
+            <input data-comic-form-target="isOneShot" type="checkbox" ${isOneShot ? 'checked' : ''}>
+            <div data-comic-form-target="publishedIssueRow">
+                <input data-comic-form-target="latestPublishedIssue" type="number" value="">
+                <input data-comic-form-target="latestPublishedIssueComplete" type="checkbox">
+            </div>
+            <div data-comic-form-target="oneShotIsbnRow" style="display: none;">
+                <input data-comic-form-target="oneShotIsbn" type="text" value="">
+                <button data-comic-form-target="lookupOneShotIsbnButton">Rechercher</button>
+            </div>
+            <div data-comic-form-target="tomesSection">
+                <div data-comic-form-target="tomesList">${tomeEntry}</div>
+                <template data-comic-form-target="tomesPrototype">${TOME_PROTOTYPE}</template>
+                <button data-comic-form-target="addTomeButton">Ajouter</button>
+            </div>
+            <button data-comic-form-target="lookupButton">Rechercher ISBN</button>
+            <button data-comic-form-target="lookupTitleButton">Rechercher Titre</button>
+            <div data-comic-form-target="lookupStatus" class="lookup-status"></div>
+        </form>
+    `;
+}
+
+describe('comic_form_controller', () => {
+    let application;
+
+    afterEach(() => {
+        if (application) stopStimulusController(application);
+    });
+
+    function getController() {
+        return application.getControllerForElementAndIdentifier(
+            document.querySelector('[data-controller="comic-form"]'), 'comic-form'
+        );
+    }
+
+    async function setup(options = {}) {
+        ({ application } = await startStimulusController(
+            ComicFormController, 'comic-form', buildHtml(options)
+        ));
+        return getController();
+    }
+
+    describe('applyOneShotState', () => {
+        it('masque la ligne "Dernier tome paru" quand one-shot', async () => {
+            const controller = await setup();
+            controller.applyOneShotState(true);
+
+            const publishedRow = document.querySelector('[data-comic-form-target="publishedIssueRow"]');
+            expect(publishedRow.style.display).toBe('none');
+        });
+
+        it('affiche le champ ISBN one-shot', async () => {
+            const controller = await setup();
+            controller.applyOneShotState(true);
+
+            const isbnRow = document.querySelector('[data-comic-form-target="oneShotIsbnRow"]');
+            expect(isbnRow.style.display).toBe('');
+        });
+
+        it('masque la section tomes quand one-shot', async () => {
+            const controller = await setup();
+            controller.applyOneShotState(true);
+
+            const tomesSection = document.querySelector('[data-comic-form-target="tomesSection"]');
+            expect(tomesSection.style.display).toBe('none');
+        });
+
+        it('pré-remplit latestPublishedIssue à 1', async () => {
+            const controller = await setup();
+            controller.applyOneShotState(true);
+
+            const input = document.querySelector('[data-comic-form-target="latestPublishedIssue"]');
+            expect(input.value).toBe('1');
+        });
+
+        it('coche latestPublishedIssueComplete', async () => {
+            const controller = await setup();
+            controller.applyOneShotState(true);
+
+            const checkbox = document.querySelector('[data-comic-form-target="latestPublishedIssueComplete"]');
+            expect(checkbox.checked).toBe(true);
+        });
+
+        it('restaure l\'affichage quand désactivé', async () => {
+            const controller = await setup();
+            controller.applyOneShotState(true);
+            controller.applyOneShotState(false);
+
+            expect(document.querySelector('[data-comic-form-target="publishedIssueRow"]').style.display).toBe('');
+            expect(document.querySelector('[data-comic-form-target="oneShotIsbnRow"]').style.display).toBe('none');
+            expect(document.querySelector('[data-comic-form-target="tomesSection"]').style.display).toBe('');
+        });
+
+        it('crée un tome avec numéro 1 si collection vide', async () => {
+            const controller = await setup();
+            controller.applyOneShotState(true);
+
+            const numberInput = document.querySelector('.tome-number-input');
+            expect(numberInput).not.toBeNull();
+            expect(numberInput.value).toBe('1');
+        });
+    });
+
+    describe('fillField', () => {
+        it('remplit un champ vide', async () => {
+            const controller = await setup();
+            const result = controller.fillField('title', 'Naruto');
+
+            expect(result).toBe(true);
+            expect(document.querySelector('[data-comic-form-target="title"]').value).toBe('Naruto');
+        });
+
+        it('ne remplace pas un champ déjà rempli', async () => {
+            await setup();
+            document.querySelector('[data-comic-form-target="title"]').value = 'Existing';
+
+            const controller = getController();
+            const result = controller.fillField('title', 'Naruto');
+
+            expect(result).toBe(false);
+            expect(document.querySelector('[data-comic-form-target="title"]').value).toBe('Existing');
+        });
+
+        it('retourne false si pas de valeur', async () => {
+            const controller = await setup();
+            expect(controller.fillField('title', null)).toBe(false);
+            expect(controller.fillField('title', '')).toBe(false);
+        });
+
+        it('ajoute la classe de mise en surbrillance', async () => {
+            const controller = await setup();
+
+            // Activer les fake timers APRÈS la connexion Stimulus
+            vi.useFakeTimers();
+
+            controller.fillField('title', 'Naruto');
+
+            const input = document.querySelector('[data-comic-form-target="title"]');
+            expect(input.classList.contains('field-filled-by-api')).toBe(true);
+
+            vi.advanceTimersByTime(3000);
+            expect(input.classList.contains('field-filled-by-api')).toBe(false);
+
+            vi.useRealTimers();
+        });
+    });
+
+    describe('fillSelect', () => {
+        it('remplit un select avec une valeur valide', async () => {
+            const controller = await setup();
+            const result = controller.fillSelect('type', 'manga');
+
+            expect(result).toBe(true);
+            expect(document.querySelector('[data-comic-form-target="type"]').value).toBe('manga');
+        });
+
+        it('retourne false si la valeur n\'existe pas', async () => {
+            const controller = await setup();
+            const result = controller.fillSelect('type', 'unknown');
+
+            expect(result).toBe(false);
+        });
+
+        it('retourne false si déjà la bonne valeur', async () => {
+            await setup();
+            document.querySelector('[data-comic-form-target="type"]').value = 'manga';
+
+            const controller = getController();
+            const result = controller.fillSelect('type', 'manga');
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('fillTomeIsbn', () => {
+        it('remplit l\'ISBN du premier tome', async () => {
+            const controller = await setup({ existingTome: true });
+            const result = controller.fillTomeIsbn('978-2-1234-5678-9');
+
+            expect(result).toBe(true);
+            expect(document.querySelector('.tome-isbn-input').value).toBe('978-2-1234-5678-9');
+        });
+
+        it('ne remplace pas un ISBN existant', async () => {
+            await setup({ existingTome: true });
+            document.querySelector('.tome-isbn-input').value = 'existing-isbn';
+
+            const controller = getController();
+            const result = controller.fillTomeIsbn('978-2-1234-5678-9');
+
+            expect(result).toBe(false);
+        });
+
+        it('retourne false sans ISBN', async () => {
+            const controller = await setup({ existingTome: true });
+            expect(controller.fillTomeIsbn(null)).toBe(false);
+            expect(controller.fillTomeIsbn('')).toBe(false);
+        });
+
+        it('synchronise avec le champ ISBN one-shot', async () => {
+            const controller = await setup({ isOneShot: true, existingTome: true });
+            controller.fillTomeIsbn('978-2-1234-5678-9');
+
+            const oneShotIsbn = document.querySelector('[data-comic-form-target="oneShotIsbn"]');
+            expect(oneShotIsbn.value).toBe('978-2-1234-5678-9');
+        });
+    });
+
+    describe('performIsbnLookup', () => {
+        it('remplit les champs avec les données de l\'API', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    authors: 'Kishimoto',
+                    description: 'Ninja manga',
+                    isbn: null,
+                    isOneShot: false,
+                    publishedDate: '1999',
+                    publisher: 'Kana',
+                    sources: ['google_books'],
+                    thumbnail: 'http://img.jpg',
+                    title: 'Naruto',
+                }),
+                ok: true,
+            });
+
+            const controller = await setup();
+            const button = document.createElement('button');
+            await controller.performIsbnLookup('978-123', button);
+
+            expect(document.querySelector('[data-comic-form-target="title"]').value).toBe('Naruto');
+            expect(document.querySelector('[data-comic-form-target="publisher"]').value).toBe('Kana');
+            expect(document.querySelector('[data-comic-form-target="description"]').value).toBe('Ninja manga');
+            expect(document.querySelector('[data-comic-form-target="coverUrl"]').value).toBe('http://img.jpg');
+        });
+
+        it('affiche une erreur si l\'API retourne une erreur', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({ error: 'ISBN introuvable' }),
+                ok: false,
+            });
+
+            const controller = await setup();
+            await controller.performIsbnLookup('000-000', null);
+
+            const flash = document.querySelector('.api-lookup-flash');
+            expect(flash).not.toBeNull();
+            expect(flash.textContent).toContain('ISBN introuvable');
+        });
+
+        it('affiche une erreur de connexion', async () => {
+            global.fetch = vi.fn().mockRejectedValue(new Error('network'));
+
+            const controller = await setup();
+            await controller.performIsbnLookup('978-123', null);
+
+            const flash = document.querySelector('.api-lookup-flash');
+            expect(flash).not.toBeNull();
+            expect(flash.textContent).toContain('Erreur de connexion');
+        });
+
+        it('désactive et réactive le bouton', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({ apiMessages: {}, sources: [], title: 'X' }),
+                ok: true,
+            });
+
+            const controller = await setup();
+            const button = document.createElement('button');
+            button.disabled = false;
+
+            const lookupPromise = controller.performIsbnLookup('978-123', button);
+            expect(button.disabled).toBe(true);
+
+            await lookupPromise;
+            expect(button.disabled).toBe(false);
+        });
+
+        it('coche one-shot si détecté par l\'API', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    isOneShot: true,
+                    sources: ['google_books'],
+                    title: 'Solo',
+                }),
+                ok: true,
+            });
+
+            const controller = await setup();
+            await controller.performIsbnLookup('978-123', null);
+
+            const checkbox = document.querySelector('[data-comic-form-target="isOneShot"]');
+            expect(checkbox.checked).toBe(true);
+        });
+
+        it('inclut le type dans l\'URL de l\'API', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({ apiMessages: {}, sources: [] }),
+                ok: true,
+            });
+
+            const controller = await setup();
+            document.querySelector('[data-comic-form-target="type"]').value = 'manga';
+            await controller.performIsbnLookup('978-123', null);
+
+            expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('type=manga'));
+        });
+    });
+
+    describe('lookupByTitle', () => {
+        it('envoie le titre à l\'API', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    authors: 'Oda',
+                    sources: ['google_books'],
+                }),
+                ok: true,
+            });
+
+            const controller = await setup();
+            document.querySelector('[data-comic-form-target="title"]').value = 'One Piece';
+            await controller.lookupByTitle();
+
+            expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('title=One%20Piece'));
+        });
+
+        it('affiche une erreur si titre vide', async () => {
+            const controller = await setup();
+            await controller.lookupByTitle();
+
+            const flash = document.querySelector('.api-lookup-flash');
+            expect(flash).not.toBeNull();
+            expect(flash.textContent).toContain('Veuillez saisir un titre');
+        });
+
+        it('pré-remplit l\'ISBN du tome si one-shot détecté', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    isbn: '978-2-1234',
+                    isOneShot: true,
+                    sources: ['google_books'],
+                    title: 'Solo',
+                }),
+                ok: true,
+            });
+
+            const controller = await setup();
+            document.querySelector('[data-comic-form-target="title"]').value = 'Solo';
+            await controller.lookupByTitle();
+
+            const isbnInput = document.querySelector('.tome-isbn-input');
+            expect(isbnInput).not.toBeNull();
+            expect(isbnInput.value).toBe('978-2-1234');
+        });
+    });
+
+    describe('buildApiStatusHtml', () => {
+        it('retourne une chaîne vide si pas de messages', async () => {
+            const controller = await setup();
+            expect(controller.buildApiStatusHtml(null)).toBe('');
+            expect(controller.buildApiStatusHtml({})).toBe('');
+        });
+
+        it('génère des badges HTML pour chaque API', async () => {
+            const controller = await setup();
+            const html = controller.buildApiStatusHtml({
+                anilist: { message: 'Not found', status: 'not_found' },
+                google_books: { message: 'OK', status: 'success' },
+            });
+
+            expect(html).toContain('api-status-badge--success');
+            expect(html).toContain('Google Books');
+            expect(html).toContain('api-status-badge--not_found');
+            expect(html).toContain('AniList');
+        });
+
+        it('utilise les labels lisibles des APIs', async () => {
+            const controller = await setup();
+            const html = controller.buildApiStatusHtml({
+                open_library: { message: 'OK', status: 'success' },
+            });
+
+            expect(html).toContain('Open Library');
+        });
+    });
+
+    describe('showFlashMessage', () => {
+        it('crée un élément flash dans le DOM', async () => {
+            const controller = await setup();
+            controller.showFlashMessage('Test message', 'error');
+
+            const flash = document.querySelector('.api-lookup-flash');
+            expect(flash).not.toBeNull();
+            expect(flash.classList.contains('api-lookup-flash--error')).toBe(true);
+            expect(flash.textContent).toContain('Test message');
+        });
+
+        it('supprime le flash précédent', async () => {
+            const controller = await setup();
+            controller.showFlashMessage('First', 'info');
+            controller.showFlashMessage('Second', 'error');
+
+            const flashes = document.querySelectorAll('.api-lookup-flash');
+            expect(flashes).toHaveLength(1);
+            expect(flashes[0].textContent).toContain('Second');
+        });
+
+        it('auto-dismiss après 5 secondes', async () => {
+            const controller = await setup();
+
+            vi.useFakeTimers();
+
+            controller.showFlashMessage('Auto dismiss', 'info');
+            expect(document.querySelector('.api-lookup-flash')).not.toBeNull();
+
+            vi.advanceTimersByTime(5000);
+            expect(document.querySelector('.api-lookup-flash--hiding')).not.toBeNull();
+
+            vi.advanceTimersByTime(300);
+            expect(document.querySelector('.api-lookup-flash')).toBeNull();
+
+            vi.useRealTimers();
+        });
+
+        it('peut être fermé manuellement via le bouton', async () => {
+            const controller = await setup();
+
+            vi.useFakeTimers();
+
+            controller.showFlashMessage('Closeable', 'info');
+            document.querySelector('.api-lookup-flash__close').click();
+
+            vi.advanceTimersByTime(300);
+            expect(document.querySelector('.api-lookup-flash')).toBeNull();
+
+            vi.useRealTimers();
+        });
+    });
+
+    describe('getSelectedType', () => {
+        it('retourne la valeur du select', async () => {
+            const controller = await setup();
+            document.querySelector('[data-comic-form-target="type"]').value = 'manga';
+
+            expect(controller.getSelectedType()).toBe('manga');
+        });
+
+        it('retourne null si aucun type sélectionné', async () => {
+            const controller = await setup();
+            expect(controller.getSelectedType()).toBeNull();
+        });
+    });
+});

--- a/tests/js/controllers/csrf_protection_controller.test.js
+++ b/tests/js/controllers/csrf_protection_controller.test.js
@@ -1,0 +1,208 @@
+import { generateCsrfHeaders, generateCsrfToken, removeCsrfToken } from '../../../assets/controllers/csrf_protection_controller.js';
+
+/**
+ * Le contrôleur CSRF utilise deux regex :
+ * - nameCheck : /^[-_a-zA-Z0-9]{4,22}$/ — valide le cookie name (token ID initial)
+ * - tokenCheck : /^[-_/+a-zA-Z0-9]{24,}$/ — valide la valeur du token généré (base64)
+ *
+ * Workflow : la valeur initiale du champ est le "csrf name" (ex: "_csrf_token_12345").
+ * Si elle matche nameCheck, elle est déplacée dans data-csrf-protection-cookie-value
+ * et remplacée par un token base64 aléatoire qui matche tokenCheck.
+ */
+
+/**
+ * Crée un formulaire avec un champ CSRF pour les tests.
+ * tokenValue doit matcher nameCheck pour déclencher la génération.
+ */
+function createFormWithCsrf(tokenValue = 'csrf_token_abcdef', cookieAttr = null) {
+    const form = document.createElement('form');
+    const input = document.createElement('input');
+    input.setAttribute('data-controller', 'csrf-protection');
+    input.value = tokenValue;
+    if (cookieAttr) {
+        input.setAttribute('data-csrf-protection-cookie-value', cookieAttr);
+    }
+    form.appendChild(input);
+    document.body.appendChild(form);
+    return form;
+}
+
+describe('csrf_protection_controller', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+        // Nettoyer les cookies
+        document.cookie.split(';').forEach((cookie) => {
+            const name = cookie.split('=')[0].trim();
+            if (name) {
+                document.cookie = `${name}=; max-age=0; path=/`;
+            }
+        });
+    });
+
+    describe('generateCsrfToken', () => {
+        it('ne fait rien si pas de champ CSRF', () => {
+            const form = document.createElement('form');
+            document.body.appendChild(form);
+
+            expect(() => generateCsrfToken(form)).not.toThrow();
+        });
+
+        it('déplace la valeur initiale dans le cookie attribute', () => {
+            // Token initial matchant nameCheck: ^[-_a-zA-Z0-9]{4,22}$
+            const form = createFormWithCsrf('my_token_name');
+
+            generateCsrfToken(form);
+
+            const csrfField = form.querySelector('input[data-controller="csrf-protection"]');
+            expect(csrfField.getAttribute('data-csrf-protection-cookie-value')).toBe('my_token_name');
+        });
+
+        it('remplace le defaultValue du champ par un token base64', () => {
+            const form = createFormWithCsrf('my_token_name');
+
+            generateCsrfToken(form);
+
+            const csrfField = form.querySelector('input[data-controller="csrf-protection"]');
+            // Le defaultValue (soumis avec le formulaire) est le nouveau token base64
+            expect(csrfField.defaultValue).not.toBe('my_token_name');
+            expect(csrfField.defaultValue.length).toBeGreaterThanOrEqual(24);
+        });
+
+        it('définit un cookie avec le format name_token=name', () => {
+            const form = createFormWithCsrf('my_token_name');
+
+            generateCsrfToken(form);
+
+            const csrfField = form.querySelector('input[data-controller="csrf-protection"]');
+            // Le cookie utilise le defaultValue (token base64) comme partie du nom
+            const expectedPrefix = `my_token_name_${csrfField.defaultValue}=my_token_name`;
+            expect(document.cookie).toContain(expectedPrefix);
+        });
+
+        it('ne préfixe pas __Host- en HTTP (jsdom)', () => {
+            // jsdom utilise http par défaut
+            const form = createFormWithCsrf('my_token_name');
+
+            generateCsrfToken(form);
+
+            expect(document.cookie).not.toContain('__Host-');
+        });
+
+        it('dispatch un événement change sur le champ', () => {
+            const form = createFormWithCsrf('my_token_name');
+            const csrfField = form.querySelector('input[data-controller="csrf-protection"]');
+            const changeSpy = vi.fn();
+            csrfField.addEventListener('change', changeSpy);
+
+            generateCsrfToken(form);
+
+            expect(changeSpy).toHaveBeenCalled();
+        });
+
+        it('fonctionne avec input name="_csrf_token"', () => {
+            const form = document.createElement('form');
+            const input = document.createElement('input');
+            input.name = '_csrf_token';
+            input.value = 'alt_csrf_name';
+            form.appendChild(input);
+            document.body.appendChild(form);
+
+            generateCsrfToken(form);
+
+            expect(input.getAttribute('data-csrf-protection-cookie-value')).toBe('alt_csrf_name');
+        });
+
+        it('ne re-génère pas si cookie attribute déjà défini', () => {
+            const form = createFormWithCsrf('my_token_name');
+
+            // Première génération
+            generateCsrfToken(form);
+            const csrfField = form.querySelector('input[data-controller="csrf-protection"]');
+            const firstToken = csrfField.value;
+
+            // Deuxième appel — le cookie attribute est déjà défini,
+            // donc la valeur initiale ne matche plus nameCheck
+            generateCsrfToken(form);
+            expect(csrfField.value).toBe(firstToken);
+        });
+    });
+
+    describe('generateCsrfHeaders', () => {
+        it('retourne un objet vide sans champ CSRF', () => {
+            const form = document.createElement('form');
+
+            expect(generateCsrfHeaders(form)).toEqual({});
+        });
+
+        it('retourne les headers quand le token est valide', () => {
+            // Simuler un formulaire avec cookie attribute déjà défini et valeur matchant tokenCheck
+            const form = document.createElement('form');
+            const input = document.createElement('input');
+            input.setAttribute('data-controller', 'csrf-protection');
+            input.setAttribute('data-csrf-protection-cookie-value', 'my_token_name');
+            // Valeur assez longue pour matcher tokenCheck: ^[-_/+a-zA-Z0-9]{24,}$
+            input.value = 'abcdefghijklmnopqrstuvwxyz';
+            form.appendChild(input);
+            document.body.appendChild(form);
+
+            const headers = generateCsrfHeaders(form);
+
+            expect(headers).toHaveProperty('my_token_name');
+            expect(headers['my_token_name']).toBe('abcdefghijklmnopqrstuvwxyz');
+        });
+
+        it('retourne un objet vide si cookie name invalide', () => {
+            const form = document.createElement('form');
+            const input = document.createElement('input');
+            input.setAttribute('data-controller', 'csrf-protection');
+            // Cookie name trop long (> 22 chars) → ne matche pas nameCheck
+            input.setAttribute('data-csrf-protection-cookie-value', 'this_name_is_way_too_long_for_name_check');
+            input.value = 'abcdefghijklmnopqrstuvwxyz';
+            form.appendChild(input);
+
+            const headers = generateCsrfHeaders(form);
+
+            expect(headers).toEqual({});
+        });
+    });
+
+    describe('removeCsrfToken', () => {
+        it('ne fait rien sans champ CSRF', () => {
+            const form = document.createElement('form');
+
+            expect(() => removeCsrfToken(form)).not.toThrow();
+        });
+
+        it('supprime le cookie CSRF', () => {
+            // Simuler un état post-generateCsrfToken
+            const form = document.createElement('form');
+            const input = document.createElement('input');
+            input.setAttribute('data-controller', 'csrf-protection');
+            input.setAttribute('data-csrf-protection-cookie-value', 'my_token_name');
+            const tokenValue = 'abcdefghijklmnopqrstuvwxyz';
+            input.value = tokenValue;
+            form.appendChild(input);
+            document.body.appendChild(form);
+
+            // Définir le cookie manuellement
+            document.cookie = `my_token_name_${tokenValue}=my_token_name; path=/; samesite=strict`;
+            expect(document.cookie).toContain(`my_token_name_${tokenValue}`);
+
+            removeCsrfToken(form);
+
+            // Le cookie devrait être supprimé (max-age=0)
+            expect(document.cookie).not.toContain(`my_token_name_${tokenValue}=my_token_name`);
+        });
+    });
+
+    describe('event listeners', () => {
+        it('génère un token lors du submit', () => {
+            const form = createFormWithCsrf('submit_test_token');
+            const csrfField = form.querySelector('input[data-controller="csrf-protection"]');
+
+            form.dispatchEvent(new Event('submit', { bubbles: true }));
+
+            expect(csrfField.getAttribute('data-csrf-protection-cookie-value')).toBe('submit_test_token');
+        });
+    });
+});

--- a/tests/js/controllers/library_controller.test.js
+++ b/tests/js/controllers/library_controller.test.js
@@ -1,0 +1,314 @@
+import LibraryController from '../../../assets/controllers/library_controller.js';
+import { startStimulusController, stopStimulusController } from '../helpers/stimulus-helper.js';
+
+const COMICS_DATA = [
+    { id: 1, title: 'Naruto', authors: 'Kishimoto', description: '', status: 'buying', type: 'manga', isWishlist: false, hasNasTome: true, updatedAt: '2025-01-15T10:00:00Z', coverUrl: null, isOneShot: false },
+    { id: 2, title: 'Astérix', authors: 'Goscinny', description: 'BD gauloise', status: 'finished', type: 'bd', isWishlist: false, hasNasTome: false, updatedAt: '2025-06-01T12:00:00Z', coverUrl: null, isOneShot: false },
+    { id: 3, title: 'Batman', authors: 'DC', description: '', status: 'buying', type: 'comics', isWishlist: false, hasNasTome: false, updatedAt: '2025-03-20T08:00:00Z', coverUrl: null, isOneShot: false },
+    { id: 4, title: 'Wish Comic', authors: 'Wish Author', description: '', status: 'wishlist', type: 'manga', isWishlist: true, hasNasTome: false, updatedAt: '2025-02-10T14:00:00Z', coverUrl: null, isOneShot: false },
+];
+
+function buildHtml({ isWishlist = false } = {}) {
+    return `
+        <div data-controller="library"
+             data-library-is-wishlist-value="${isWishlist}">
+            <input data-library-target="searchInput" type="text">
+            <span data-library-target="count"></span>
+            <div data-library-target="results"></div>
+        </div>
+    `;
+}
+
+describe('library_controller', () => {
+    let application;
+
+    beforeEach(() => {
+        global.fetch = vi.fn().mockResolvedValue({
+            json: () => Promise.resolve(COMICS_DATA),
+            ok: true,
+        });
+        // Nettoyer l'URL avant chaque test
+        window.history.replaceState({}, '', window.location.pathname);
+    });
+
+    afterEach(() => {
+        if (application) stopStimulusController(application);
+    });
+
+    function getController() {
+        return application.getControllerForElementAndIdentifier(
+            document.querySelector('[data-controller="library"]'), 'library'
+        );
+    }
+
+    describe('parseUrlFilters', () => {
+        it('parse les filtres depuis l\'URL', async () => {
+            // Simuler des paramètres d'URL
+            const url = new URL(window.location.href);
+            url.searchParams.set('type', 'manga');
+            url.searchParams.set('status', 'buying');
+            url.searchParams.set('nas', '1');
+            url.searchParams.set('sort', 'title_desc');
+            url.searchParams.set('q', 'naruto');
+            window.history.replaceState({}, '', url.toString());
+
+            ({ application } = await startStimulusController(
+                LibraryController, 'library', buildHtml()
+            ));
+
+            const controller = getController();
+            expect(controller.filters.type).toBe('manga');
+            expect(controller.filters.status).toBe('buying');
+            expect(controller.filters.nas).toBe('1');
+            expect(controller.filters.sort).toBe('title_desc');
+            expect(controller.filters.search).toBe('naruto');
+
+            // Nettoyer l'URL
+            window.history.replaceState({}, '', window.location.pathname);
+        });
+
+        it('utilise les valeurs par défaut si aucun paramètre', async () => {
+            window.history.replaceState({}, '', window.location.pathname);
+
+            ({ application } = await startStimulusController(
+                LibraryController, 'library', buildHtml()
+            ));
+
+            const controller = getController();
+            expect(controller.filters.type).toBeNull();
+            expect(controller.filters.status).toBeNull();
+            expect(controller.filters.nas).toBeNull();
+            expect(controller.filters.sort).toBe('title_asc');
+            expect(controller.filters.search).toBe('');
+        });
+    });
+
+    describe('loadComics', () => {
+        it('charge depuis le cache puis l\'API', async () => {
+            localStorage.setItem('bibliotheque_comics_cache', JSON.stringify(COMICS_DATA));
+
+            ({ application } = await startStimulusController(
+                LibraryController, 'library', buildHtml()
+            ));
+
+            await vi.waitFor(() => {
+                expect(global.fetch).toHaveBeenCalledWith('/api/comics');
+            });
+        });
+
+        it('affiche le message offline sans cache', async () => {
+            global.fetch = vi.fn().mockRejectedValue(new Error('offline'));
+            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+            ({ application } = await startStimulusController(
+                LibraryController, 'library', buildHtml()
+            ));
+
+            await vi.waitFor(() => {
+                const results = document.querySelector('[data-library-target="results"]');
+                expect(results.innerHTML).toContain('Aucune donnee en cache');
+            });
+        });
+    });
+
+    describe('renderResults - filtrage', () => {
+        async function setupWithComics(options = {}) {
+            ({ application } = await startStimulusController(
+                LibraryController, 'library', buildHtml(options)
+            ));
+
+            const controller = getController();
+            controller.comics = COMICS_DATA;
+            return controller;
+        }
+
+        it('exclut les comics wishlist en mode library', async () => {
+            const controller = await setupWithComics({ isWishlist: false });
+            controller.renderResults();
+
+            const results = document.querySelector('[data-library-target="results"]');
+            expect(results.innerHTML).toContain('Naruto');
+            expect(results.innerHTML).not.toContain('Wish Comic');
+        });
+
+        it('n\'affiche que les wishlist en mode wishlist', async () => {
+            const controller = await setupWithComics({ isWishlist: true });
+            controller.renderResults();
+
+            const results = document.querySelector('[data-library-target="results"]');
+            expect(results.innerHTML).toContain('Wish Comic');
+            expect(results.innerHTML).not.toContain('Naruto');
+        });
+
+        it('filtre par type', async () => {
+            const controller = await setupWithComics();
+            controller.filters.type = 'manga';
+            controller.renderResults();
+
+            const results = document.querySelector('[data-library-target="results"]');
+            expect(results.innerHTML).toContain('Naruto');
+            expect(results.innerHTML).not.toContain('Astérix');
+            expect(results.innerHTML).not.toContain('Batman');
+        });
+
+        it('filtre par statut', async () => {
+            const controller = await setupWithComics();
+            controller.filters.status = 'finished';
+            controller.renderResults();
+
+            const results = document.querySelector('[data-library-target="results"]');
+            expect(results.innerHTML).toContain('Astérix');
+            expect(results.innerHTML).not.toContain('Naruto');
+        });
+
+        it('filtre par NAS (oui)', async () => {
+            const controller = await setupWithComics();
+            controller.filters.nas = '1';
+            controller.renderResults();
+
+            const results = document.querySelector('[data-library-target="results"]');
+            expect(results.innerHTML).toContain('Naruto');
+            expect(results.innerHTML).not.toContain('Astérix');
+        });
+
+        it('filtre par NAS (non)', async () => {
+            const controller = await setupWithComics();
+            controller.filters.nas = '0';
+            controller.renderResults();
+
+            const results = document.querySelector('[data-library-target="results"]');
+            expect(results.innerHTML).not.toContain('Naruto');
+            expect(results.innerHTML).toContain('Astérix');
+        });
+
+        it('filtre par recherche textuelle', async () => {
+            const controller = await setupWithComics();
+            controller.filters.search = 'gauloise';
+            controller.renderResults();
+
+            const results = document.querySelector('[data-library-target="results"]');
+            expect(results.innerHTML).toContain('Astérix');
+            expect(results.innerHTML).not.toContain('Naruto');
+        });
+
+        it('ignore la recherche trop courte (< 2 caractères)', async () => {
+            const controller = await setupWithComics();
+            controller.filters.search = 'a';
+            controller.renderResults();
+
+            const results = document.querySelector('[data-library-target="results"]');
+            // Tous les comics non-wishlist doivent être affichés
+            expect(results.innerHTML).toContain('Naruto');
+            expect(results.innerHTML).toContain('Astérix');
+        });
+
+        it('met à jour le compteur', async () => {
+            const controller = await setupWithComics();
+            controller.renderResults();
+
+            const count = document.querySelector('[data-library-target="count"]');
+            expect(count.textContent).toBe('3 serie(s)');
+        });
+
+        it('affiche un message si aucun résultat', async () => {
+            const controller = await setupWithComics();
+            controller.filters.type = 'livre';
+            controller.renderResults();
+
+            const results = document.querySelector('[data-library-target="results"]');
+            expect(results.innerHTML).toContain('Aucune serie trouvee');
+        });
+
+        it('affiche le bouton Ajouter en mode wishlist', async () => {
+            const controller = await setupWithComics({ isWishlist: true });
+            controller.renderResults();
+
+            const results = document.querySelector('[data-library-target="results"]');
+            expect(results.innerHTML).toContain('to-library');
+        });
+    });
+
+    describe('sortComics', () => {
+        async function setupWithComics() {
+            ({ application } = await startStimulusController(
+                LibraryController, 'library', buildHtml()
+            ));
+            return getController();
+        }
+
+        it('trie par titre ascendant (par défaut)', async () => {
+            const controller = await setupWithComics();
+            const sorted = controller.sortComics([...COMICS_DATA]);
+
+            expect(sorted[0].title).toBe('Astérix');
+            expect(sorted[1].title).toBe('Batman');
+            expect(sorted[2].title).toBe('Naruto');
+        });
+
+        it('trie par titre descendant', async () => {
+            const controller = await setupWithComics();
+            controller.filters.sort = 'title_desc';
+            const sorted = controller.sortComics([...COMICS_DATA]);
+
+            expect(sorted[0].title).toBe('Wish Comic');
+            expect(sorted[sorted.length - 1].title).toBe('Astérix');
+        });
+
+        it('trie par date de mise à jour descendante', async () => {
+            const controller = await setupWithComics();
+            controller.filters.sort = 'updated_desc';
+            const sorted = controller.sortComics([...COMICS_DATA]);
+
+            expect(sorted[0].title).toBe('Astérix'); // 2025-06-01
+            expect(sorted[1].title).toBe('Batman');   // 2025-03-20
+        });
+
+        it('trie par date de mise à jour ascendante', async () => {
+            const controller = await setupWithComics();
+            controller.filters.sort = 'updated_asc';
+            const sorted = controller.sortComics([...COMICS_DATA]);
+
+            expect(sorted[0].title).toBe('Naruto');   // 2025-01-15
+            expect(sorted[sorted.length - 1].title).toBe('Astérix'); // 2025-06-01
+        });
+
+        it('trie par statut puis titre', async () => {
+            const controller = await setupWithComics();
+            controller.filters.sort = 'status';
+            const sorted = controller.sortComics([...COMICS_DATA]);
+
+            // buying < finished < wishlist (alphabétique)
+            expect(sorted[0].status).toBe('buying');
+            expect(sorted[1].status).toBe('buying');
+            // Même statut → tri par titre
+            expect(sorted[0].title).toBe('Batman');
+            expect(sorted[1].title).toBe('Naruto');
+        });
+    });
+
+    describe('updateFilter + updateUrlAndRender', () => {
+        it('met à jour l\'URL quand un filtre change', async () => {
+            ({ application } = await startStimulusController(
+                LibraryController, 'library', buildHtml()
+            ));
+
+            const controller = getController();
+            controller.comics = COMICS_DATA;
+            controller.updateFilter('type', 'manga');
+
+            expect(window.location.search).toContain('type=manga');
+        });
+
+        it('supprime le paramètre URL quand la valeur est null', async () => {
+            ({ application } = await startStimulusController(
+                LibraryController, 'library', buildHtml()
+            ));
+
+            const controller = getController();
+            controller.comics = COMICS_DATA;
+            controller.updateFilter('type', null);
+
+            expect(window.location.search).not.toContain('type=');
+        });
+    });
+});

--- a/tests/js/controllers/search_controller.test.js
+++ b/tests/js/controllers/search_controller.test.js
@@ -1,0 +1,220 @@
+import SearchController from '../../../assets/controllers/search_controller.js';
+import { startStimulusController, stopStimulusController } from '../helpers/stimulus-helper.js';
+
+const COMICS_DATA = [
+    { id: 1, title: 'Naruto', authors: 'Masashi Kishimoto', description: 'Ninja manga', status: 'buying', type: 'manga', coverUrl: null, isOneShot: false, hasNasTome: false },
+    { id: 2, title: 'One Piece', authors: 'Eiichiro Oda', description: 'Pirate manga', status: 'buying', type: 'manga', coverUrl: null, isOneShot: false, hasNasTome: true },
+    { id: 3, title: 'Astérix', authors: 'Goscinny, Uderzo', description: 'BD franco-belge', status: 'finished', type: 'bd', coverUrl: null, isOneShot: false, hasNasTome: false },
+];
+
+function buildHtml() {
+    return `
+        <div data-controller="search">
+            <input data-search-target="input" type="text" value="">
+            <div data-search-target="results"></div>
+        </div>
+    `;
+}
+
+describe('search_controller', () => {
+    let application;
+
+    beforeEach(() => {
+        global.fetch = vi.fn().mockResolvedValue({
+            json: () => Promise.resolve(COMICS_DATA),
+            ok: true,
+        });
+        vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        if (application) stopStimulusController(application);
+    });
+
+    function getController() {
+        return application.getControllerForElementAndIdentifier(
+            document.querySelector('[data-controller="search"]'), 'search'
+        );
+    }
+
+    describe('loadComics', () => {
+        it('charge les données depuis le cache puis l\'API', async () => {
+            localStorage.setItem('bibliotheque_comics_cache', JSON.stringify([COMICS_DATA[0]]));
+
+            ({ application } = await startStimulusController(
+                SearchController, 'search', buildHtml()
+            ));
+
+            await vi.waitFor(() => {
+                expect(global.fetch).toHaveBeenCalledWith('/api/comics');
+            });
+        });
+
+        it('sauvegarde les données de l\'API dans le cache', async () => {
+            ({ application } = await startStimulusController(
+                SearchController, 'search', buildHtml()
+            ));
+
+            await vi.waitFor(() => {
+                expect(localStorage.getItem('bibliotheque_comics_cache')).toBe(JSON.stringify(COMICS_DATA));
+            });
+        });
+
+        it('utilise le cache en mode offline', async () => {
+            global.fetch = vi.fn().mockRejectedValue(new Error('offline'));
+            localStorage.setItem('bibliotheque_comics_cache', JSON.stringify(COMICS_DATA));
+            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+            ({ application } = await startStimulusController(
+                SearchController, 'search', buildHtml()
+            ));
+
+            await vi.waitFor(() => {
+                expect(consoleSpy).toHaveBeenCalledWith('Mode hors ligne, utilisation du cache');
+            });
+        });
+    });
+
+    describe('search (debounce)', () => {
+        it('attend 300ms avant d\'effectuer la recherche', async () => {
+            ({ application } = await startStimulusController(
+                SearchController, 'search', buildHtml()
+            ));
+
+            const controller = getController();
+            controller.comics = COMICS_DATA;
+
+            // Maintenant activer les fake timers
+            vi.useFakeTimers();
+
+            const input = document.querySelector('[data-search-target="input"]');
+            input.value = 'naruto';
+            controller.search();
+
+            // Pas encore de résultats
+            const results = document.querySelector('[data-search-target="results"]');
+            expect(results.innerHTML).toBe('');
+
+            vi.advanceTimersByTime(300);
+
+            expect(results.innerHTML).toContain('Naruto');
+
+            vi.useRealTimers();
+        });
+
+        it('affiche l\'état vide quand la query est effacée', async () => {
+            ({ application } = await startStimulusController(
+                SearchController, 'search', buildHtml()
+            ));
+
+            const controller = getController();
+            controller.comics = COMICS_DATA;
+
+            vi.useFakeTimers();
+
+            const input = document.querySelector('[data-search-target="input"]');
+            input.value = '';
+            controller.search();
+
+            vi.advanceTimersByTime(300);
+
+            const results = document.querySelector('[data-search-target="results"]');
+            expect(results.innerHTML).toContain('Entrez un terme de recherche');
+
+            vi.useRealTimers();
+        });
+    });
+
+    describe('performSearch', () => {
+        async function setupWithComics() {
+            ({ application } = await startStimulusController(
+                SearchController, 'search', buildHtml()
+            ));
+            const controller = getController();
+            controller.comics = COMICS_DATA;
+            return controller;
+        }
+
+        it('filtre par titre', async () => {
+            const controller = await setupWithComics();
+            controller.performSearch('naruto');
+
+            const results = document.querySelector('[data-search-target="results"]');
+            expect(results.innerHTML).toContain('Naruto');
+            expect(results.innerHTML).not.toContain('Astérix');
+        });
+
+        it('filtre par auteur', async () => {
+            const controller = await setupWithComics();
+            controller.performSearch('goscinny');
+
+            const results = document.querySelector('[data-search-target="results"]');
+            expect(results.innerHTML).toContain('Astérix');
+            expect(results.innerHTML).not.toContain('Naruto');
+        });
+
+        it('filtre par description', async () => {
+            const controller = await setupWithComics();
+            controller.performSearch('pirate');
+
+            const results = document.querySelector('[data-search-target="results"]');
+            expect(results.innerHTML).toContain('One Piece');
+        });
+
+        it('est insensible aux accents', async () => {
+            const controller = await setupWithComics();
+            controller.performSearch('asterix');
+
+            const results = document.querySelector('[data-search-target="results"]');
+            expect(results.innerHTML).toContain('Astérix');
+        });
+    });
+
+    describe('renderResults', () => {
+        async function setupWithComics() {
+            ({ application } = await startStimulusController(
+                SearchController, 'search', buildHtml()
+            ));
+            const controller = getController();
+            controller.comics = COMICS_DATA;
+            return controller;
+        }
+
+        it('affiche le compteur de résultats', async () => {
+            const controller = await setupWithComics();
+            controller.performSearch('manga');
+
+            const results = document.querySelector('[data-search-target="results"]');
+            expect(results.innerHTML).toContain('2 resultat(s)');
+        });
+
+        it('affiche un message quand aucun résultat', async () => {
+            const controller = await setupWithComics();
+            controller.performSearch('inexistant');
+
+            const results = document.querySelector('[data-search-target="results"]');
+            expect(results.innerHTML).toContain('Aucun resultat');
+        });
+
+        it('affiche le message de chargement si comics non chargés', async () => {
+            ({ application } = await startStimulusController(
+                SearchController, 'search', buildHtml()
+            ));
+            const controller = getController();
+            controller.comics = null;
+            controller.performSearch('test');
+
+            const results = document.querySelector('[data-search-target="results"]');
+            expect(results.innerHTML).toContain('Chargement des donnees');
+        });
+
+        it('échappe la query dans le HTML', async () => {
+            const controller = await setupWithComics();
+            controller.performSearch('<script>xss</script>');
+
+            const results = document.querySelector('[data-search-target="results"]');
+            expect(results.innerHTML).toContain('&lt;script&gt;');
+            expect(results.innerHTML).not.toContain('<script>xss</script>');
+        });
+    });
+});

--- a/tests/js/controllers/tomes_collection_controller.test.js
+++ b/tests/js/controllers/tomes_collection_controller.test.js
@@ -1,0 +1,149 @@
+import TomesCollectionController from '../../../assets/controllers/tomes_collection_controller.js';
+import { startStimulusController, stopStimulusController } from '../helpers/stimulus-helper.js';
+
+const PROTOTYPE_HTML = `
+    <div data-tomes-collection-target="entry" class="tome-entry">
+        <input class="tome-number-input" name="tomes[__name__][number]" value="">
+        <input class="tome-isbn-input" name="tomes[__name__][isbn]" value="">
+        <button data-action="tomes-collection#removeTome" class="tome-remove">Supprimer</button>
+    </div>
+`;
+
+function buildHtml(entries = '') {
+    return `
+        <div data-controller="tomes-collection">
+            <div data-tomes-collection-target="list">
+                ${entries}
+            </div>
+            <template data-tomes-collection-target="prototype">${PROTOTYPE_HTML}</template>
+            <button data-action="tomes-collection#addTome">Ajouter</button>
+        </div>
+    `;
+}
+
+describe('tomes_collection_controller', () => {
+    let application;
+
+    afterEach(() => {
+        if (application) stopStimulusController(application);
+    });
+
+    describe('addTome', () => {
+        it('ajoute un tome à la liste', async () => {
+            ({ application } = await startStimulusController(
+                TomesCollectionController, 'tomes-collection', buildHtml()
+            ));
+
+            const addButton = document.querySelector('[data-action="tomes-collection#addTome"]');
+            addButton.click();
+
+            const entries = document.querySelectorAll('[data-tomes-collection-target="entry"]');
+            expect(entries).toHaveLength(1);
+        });
+
+        it('remplace __name__ par l\'index courant', async () => {
+            ({ application } = await startStimulusController(
+                TomesCollectionController, 'tomes-collection', buildHtml()
+            ));
+
+            const addButton = document.querySelector('[data-action="tomes-collection#addTome"]');
+            addButton.click();
+
+            const input = document.querySelector('.tome-number-input');
+            expect(input.name).toBe('tomes[0][number]');
+        });
+
+        it('incrémente l\'index à chaque ajout', async () => {
+            ({ application } = await startStimulusController(
+                TomesCollectionController, 'tomes-collection', buildHtml()
+            ));
+
+            const addButton = document.querySelector('[data-action="tomes-collection#addTome"]');
+            addButton.click();
+            addButton.click();
+
+            const inputs = document.querySelectorAll('.tome-number-input');
+            expect(inputs[0].name).toBe('tomes[0][number]');
+            expect(inputs[1].name).toBe('tomes[1][number]');
+        });
+
+        it('met le focus sur le champ numéro', async () => {
+            ({ application } = await startStimulusController(
+                TomesCollectionController, 'tomes-collection', buildHtml()
+            ));
+
+            const addButton = document.querySelector('[data-action="tomes-collection#addTome"]');
+            addButton.click();
+
+            const input = document.querySelector('.tome-number-input');
+            expect(document.activeElement).toBe(input);
+        });
+
+        it('initialise l\'index au nombre d\'entrées existantes', async () => {
+            const existingEntry = `
+                <div data-tomes-collection-target="entry" class="tome-entry">
+                    <input class="tome-number-input" name="tomes[0][number]" value="1">
+                </div>
+            `;
+            ({ application } = await startStimulusController(
+                TomesCollectionController, 'tomes-collection', buildHtml(existingEntry)
+            ));
+
+            const addButton = document.querySelector('[data-action="tomes-collection#addTome"]');
+            addButton.click();
+
+            const inputs = document.querySelectorAll('.tome-number-input');
+            expect(inputs[1].name).toBe('tomes[1][number]');
+        });
+    });
+
+    describe('removeTome', () => {
+        it('ajoute la classe --removing à l\'entrée', async () => {
+            ({ application } = await startStimulusController(
+                TomesCollectionController, 'tomes-collection', buildHtml()
+            ));
+
+            // Ajouter un tome via le contrôleur
+            const addButton = document.querySelector('[data-action="tomes-collection#addTome"]');
+            addButton.click();
+
+            // Appeler removeTome directement avec un event simulé
+            const controller = application.getControllerForElementAndIdentifier(
+                document.querySelector('[data-controller="tomes-collection"]'), 'tomes-collection'
+            );
+            const removeButton = document.querySelector('.tome-remove');
+            controller.removeTome({ preventDefault: () => {}, target: removeButton });
+
+            const entry = document.querySelector('[data-tomes-collection-target="entry"]');
+            expect(entry.classList.contains('tome-entry--removing')).toBe(true);
+        });
+
+        it('supprime l\'entrée après 200ms', async () => {
+            ({ application } = await startStimulusController(
+                TomesCollectionController, 'tomes-collection', buildHtml()
+            ));
+
+            const addButton = document.querySelector('[data-action="tomes-collection#addTome"]');
+            addButton.click();
+
+            const controller = application.getControllerForElementAndIdentifier(
+                document.querySelector('[data-controller="tomes-collection"]'), 'tomes-collection'
+            );
+
+            // Activer les fake timers APRÈS que Stimulus soit connecté
+            vi.useFakeTimers();
+
+            const removeButton = document.querySelector('.tome-remove');
+            controller.removeTome({ preventDefault: () => {}, target: removeButton });
+
+            // Pas encore supprimé
+            expect(document.querySelectorAll('[data-tomes-collection-target="entry"]')).toHaveLength(1);
+
+            vi.advanceTimersByTime(200);
+
+            expect(document.querySelectorAll('[data-tomes-collection-target="entry"]')).toHaveLength(0);
+
+            vi.useRealTimers();
+        });
+    });
+});

--- a/tests/js/helpers/stimulus-helper.js
+++ b/tests/js/helpers/stimulus-helper.js
@@ -1,0 +1,39 @@
+import { Application } from '@hotwired/stimulus';
+
+/**
+ * Démarre un contrôleur Stimulus dans un conteneur DOM isolé.
+ *
+ * @param {typeof import('@hotwired/stimulus').Controller} ControllerClass
+ * @param {string} identifier - Identifiant Stimulus (ex: 'tomes-collection')
+ * @param {string} html - HTML du conteneur (doit contenir data-controller)
+ * @returns {Promise<{application: Application, element: HTMLElement}>}
+ */
+export async function startStimulusController(ControllerClass, identifier, html) {
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    document.body.appendChild(container);
+
+    const element = container.querySelector(`[data-controller="${identifier}"]`);
+
+    const application = Application.start(container);
+    application.register(identifier, ControllerClass);
+
+    // Attendre que Stimulus connecte le contrôleur
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    return { application, element };
+}
+
+/**
+ * Arrête l'application Stimulus et nettoie le DOM.
+ *
+ * @param {Application} application
+ */
+export function stopStimulusController(application) {
+    application.stop();
+
+    // Supprime tous les conteneurs ajoutés au body
+    while (document.body.firstChild) {
+        document.body.firstChild.remove();
+    }
+}

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -1,0 +1,70 @@
+/**
+ * Configuration globale des mocks pour les tests Vitest.
+ * Fournit des implémentations en mémoire de fetch, localStorage, Cache API et crypto.
+ */
+
+// --- fetch mock ---
+global.fetch = vi.fn();
+
+// --- localStorage mock (implémentation en mémoire) ---
+const localStorageMock = (() => {
+    let store = {};
+    return {
+        clear: () => { store = {}; },
+        getItem: (key) => store[key] ?? null,
+        key: (index) => Object.keys(store)[index] ?? null,
+        get length() { return Object.keys(store).length; },
+        removeItem: (key) => { delete store[key]; },
+        setItem: (key, value) => { store[key] = String(value); },
+    };
+})();
+
+Object.defineProperty(global, 'localStorage', { value: localStorageMock });
+
+// --- Cache API mock ---
+function createCacheMock() {
+    const cacheStore = new Map();
+    return {
+        delete: vi.fn(async (request) => cacheStore.delete(String(request))),
+        match: vi.fn(async (request) => cacheStore.get(String(request)) || undefined),
+        put: vi.fn(async (request, response) => { cacheStore.set(String(request), response); }),
+    };
+}
+
+let cachesMap = new Map();
+
+const cachesMock = {
+    delete: vi.fn(async (name) => cachesMap.delete(name)),
+    open: vi.fn(async (name) => {
+        if (!cachesMap.has(name)) {
+            cachesMap.set(name, createCacheMock());
+        }
+        return cachesMap.get(name);
+    }),
+};
+
+Object.defineProperty(global, 'caches', { configurable: true, value: cachesMock, writable: true });
+
+// --- crypto.getRandomValues mock ---
+if (!global.crypto) {
+    global.crypto = {};
+}
+if (!global.crypto.getRandomValues) {
+    global.crypto.getRandomValues = (array) => {
+        for (let i = 0; i < array.length; i++) {
+            array[i] = Math.floor(Math.random() * 256);
+        }
+        return array;
+    };
+}
+
+// --- Reset après chaque test ---
+afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    global.fetch = vi.fn();
+    // Reset le cache API (nouvelles instances pour chaque test)
+    cachesMap = new Map();
+    cachesMock.open.mockClear();
+    cachesMock.delete.mockClear();
+});

--- a/tests/js/utils/cache-utils.test.js
+++ b/tests/js/utils/cache-utils.test.js
@@ -1,0 +1,60 @@
+import { getFromCache, saveToCache } from '../../../assets/utils/cache-utils.js';
+
+describe('getFromCache', () => {
+    it('retourne null si le cache est vide', () => {
+        expect(getFromCache()).toBeNull();
+    });
+
+    it('retourne les données désérialisées', () => {
+        const data = [{ id: 1, title: 'Naruto' }];
+        localStorage.setItem('bibliotheque_comics_cache', JSON.stringify(data));
+
+        expect(getFromCache()).toEqual(data);
+    });
+
+    it('utilise la clé par défaut', () => {
+        localStorage.setItem('bibliotheque_comics_cache', '"test"');
+
+        expect(getFromCache()).toBe('test');
+    });
+
+    it('accepte une clé personnalisée', () => {
+        localStorage.setItem('custom_key', JSON.stringify([1, 2]));
+
+        expect(getFromCache('custom_key')).toEqual([1, 2]);
+    });
+
+    it('retourne null en cas de JSON invalide', () => {
+        localStorage.setItem('bibliotheque_comics_cache', '{invalid');
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        expect(getFromCache()).toBeNull();
+        expect(consoleSpy).toHaveBeenCalled();
+    });
+});
+
+describe('saveToCache', () => {
+    it('sauvegarde les données dans localStorage', () => {
+        const data = [{ id: 1, title: 'One Piece' }];
+        saveToCache(data);
+
+        expect(localStorage.getItem('bibliotheque_comics_cache')).toBe(JSON.stringify(data));
+    });
+
+    it('accepte une clé personnalisée', () => {
+        saveToCache([42], 'my_cache');
+
+        expect(localStorage.getItem('my_cache')).toBe('[42]');
+    });
+
+    it('gère silencieusement les erreurs de stockage', () => {
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const original = localStorage.setItem;
+        localStorage.setItem = () => { throw new Error('QuotaExceeded'); };
+
+        expect(() => saveToCache([1])).not.toThrow();
+        expect(consoleSpy).toHaveBeenCalled();
+
+        localStorage.setItem = original;
+    });
+});

--- a/tests/js/utils/card-renderer.test.js
+++ b/tests/js/utils/card-renderer.test.js
@@ -1,0 +1,172 @@
+import { renderCard } from '../../../assets/utils/card-renderer.js';
+
+/** Comic de base pour les tests */
+function makeComic(overrides = {}) {
+    return {
+        coverUrl: null,
+        currentIssue: 5,
+        currentIssueComplete: false,
+        deleteToken: 'del-token',
+        hasNasTome: false,
+        id: 42,
+        isOneShot: false,
+        lastBought: 4,
+        lastBoughtComplete: false,
+        lastDownloaded: null,
+        lastDownloadedComplete: false,
+        latestPublishedIssue: 10,
+        latestPublishedIssueComplete: false,
+        missingTomesNumbers: [6, 7],
+        ownedTomesNumbers: [1, 2, 3, 4, 5],
+        status: 'buying',
+        title: 'Naruto',
+        toLibraryToken: null,
+        type: 'manga',
+        ...overrides,
+    };
+}
+
+describe('renderCard', () => {
+    it('génère le HTML avec titre et badges', () => {
+        const html = renderCard(makeComic());
+
+        expect(html).toContain('Naruto');
+        expect(html).toContain('status-buying');
+        expect(html).toContain("En cours d'achat");
+        expect(html).toContain('type-badge-manga');
+        expect(html).toContain('Manga');
+    });
+
+    it('affiche la couverture si coverUrl est fournie', () => {
+        const html = renderCard(makeComic({ coverUrl: '/img/naruto.jpg' }));
+
+        expect(html).toContain('<img src="/img/naruto.jpg"');
+        expect(html).toContain('Couverture de Naruto');
+    });
+
+    it("n'affiche pas de couverture si coverUrl est null", () => {
+        const html = renderCard(makeComic({ coverUrl: null }));
+
+        expect(html).not.toContain('comic-card-cover');
+    });
+
+    it('échappe le titre contre XSS', () => {
+        const html = renderCard(makeComic({ title: '<script>alert("xss")</script>' }));
+
+        expect(html).toContain('&lt;script&gt;');
+        expect(html).not.toContain('<script>alert');
+    });
+
+    it('affiche "Tome unique" pour les one-shots', () => {
+        const html = renderCard(makeComic({ isOneShot: true }));
+
+        expect(html).toContain('Tome unique');
+        // Ne devrait pas afficher les détails de tomes
+        expect(html).not.toContain('Possede');
+    });
+
+    it('affiche le badge NAS si hasNasTome est vrai', () => {
+        const html = renderCard(makeComic({ hasNasTome: true }));
+
+        expect(html).toContain('type-badge-nas');
+        expect(html).toContain('NAS');
+    });
+
+    it("n'affiche pas le badge NAS si hasNasTome est faux", () => {
+        const html = renderCard(makeComic({ hasNasTome: false }));
+
+        expect(html).not.toContain('type-badge-nas');
+    });
+
+    it('affiche les tomes manquants avec la classe warning', () => {
+        const html = renderCard(makeComic({ missingTomesNumbers: [3, 5] }));
+
+        expect(html).toContain('Manquants');
+        expect(html).toContain('warning');
+        expect(html).toContain('3, 5');
+    });
+
+    it('affiche les tomes possédés', () => {
+        const html = renderCard(makeComic({ ownedTomesNumbers: [1, 2, 3] }));
+
+        expect(html).toContain('Tomes');
+        expect(html).toContain('1, 2, 3');
+    });
+
+    it('affiche le bouton Modifier et Supprimer', () => {
+        const html = renderCard(makeComic());
+
+        expect(html).toContain('/comic/42/edit');
+        expect(html).toContain('Modifier');
+        expect(html).toContain('/comic/42/delete');
+        expect(html).toContain('Supprimer');
+    });
+
+    it("n'affiche pas le bouton Ajouter par défaut", () => {
+        const html = renderCard(makeComic());
+
+        expect(html).not.toContain('to-library');
+        expect(html).not.toContain('Ajouter');
+    });
+
+    it('affiche le bouton Ajouter si showAddButton est vrai', () => {
+        const html = renderCard(makeComic({ toLibraryToken: 'lib-token' }), { showAddButton: true });
+
+        expect(html).toContain('/comic/42/to-library');
+        expect(html).toContain('Ajouter');
+        expect(html).toContain('lib-token');
+    });
+
+    it("affiche 'Complet' quand currentIssueComplete est vrai", () => {
+        const html = renderCard(makeComic({ currentIssue: 10, currentIssueComplete: true }));
+
+        expect(html).toContain('Complet');
+    });
+
+    it('affiche les infos de dernière publication avec terminé', () => {
+        const html = renderCard(makeComic({
+            latestPublishedIssue: 72,
+            latestPublishedIssueComplete: true,
+        }));
+
+        expect(html).toContain('Parus');
+        expect(html).toContain('72 (termine)');
+    });
+
+    it('utilise les labels personnalisés', () => {
+        const html = renderCard(makeComic(), {
+            statusLabels: { buying: 'Achat en cours' },
+            typeLabels: { manga: 'マンガ' },
+        });
+
+        expect(html).toContain('Achat en cours');
+        expect(html).toContain('マンガ');
+    });
+
+    it('utilise statusLabel/typeLabel du comic si fournis', () => {
+        const html = renderCard(makeComic({ statusLabel: 'Custom Status', typeLabel: 'Custom Type' }));
+
+        expect(html).toContain('Custom Status');
+        expect(html).toContain('Custom Type');
+    });
+
+    it('affiche le lien vers la page de détail', () => {
+        const html = renderCard(makeComic({ id: 99 }));
+
+        expect(html).toContain('href="/comic/99"');
+    });
+
+    it("affiche 'Complet' pour lastBoughtComplete", () => {
+        const html = renderCard(makeComic({ lastBought: 5, lastBoughtComplete: true }));
+
+        expect(html).toContain('Dernier achat');
+        expect(html).toContain('Complet');
+    });
+
+    it("affiche 'Complet' pour lastDownloadedComplete", () => {
+        const html = renderCard(makeComic({ lastDownloaded: 3, lastDownloadedComplete: true }));
+
+        expect(html).toContain('Telecharge');
+        expect(html).toContain('Complet');
+    });
+});

--- a/tests/js/utils/string-utils.test.js
+++ b/tests/js/utils/string-utils.test.js
@@ -1,0 +1,51 @@
+import { escapeHtml, normalizeString } from '../../../assets/utils/string-utils.js';
+
+describe('normalizeString', () => {
+    it('convertit en minuscules', () => {
+        expect(normalizeString('ABC')).toBe('abc');
+    });
+
+    it('supprime les accents', () => {
+        expect(normalizeString('éàüôç')).toBe('eauoc');
+    });
+
+    it('combine minuscules et accents', () => {
+        expect(normalizeString('Château FÉLIX')).toBe('chateau felix');
+    });
+
+    it('retourne une chaîne vide inchangée', () => {
+        expect(normalizeString('')).toBe('');
+    });
+
+    it('gère les caractères spéciaux sans accent', () => {
+        expect(normalizeString('one-shot #1')).toBe('one-shot #1');
+    });
+});
+
+describe('escapeHtml', () => {
+    it('échappe les chevrons', () => {
+        expect(escapeHtml('<script>alert("xss")</script>')).toBe(
+            '&lt;script&gt;alert("xss")&lt;/script&gt;'
+        );
+    });
+
+    it('échappe les esperluettes', () => {
+        expect(escapeHtml('a & b')).toBe('a &amp; b');
+    });
+
+    it('retourne une chaîne vide pour null', () => {
+        expect(escapeHtml(null)).toBe('');
+    });
+
+    it('retourne une chaîne vide pour undefined', () => {
+        expect(escapeHtml(undefined)).toBe('');
+    });
+
+    it('retourne une chaîne vide pour une chaîne vide', () => {
+        expect(escapeHtml('')).toBe('');
+    });
+
+    it('laisse le texte normal inchangé', () => {
+        expect(escapeHtml('Naruto Vol. 1')).toBe('Naruto Vol. 1');
+    });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'jsdom',
+        globals: true,
+        include: ['tests/js/**/*.test.js'],
+        setupFiles: ['tests/js/setup.js'],
+    },
+});


### PR DESCRIPTION
## Summary
- **139 tests unitaires** Vitest couvrant les 3 modules utilitaires et les 6 contrôleurs Stimulus
- Infrastructure de test : `vitest.config.js`, `tests/js/setup.js` (mocks globaux), `tests/js/helpers/stimulus-helper.js`
- Devdependencies ajoutées : `vitest`, `jsdom`, `@hotwired/stimulus@3.2.2`

## Détail des tests

| Fichier | Tests | Cible |
|---------|-------|-------|
| `string-utils.test.js` | 11 | `normalizeString`, `escapeHtml` |
| `cache-utils.test.js` | 8 | `getFromCache`, `saveToCache` |
| `card-renderer.test.js` | 19 | `renderCard` (HTML, XSS, badges) |
| `tomes_collection_controller.test.js` | 7 | `addTome`, `removeTome` |
| `cache_warmer_controller.test.js` | 9 | `warmCache` (routing cache, skip, erreurs) |
| `csrf_protection_controller.test.js` | 14 | `generateCsrfToken`, `generateCsrfHeaders`, `removeCsrfToken` |
| `search_controller.test.js` | 13 | `loadComics`, `search`, `performSearch`, `renderResults` |
| `library_controller.test.js` | 22 | `parseUrlFilters`, `loadComics`, `renderResults`, `sortComics`, `updateFilter` |
| `comic_form_controller.test.js` | 36 | `applyOneShotState`, `fillField`, ISBN lookup, flash messages |

## Test plan
- [x] `ddev exec npm test` — 139 tests passing (~1.3s)
- [x] `ddev exec npm run test:watch` — mode watch fonctionnel

fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)