### PR TITLE
fix(form): filtrer les champs volume-spécifiques lors du lookup ISBN tome

### DIFF
--- a/assets/controllers/comic_form_controller.js
+++ b/assets/controllers/comic_form_controller.js
@@ -171,7 +171,8 @@ export default class extends Controller {
     }
 
     /**
-     * Recherche les informations du livre par ISBN du tome (pour les one-shots).
+     * Recherche les informations du livre par ISBN d'un tome.
+     * Ne remplit que les champs pertinents au niveau série (auteurs, éditeur, couverture).
      */
     async lookupTomeIsbn(event) {
         const button = event.currentTarget;
@@ -185,7 +186,7 @@ export default class extends Controller {
             return;
         }
 
-        await this.performIsbnLookup(isbn, button);
+        await this.performIsbnLookup(isbn, button, { fromTome: true });
     }
 
     /**
@@ -210,8 +211,13 @@ export default class extends Controller {
 
     /**
      * Logique commune de recherche ISBN via l'API.
+     * @param {string} isbn - ISBN à rechercher
+     * @param {HTMLButtonElement|null} button - Bouton à désactiver pendant la recherche
+     * @param {Object} options - Options de recherche
+     * @param {boolean} options.fromTome - Si true, ne remplit que les champs série (pas title/date/description)
      */
-    async performIsbnLookup(isbn, button) {
+    async performIsbnLookup(isbn, button, options = {}) {
+        const { fromTome = false } = options;
         const type = this.getSelectedType();
 
         if (button) button.disabled = true;
@@ -229,16 +235,20 @@ export default class extends Controller {
             // Liste des champs remplis
             const filledFields = [];
 
-            // Remplit les champs de la série
-            if (this.fillField('title', data.title)) filledFields.push('title');
+            // Champs volume-spécifiques : uniquement en mode normal (pas depuis un tome)
+            if (!fromTome) {
+                if (this.fillField('title', data.title)) filledFields.push('title');
+                if (this.fillField('publishedDate', data.publishedDate)) filledFields.push('publishedDate');
+                if (this.fillField('description', data.description)) filledFields.push('description');
+            }
+
+            // Champs série : toujours remplis
             if (this.fillAuthors(data.authors)) filledFields.push('authors');
             if (this.fillField('publisher', data.publisher)) filledFields.push('publisher');
-            if (this.fillField('publishedDate', data.publishedDate)) filledFields.push('publishedDate');
-            if (this.fillField('description', data.description)) filledFields.push('description');
             if (this.fillField('coverUrl', data.thumbnail)) filledFields.push('coverUrl');
 
-            // Gère le one-shot détecté (coche la case si pas déjà cochée)
-            if (data.isOneShot === true && this.hasIsOneShotTarget && !this.isOneShotTarget.checked) {
+            // Gère le one-shot détecté (uniquement en mode normal)
+            if (!fromTome && data.isOneShot === true && this.hasIsOneShotTarget && !this.isOneShotTarget.checked) {
                 this.isOneShotTarget.checked = true;
                 this.applyOneShotState(true);
                 filledFields.push('isOneShot');

--- a/tests/js/controllers/comic_form_controller.test.js
+++ b/tests/js/controllers/comic_form_controller.test.js
@@ -330,6 +330,81 @@ describe('comic_form_controller', () => {
             expect(checkbox.checked).toBe(true);
         });
 
+        it('ne remplit PAS title/publishedDate/description depuis un tome', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    authors: 'Kishimoto',
+                    description: 'Résumé du tome 1',
+                    isOneShot: false,
+                    publishedDate: '2024',
+                    publisher: 'Kana',
+                    sources: ['google_books'],
+                    thumbnail: 'http://img.jpg',
+                    title: 'Naruto Vol. 1',
+                }),
+                ok: true,
+            });
+
+            const controller = await setup();
+            const button = document.createElement('button');
+            await controller.performIsbnLookup('978-123', button, { fromTome: true });
+
+            // Champs série : remplis
+            expect(document.querySelector('[data-comic-form-target="publisher"]').value).toBe('Kana');
+            expect(document.querySelector('[data-comic-form-target="coverUrl"]').value).toBe('http://img.jpg');
+
+            // Champs volume-spécifiques : NON remplis
+            expect(document.querySelector('[data-comic-form-target="title"]').value).toBe('');
+            expect(document.querySelector('[data-comic-form-target="publishedDate"]').value).toBe('');
+            expect(document.querySelector('[data-comic-form-target="description"]').value).toBe('');
+        });
+
+        it('remplit title/publishedDate/description en mode normal', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    authors: 'Kishimoto',
+                    description: 'Ninja manga',
+                    isOneShot: false,
+                    publishedDate: '1999',
+                    publisher: 'Kana',
+                    sources: ['google_books'],
+                    thumbnail: 'http://img.jpg',
+                    title: 'Naruto',
+                }),
+                ok: true,
+            });
+
+            const controller = await setup();
+            const button = document.createElement('button');
+            await controller.performIsbnLookup('978-123', button);
+
+            expect(document.querySelector('[data-comic-form-target="title"]').value).toBe('Naruto');
+            expect(document.querySelector('[data-comic-form-target="publishedDate"]').value).toBe('1999');
+            expect(document.querySelector('[data-comic-form-target="description"]').value).toBe('Ninja manga');
+            expect(document.querySelector('[data-comic-form-target="publisher"]').value).toBe('Kana');
+            expect(document.querySelector('[data-comic-form-target="coverUrl"]').value).toBe('http://img.jpg');
+        });
+
+        it('ne coche PAS isOneShot depuis un tome', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    isOneShot: true,
+                    sources: ['google_books'],
+                    title: 'Solo Vol. 1',
+                }),
+                ok: true,
+            });
+
+            const controller = await setup();
+            await controller.performIsbnLookup('978-123', null, { fromTome: true });
+
+            const checkbox = document.querySelector('[data-comic-form-target="isOneShot"]');
+            expect(checkbox.checked).toBe(false);
+        });
+
         it('inclut le type dans l\'URL de l\'API', async () => {
             global.fetch = vi.fn().mockResolvedValue({
                 json: () => Promise.resolve({ apiMessages: {}, sources: [] }),


### PR DESCRIPTION
## Summary
- Quand `performIsbnLookup` est appelé depuis un tome (`{ fromTome: true }`), ne remplit que les champs pertinents au niveau série : **auteurs**, **éditeur**, **couverture**
- Les champs volume-spécifiques (**title**, **publishedDate**, **description**) et **isOneShot** sont ignorés pour éviter d'écraser les données série avec des données du volume
- Le mode normal (one-shot / ISBN série) reste inchangé

## Test Plan
- [x] 3 nouveaux tests Vitest couvrant le comportement `fromTome`
- [x] 142/142 tests passent (0 régression)
- [ ] Test manuel : éditer une série → ajouter tome avec ISBN → vérifier que seuls auteurs/éditeur/couverture sont remplis

fixes #7