### PR TITLE
feat(scan): scan ISBN via caméra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Scan ISBN via caméra** : Scanner de code-barres ISBN via l'API native BarcodeDetector (Chrome Android)
+  - Scan depuis les formulaires (champ ISBN one-shot et tomes)
+  - Saisie rapide : bouton scan sur la page d'accueil → pré-remplissage automatique du formulaire
+  - Modal plein écran avec animation de balayage
+  - 19 tests Vitest pour les contrôleurs barcode-scanner et quick-scan
+
 - **Tests JavaScript (Vitest)** : Suite de tests unitaires pour tout le code JS du projet
   - 139 tests couvrant 3 modules utilitaires et 6 contrôleurs Stimulus
   - Framework Vitest avec jsdom (support ESM natif compatible AssetMapper)

--- a/assets/controllers/barcode_scanner_controller.js
+++ b/assets/controllers/barcode_scanner_controller.js
@@ -1,0 +1,157 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Contrôleur Stimulus pour le scan de code-barres ISBN via la caméra.
+ *
+ * Utilise l'API native BarcodeDetector (Chrome Android 83+).
+ * Émet des événements : detected, unsupported, error.
+ */
+export default class extends Controller {
+    static values = {
+        formats: { default: ['ean_13'], type: Array },
+    };
+
+    connect() {
+        this.detector = null;
+        this.modal = null;
+        this.scanning = false;
+        this.stream = null;
+    }
+
+    /**
+     * Ouvre le scanner : crée le modal, démarre la caméra et la boucle de détection.
+     */
+    async open() {
+        if (typeof BarcodeDetector === 'undefined') {
+            this.dispatch('unsupported');
+            return;
+        }
+
+        this.detector = new BarcodeDetector({ formats: this.formatsValue });
+
+        this.createModal();
+
+        try {
+            this.stream = await navigator.mediaDevices.getUserMedia({
+                video: { facingMode: 'environment' },
+            });
+
+            const video = this.modal.querySelector('video');
+            video.srcObject = this.stream;
+            await video.play();
+
+            this.scanning = true;
+            this.startDetectionLoop();
+        } catch (error) {
+            this.dispatch('error', { detail: { message: error.message } });
+            this.destroyModal();
+        }
+    }
+
+    /**
+     * Ferme le scanner : arrête le stream et supprime le modal.
+     */
+    close() {
+        this.scanning = false;
+        this.stopStream();
+        this.destroyModal();
+    }
+
+    /**
+     * Effectue un cycle de détection (exposé pour les tests).
+     */
+    async detectBarcode() {
+        if (!this.detector || !this.modal) {
+            return;
+        }
+
+        const video = this.modal.querySelector('video');
+
+        try {
+            const barcodes = await this.detector.detect(video);
+
+            if (barcodes.length > 0) {
+                const { format, rawValue } = barcodes[0];
+
+                if (navigator.vibrate) {
+                    navigator.vibrate(200);
+                }
+
+                this.dispatch('detected', { detail: { format, rawValue } });
+                this.close();
+            }
+        } catch {
+            // Ignore les erreurs de détection (frame pas prête, etc.)
+        }
+    }
+
+    /**
+     * Boucle de détection avec throttle ~300ms.
+     */
+    startDetectionLoop() {
+        let lastDetection = 0;
+
+        const loop = async () => {
+            if (!this.scanning) {
+                return;
+            }
+
+            const now = performance.now();
+            if (now - lastDetection >= 300) {
+                lastDetection = now;
+                await this.detectBarcode();
+            }
+
+            if (this.scanning) {
+                requestAnimationFrame(loop);
+            }
+        };
+
+        requestAnimationFrame(loop);
+    }
+
+    /**
+     * Crée le modal plein écran avec le flux vidéo.
+     */
+    createModal() {
+        this.modal = document.createElement('div');
+        this.modal.className = 'scanner-modal';
+        this.modal.innerHTML = `
+            <video autoplay playsinline muted></video>
+            <div class="scanner-modal__overlay">
+                <div class="scanner-modal__scan-area">
+                    <div class="scanner-modal__scan-line"></div>
+                </div>
+            </div>
+            <button type="button" class="scanner-modal__close" aria-label="Fermer le scanner">&times;</button>
+        `;
+
+        this.modal.querySelector('.scanner-modal__close').addEventListener('click', () => this.close());
+
+        document.body.appendChild(this.modal);
+    }
+
+    /**
+     * Supprime le modal du DOM.
+     */
+    destroyModal() {
+        if (this.modal) {
+            this.modal.remove();
+            this.modal = null;
+        }
+    }
+
+    /**
+     * Arrête le stream caméra.
+     */
+    stopStream() {
+        if (this.stream) {
+            this.stream.getTracks().forEach(track => track.stop());
+            this.stream = null;
+        }
+    }
+
+    disconnect() {
+        this.close();
+    }
+}

--- a/assets/controllers/comic_form_controller.js
+++ b/assets/controllers/comic_form_controller.js
@@ -60,6 +60,72 @@ export default class extends Controller {
         if (this.hasIsOneShotTarget) {
             this.applyOneShotState(this.isOneShotTarget.checked);
         }
+
+        // Auto-lookup si scan_isbn est dans l'URL (saisie rapide)
+        this.handleScanIsbnParam();
+    }
+
+    /**
+     * Vérifie le paramètre URL scan_isbn et déclenche le lookup automatique.
+     */
+    handleScanIsbnParam() {
+        const params = new URLSearchParams(window.location.search);
+        const scanIsbn = params.get('scan_isbn');
+
+        if (!scanIsbn) {
+            return;
+        }
+
+        // Pré-remplit le champ ISBN
+        if (this.hasIsbnTarget) {
+            this.isbnTarget.value = scanIsbn;
+        }
+
+        // Déclenche le lookup
+        this.performIsbnLookup(scanIsbn, null);
+
+        // Nettoie le paramètre de l'URL
+        params.delete('scan_isbn');
+        const newUrl = params.toString()
+            ? `${window.location.pathname}?${params}`
+            : window.location.pathname;
+        window.history.replaceState({}, '', newUrl);
+    }
+
+    /**
+     * Gère un événement de scan barcode et remplit le champ ISBN correspondant.
+     */
+    handleBarcodeScan(event) {
+        const isbn = event.detail.rawValue;
+        const context = event.params?.context || 'isbn';
+
+        if (context === 'oneshot') {
+            // Remplit le champ ISBN one-shot
+            if (this.hasOneShotIsbnTarget) {
+                this.oneShotIsbnTarget.value = isbn;
+                this.syncIsbnToTome();
+            }
+            this.performIsbnLookup(isbn, null);
+        } else if (context.startsWith('tome-')) {
+            // Remplit le champ ISBN du tome correspondant
+            const tomeIndex = context.replace('tome-', '');
+            const tomeEntries = this.tomesListTarget.querySelectorAll('[data-tomes-collection-target="entry"]');
+            const entry = tomeEntries[parseInt(tomeIndex, 10)];
+
+            if (entry) {
+                const isbnInput = entry.querySelector('.tome-isbn-input');
+                if (isbnInput) {
+                    isbnInput.value = isbn;
+                }
+            }
+            this.performIsbnLookup(isbn, null, { fromTome: true });
+        } else {
+            // Champ ISBN principal
+            if (this.hasIsbnTarget) {
+                this.isbnTarget.value = isbn;
+            }
+            this.performIsbnLookup(isbn, null);
+        }
     }
 
     /**

--- a/assets/controllers/quick_scan_controller.js
+++ b/assets/controllers/quick_scan_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Contrôleur pour la saisie rapide via scan ISBN depuis la page d'accueil.
+ * Ouvre le scanner barcode, appelle l'API, et redirige vers le formulaire.
+ */
+export default class extends Controller {
+    /**
+     * Ouvre le scanner en dispatchant un événement.
+     */
+    scan() {
+        this.dispatch('open-scanner');
+    }
+
+    /**
+     * Gère la détection d'un code-barres : appelle l'API et redirige.
+     */
+    async handleDetected(event) {
+        const isbn = event.detail.rawValue;
+        const button = this.element.querySelector('.fab-scan');
+
+        if (button) {
+            button.classList.add('fab-scan--loading');
+        }
+
+        try {
+            await fetch(`/api/isbn-lookup?isbn=${encodeURIComponent(isbn)}`);
+        } catch {
+            // Ignore les erreurs réseau, on redirige quand même
+        } finally {
+            if (button) {
+                button.classList.remove('fab-scan--loading');
+            }
+        }
+
+        window.location.assign(`/comic/new?scan_isbn=${encodeURIComponent(isbn)}`);
+    }
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -2122,3 +2122,138 @@ body[data-connection-status="OFFLINE"] .offline-indicator {
         width: auto;
     }
 }
+
+/* FAB Stack (scan + add) */
+.fab-stack {
+    align-items: center;
+    bottom: calc(var(--bottom-nav-height) + var(--md-spacing-md) + env(safe-area-inset-bottom, 0px));
+    display: flex;
+    flex-direction: column;
+    gap: var(--md-spacing-md);
+    position: fixed;
+    right: var(--md-spacing-md);
+    z-index: 90;
+}
+
+.fab-stack .fab {
+    bottom: auto;
+    position: static;
+    right: auto;
+}
+
+.fab-scan {
+    background-color: var(--md-primary);
+}
+
+.fab-scan--loading {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.fab-scan--loading::after {
+    animation: spin 1s linear infinite;
+    border: 2px solid transparent;
+    border-radius: 50%;
+    border-top-color: var(--md-on-primary);
+    content: '';
+    height: 20px;
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 20px;
+}
+
+.fab-scan--loading svg {
+    visibility: hidden;
+}
+
+@keyframes spin {
+    to { transform: translate(-50%, -50%) rotate(360deg); }
+}
+
+/* Scanner Modal (plein écran) */
+.scanner-modal {
+    align-items: center;
+    background-color: #000;
+    display: flex;
+    height: 100%;
+    inset: 0;
+    justify-content: center;
+    position: fixed;
+    z-index: 1000;
+}
+
+.scanner-modal video {
+    height: 100%;
+    object-fit: cover;
+    width: 100%;
+}
+
+.scanner-modal__overlay {
+    align-items: center;
+    display: flex;
+    inset: 0;
+    justify-content: center;
+    pointer-events: none;
+    position: absolute;
+}
+
+.scanner-modal__scan-area {
+    border: 2px solid rgba(255, 255, 255, 0.6);
+    border-radius: var(--md-radius-md);
+    height: 200px;
+    overflow: hidden;
+    position: relative;
+    width: 280px;
+}
+
+.scanner-modal__scan-line {
+    animation: scanLine 2s ease-in-out infinite;
+    background: linear-gradient(to bottom, transparent, var(--md-primary), transparent);
+    height: 3px;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+}
+
+@keyframes scanLine {
+    0%, 100% { top: 0; }
+    50% { top: calc(100% - 3px); }
+}
+
+.scanner-modal__close {
+    align-items: center;
+    background-color: rgba(0, 0, 0, 0.5);
+    border: none;
+    border-radius: 50%;
+    color: #fff;
+    cursor: pointer;
+    display: flex;
+    font-size: 1.5rem;
+    height: 48px;
+    justify-content: center;
+    position: absolute;
+    right: var(--md-spacing-md);
+    top: calc(var(--md-spacing-md) + env(safe-area-inset-top, 0px));
+    width: 48px;
+    z-index: 1;
+}
+
+.scanner-modal__close:hover {
+    background-color: rgba(0, 0, 0, 0.7);
+}
+
+/* Bouton scan dans les formulaires */
+.btn-scan {
+    color: var(--md-primary);
+}
+
+/* Desktop */
+@media (min-width: 768px) {
+    .fab-stack {
+        bottom: var(--md-spacing-lg);
+        right: var(--md-spacing-lg);
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -51,12 +51,19 @@
             </main>
 
             {% if app.user and app.request.attributes.get('_route') not in ['app_comic_new', 'app_comic_edit'] %}
-            {# FAB - Add new comic (hidden on form pages) #}
-            <a href="{{ path('app_comic_new', app.request.attributes.get('_route') == 'app_wishlist' ? {wishlist: 1} : {}) }}" class="fab" aria-label="Ajouter une serie" data-turbo-frame="_top">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                    <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
-                </svg>
-            </a>
+            {# FABs - Scan + Add new comic (hidden on form pages) #}
+            <div class="fab-stack" data-controller="quick-scan barcode-scanner" data-action="barcode-scanner:detected->quick-scan#handleDetected">
+                <button type="button" class="fab fab-scan" data-action="barcode-scanner#open" aria-label="Scanner un code-barres">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path d="M2 4h2v16H2V4zm4 0h1v16H6V4zm3 0h2v16H9V4zm4 0h1v16h-1V4zm3 0h2v16h-2V4zm4 0h2v16h-2V4z"/>
+                    </svg>
+                </button>
+                <a href="{{ path('app_comic_new', app.request.attributes.get('_route') == 'app_wishlist' ? {wishlist: 1} : {}) }}" class="fab" aria-label="Ajouter une serie" data-turbo-frame="_top">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+                    </svg>
+                </a>
+            </div>
             {% endif %}
 
             {% if app.user %}

--- a/templates/comic/_form.html.twig
+++ b/templates/comic/_form.html.twig
@@ -1,4 +1,4 @@
-{{ form_start(form, {attr: {class: 'comic-form', 'data-controller': 'comic-form tomes-collection'}}) }}
+{{ form_start(form, {attr: {class: 'comic-form', 'data-controller': 'comic-form tomes-collection barcode-scanner', 'data-action': 'barcode-scanner:detected->comic-form#handleBarcodeScan'}}) }}
     {# Type en premier pour conditionner la recherche API #}
     <div class="form-row">
         <div class="mdc-text-field">
@@ -41,6 +41,9 @@
                 {{ form_widget(form.isbn, {attr: {'data-comic-form-target': 'oneShotIsbn', 'data-action': 'input->comic-form#syncIsbnToTome', placeholder: 'ISBN-10 ou ISBN-13'}}) }}
                 <button type="button" class="btn btn-secondary btn-icon" data-action="comic-form#lookupOneShotIsbn" data-comic-form-target="lookupOneShotIsbnButton" title="Rechercher via ISBN">
                     <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg>
+                </button>
+                <button type="button" class="btn btn-secondary btn-icon btn-scan" data-action="barcode-scanner#open" data-comic-form-context-param="oneshot" title="Scanner un code-barres">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><line x1="6" y1="8" x2="6" y2="16"/><line x1="9" y1="8" x2="9" y2="16"/><line x1="12" y1="8" x2="12" y2="16"/><line x1="15" y1="8" x2="15" y2="16"/><line x1="18" y1="8" x2="18" y2="16"/></svg>
                 </button>
             </div>
             {{ form_errors(form.isbn) }}
@@ -157,6 +160,9 @@
                             <button type="button" class="btn btn-icon btn-secondary tome-isbn-lookup" data-action="comic-form#lookupTomeIsbn" title="Rechercher via ISBN" style="display: none;">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg>
                             </button>
+                            <button type="button" class="btn btn-icon btn-secondary btn-scan" data-action="barcode-scanner#open" data-comic-form-context-param="tome-{{ loop.index0 }}" title="Scanner un code-barres">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><line x1="6" y1="8" x2="6" y2="16"/><line x1="9" y1="8" x2="9" y2="16"/><line x1="12" y1="8" x2="12" y2="16"/><line x1="15" y1="8" x2="15" y2="16"/><line x1="18" y1="8" x2="18" y2="16"/></svg>
+                            </button>
                         </div>
                         <div class="tome-checkboxes">
                             <label class="tome-checkbox">
@@ -193,6 +199,9 @@
                         <input type="text" name="{{ form.tomes.vars.full_name }}[__name__][isbn]" placeholder="ISBN" class="tome-isbn-input">
                         <button type="button" class="btn btn-icon btn-secondary tome-isbn-lookup" data-action="comic-form#lookupTomeIsbn" title="Rechercher via ISBN" style="display: none;">
                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg>
+                        </button>
+                        <button type="button" class="btn btn-icon btn-secondary btn-scan" data-action="barcode-scanner#open" data-comic-form-context-param="tome-__name__" title="Scanner un code-barres">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><line x1="6" y1="8" x2="6" y2="16"/><line x1="9" y1="8" x2="9" y2="16"/><line x1="12" y1="8" x2="12" y2="16"/><line x1="15" y1="8" x2="15" y2="16"/><line x1="18" y1="8" x2="18" y2="16"/></svg>
                         </button>
                     </div>
                     <div class="tome-checkboxes">

--- a/tests/js/controllers/barcode_scanner_controller.test.js
+++ b/tests/js/controllers/barcode_scanner_controller.test.js
@@ -1,0 +1,241 @@
+import BarcodeScannerController from '../../../assets/controllers/barcode_scanner_controller.js';
+import { startStimulusController, stopStimulusController } from '../helpers/stimulus-helper.js';
+
+function buildHtml() {
+    return `
+        <div data-controller="barcode-scanner">
+            <button data-action="barcode-scanner#open">Scanner</button>
+        </div>
+    `;
+}
+
+describe('barcode_scanner_controller', () => {
+    let application;
+    let mockStream;
+    let mockDetector;
+
+    beforeEach(() => {
+        // Mock MediaStream avec track.stop()
+        const mockTrack = { stop: vi.fn() };
+        mockStream = {
+            getTracks: vi.fn(() => [mockTrack]),
+        };
+
+        // Mock getUserMedia
+        global.navigator.mediaDevices = {
+            getUserMedia: vi.fn().mockResolvedValue(mockStream),
+        };
+
+        // Mock BarcodeDetector (doit utiliser function, pas arrow, pour new)
+        mockDetector = {
+            detect: vi.fn().mockResolvedValue([]),
+        };
+        global.BarcodeDetector = vi.fn(function () {
+            return mockDetector;
+        });
+        global.BarcodeDetector.getSupportedFormats = vi.fn().mockResolvedValue(['ean_13']);
+
+        // Mock navigator.vibrate
+        global.navigator.vibrate = vi.fn();
+    });
+
+    afterEach(() => {
+        if (application) stopStimulusController(application);
+        delete global.BarcodeDetector;
+    });
+
+    function getController() {
+        return application.getControllerForElementAndIdentifier(
+            document.querySelector('[data-controller="barcode-scanner"]'), 'barcode-scanner'
+        );
+    }
+
+    async function setup() {
+        ({ application } = await startStimulusController(
+            BarcodeScannerController, 'barcode-scanner', buildHtml()
+        ));
+        return getController();
+    }
+
+    describe('open', () => {
+        it('crée le modal plein écran', async () => {
+            const controller = await setup();
+            await controller.open();
+
+            const modal = document.querySelector('.scanner-modal');
+            expect(modal).not.toBeNull();
+            expect(modal.querySelector('video')).not.toBeNull();
+            expect(modal.querySelector('.scanner-modal__close')).not.toBeNull();
+        });
+
+        it('demande accès à la caméra arrière', async () => {
+            const controller = await setup();
+            await controller.open();
+
+            expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
+                video: { facingMode: 'environment' },
+            });
+        });
+
+        it('attache le stream au video element', async () => {
+            const controller = await setup();
+            await controller.open();
+
+            const video = document.querySelector('.scanner-modal video');
+            expect(video.srcObject).toBe(mockStream);
+        });
+
+        it('crée un BarcodeDetector avec le format ean_13', async () => {
+            const controller = await setup();
+            await controller.open();
+
+            expect(global.BarcodeDetector).toHaveBeenCalledWith({ formats: ['ean_13'] });
+        });
+    });
+
+    describe('détection', () => {
+        it('émet barcode-scanner:detected quand un code-barres est détecté', async () => {
+            const controller = await setup();
+            const detectedPromise = new Promise((resolve) => {
+                controller.element.addEventListener('barcode-scanner:detected', (e) => {
+                    resolve(e.detail);
+                });
+            });
+
+            // Ouvre le scanner
+            await controller.open();
+
+            // Simule une détection au prochain appel
+            mockDetector.detect.mockResolvedValueOnce([
+                { rawValue: '9782723456789', format: 'ean_13' },
+            ]);
+
+            // Déclenche manuellement un cycle de détection
+            await controller.detectBarcode();
+
+            const detail = await detectedPromise;
+            expect(detail.rawValue).toBe('9782723456789');
+            expect(detail.format).toBe('ean_13');
+        });
+
+        it('vibre lors de la détection', async () => {
+            const controller = await setup();
+            await controller.open();
+
+            mockDetector.detect.mockResolvedValueOnce([
+                { rawValue: '9782723456789', format: 'ean_13' },
+            ]);
+
+            await controller.detectBarcode();
+
+            expect(navigator.vibrate).toHaveBeenCalledWith(200);
+        });
+
+        it('ferme le modal après détection', async () => {
+            const controller = await setup();
+            await controller.open();
+
+            mockDetector.detect.mockResolvedValueOnce([
+                { rawValue: '9782723456789', format: 'ean_13' },
+            ]);
+
+            await controller.detectBarcode();
+
+            const modal = document.querySelector('.scanner-modal');
+            expect(modal).toBeNull();
+        });
+
+        it('ne fait rien si aucun code-barres détecté', async () => {
+            const controller = await setup();
+            const detectedSpy = vi.fn();
+            controller.element.addEventListener('barcode-scanner:detected', detectedSpy);
+
+            await controller.open();
+            mockDetector.detect.mockResolvedValueOnce([]);
+
+            await controller.detectBarcode();
+
+            expect(detectedSpy).not.toHaveBeenCalled();
+            // Le modal est toujours ouvert
+            expect(document.querySelector('.scanner-modal')).not.toBeNull();
+        });
+    });
+
+    describe('close', () => {
+        it('arrête le stream caméra', async () => {
+            const controller = await setup();
+            await controller.open();
+
+            controller.close();
+
+            const track = mockStream.getTracks()[0];
+            expect(track.stop).toHaveBeenCalled();
+        });
+
+        it('supprime le modal du DOM', async () => {
+            const controller = await setup();
+            await controller.open();
+            expect(document.querySelector('.scanner-modal')).not.toBeNull();
+
+            controller.close();
+            expect(document.querySelector('.scanner-modal')).toBeNull();
+        });
+    });
+
+    describe('BarcodeDetector non supporté', () => {
+        it('émet un événement unsupported si BarcodeDetector est absent', async () => {
+            delete global.BarcodeDetector;
+
+            const controller = await setup();
+            const unsupportedPromise = new Promise((resolve) => {
+                controller.element.addEventListener('barcode-scanner:unsupported', () => {
+                    resolve(true);
+                });
+            });
+
+            await controller.open();
+
+            expect(await unsupportedPromise).toBe(true);
+        });
+
+        it('ne crée pas de modal si BarcodeDetector est absent', async () => {
+            delete global.BarcodeDetector;
+
+            const controller = await setup();
+            await controller.open();
+
+            expect(document.querySelector('.scanner-modal')).toBeNull();
+        });
+    });
+
+    describe('erreur caméra', () => {
+        it('émet un événement error si la caméra est refusée', async () => {
+            navigator.mediaDevices.getUserMedia.mockRejectedValueOnce(
+                new DOMException('Permission denied', 'NotAllowedError')
+            );
+
+            const controller = await setup();
+            const errorPromise = new Promise((resolve) => {
+                controller.element.addEventListener('barcode-scanner:error', (e) => {
+                    resolve(e.detail);
+                });
+            });
+
+            await controller.open();
+
+            const detail = await errorPromise;
+            expect(detail.message).toContain('Permission');
+        });
+
+        it('nettoie le modal en cas d\'erreur caméra', async () => {
+            navigator.mediaDevices.getUserMedia.mockRejectedValueOnce(
+                new DOMException('Permission denied', 'NotAllowedError')
+            );
+
+            const controller = await setup();
+            await controller.open();
+
+            expect(document.querySelector('.scanner-modal')).toBeNull();
+        });
+    });
+});

--- a/tests/js/controllers/comic_form_controller.test.js
+++ b/tests/js/controllers/comic_form_controller.test.js
@@ -564,4 +564,116 @@ describe('comic_form_controller', () => {
             expect(controller.getSelectedType()).toBeNull();
         });
     });
+
+    describe('handleBarcodeScan', () => {
+        it('remplit le champ ISBN one-shot et déclenche le lookup', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    sources: ['google_books'],
+                    title: 'Naruto',
+                }),
+                ok: true,
+            });
+
+            const controller = await setup({ isOneShot: true, existingTome: true });
+
+            // Simule un événement de scan avec contexte one-shot
+            const event = new CustomEvent('barcode-scanner:detected', {
+                detail: { rawValue: '9782723456789', format: 'ean_13' },
+            });
+            event.params = { context: 'oneshot' };
+            controller.handleBarcodeScan(event);
+
+            const oneShotIsbn = document.querySelector('[data-comic-form-target="oneShotIsbn"]');
+            expect(oneShotIsbn.value).toBe('9782723456789');
+
+            // Vérifie que le lookup a été appelé
+            await vi.waitFor(() => {
+                expect(global.fetch).toHaveBeenCalledWith(
+                    expect.stringContaining('isbn=9782723456789')
+                );
+            });
+        });
+
+        it('remplit le champ ISBN d\'un tome et déclenche le lookup', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    publisher: 'Kana',
+                    sources: ['google_books'],
+                }),
+                ok: true,
+            });
+
+            const controller = await setup({ existingTome: true });
+
+            const event = new CustomEvent('barcode-scanner:detected', {
+                detail: { rawValue: '9782723456789', format: 'ean_13' },
+            });
+            event.params = { context: 'tome-0' };
+            controller.handleBarcodeScan(event);
+
+            const tomeIsbn = document.querySelector('.tome-isbn-input');
+            expect(tomeIsbn.value).toBe('9782723456789');
+
+            await vi.waitFor(() => {
+                expect(global.fetch).toHaveBeenCalledWith(
+                    expect.stringContaining('isbn=9782723456789')
+                );
+            });
+        });
+    });
+
+    describe('scan_isbn URL param', () => {
+        it('déclenche le lookup automatique si scan_isbn est dans l\'URL', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    sources: ['google_books'],
+                    title: 'One Piece',
+                }),
+                ok: true,
+            });
+
+            // Simule le paramètre URL
+            const url = new URL(window.location.href);
+            url.searchParams.set('scan_isbn', '9782723456789');
+            window.history.replaceState({}, '', url.toString());
+
+            await setup();
+
+            // Vérifie que le lookup a été déclenché
+            await vi.waitFor(() => {
+                expect(global.fetch).toHaveBeenCalledWith(
+                    expect.stringContaining('isbn=9782723456789')
+                );
+            });
+
+            // Nettoie l'URL
+            window.history.replaceState({}, '', window.location.pathname);
+        });
+
+        it('remplit le champ ISBN avant le lookup', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    sources: [],
+                }),
+                ok: true,
+            });
+
+            const url = new URL(window.location.href);
+            url.searchParams.set('scan_isbn', '9782723456789');
+            window.history.replaceState({}, '', url.toString());
+
+            await setup();
+
+            const isbnInput = document.querySelector('[data-comic-form-target="isbn"]');
+            expect(isbnInput.value).toBe('9782723456789');
+
+            // Nettoie l'URL
+            window.history.replaceState({}, '', window.location.pathname);
+        });
+    });
 });

--- a/tests/js/controllers/quick_scan_controller.test.js
+++ b/tests/js/controllers/quick_scan_controller.test.js
@@ -1,0 +1,145 @@
+import QuickScanController from '../../../assets/controllers/quick_scan_controller.js';
+import { startStimulusController, stopStimulusController } from '../helpers/stimulus-helper.js';
+
+function buildHtml() {
+    return `
+        <div data-controller="quick-scan barcode-scanner">
+            <button data-action="quick-scan#scan" class="fab fab-scan">Scanner</button>
+        </div>
+    `;
+}
+
+describe('quick_scan_controller', () => {
+    let application;
+
+    afterEach(() => {
+        if (application) stopStimulusController(application);
+    });
+
+    function getController() {
+        return application.getControllerForElementAndIdentifier(
+            document.querySelector('[data-controller*="quick-scan"]'), 'quick-scan'
+        );
+    }
+
+    async function setup() {
+        ({ application } = await startStimulusController(
+            QuickScanController, 'quick-scan', buildHtml()
+        ));
+        return getController();
+    }
+
+    describe('scan', () => {
+        it('dispatche un événement pour ouvrir le scanner', async () => {
+            const controller = await setup();
+            const openSpy = vi.fn();
+            controller.element.addEventListener('quick-scan:open-scanner', openSpy);
+
+            controller.scan();
+
+            expect(openSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('handleDetected', () => {
+        it('appelle l\'API isbn-lookup avec l\'ISBN scanné', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({ title: 'Naruto' }),
+                ok: true,
+            });
+
+            const controller = await setup();
+            const event = new CustomEvent('barcode-scanner:detected', {
+                detail: { rawValue: '9782723456789', format: 'ean_13' },
+            });
+
+            await controller.handleDetected(event);
+
+            expect(global.fetch).toHaveBeenCalledWith(
+                '/api/isbn-lookup?isbn=9782723456789'
+            );
+        });
+
+        it('redirige vers le formulaire avec scan_isbn si trouvé', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({ title: 'Naruto' }),
+                ok: true,
+            });
+
+            // Mock window.location
+            const assignMock = vi.fn();
+            Object.defineProperty(window, 'location', {
+                configurable: true,
+                value: { ...window.location, assign: assignMock },
+                writable: true,
+            });
+
+            const controller = await setup();
+            const event = new CustomEvent('barcode-scanner:detected', {
+                detail: { rawValue: '9782723456789', format: 'ean_13' },
+            });
+
+            await controller.handleDetected(event);
+
+            expect(assignMock).toHaveBeenCalledWith(
+                '/comic/new?scan_isbn=9782723456789'
+            );
+        });
+
+        it('redirige aussi si l\'ISBN n\'est pas trouvé', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({ error: 'Not found' }),
+                ok: false,
+            });
+
+            const assignMock = vi.fn();
+            Object.defineProperty(window, 'location', {
+                configurable: true,
+                value: { ...window.location, assign: assignMock },
+                writable: true,
+            });
+
+            const controller = await setup();
+            const event = new CustomEvent('barcode-scanner:detected', {
+                detail: { rawValue: '9782723456789', format: 'ean_13' },
+            });
+
+            await controller.handleDetected(event);
+
+            expect(assignMock).toHaveBeenCalledWith(
+                '/comic/new?scan_isbn=9782723456789'
+            );
+        });
+
+        it('ajoute la classe loading au bouton pendant l\'appel API', async () => {
+            let resolvePromise;
+            global.fetch = vi.fn().mockReturnValue(
+                new Promise((resolve) => { resolvePromise = resolve; })
+            );
+
+            const controller = await setup();
+            const button = document.querySelector('.fab-scan');
+            const event = new CustomEvent('barcode-scanner:detected', {
+                detail: { rawValue: '9782723456789', format: 'ean_13' },
+            });
+
+            // Mock location pour éviter l'erreur
+            Object.defineProperty(window, 'location', {
+                configurable: true,
+                value: { ...window.location, assign: vi.fn() },
+                writable: true,
+            });
+
+            const handlePromise = controller.handleDetected(event);
+            expect(button.classList.contains('fab-scan--loading')).toBe(true);
+
+            resolvePromise({
+                json: () => Promise.resolve({}),
+                ok: true,
+            });
+
+            await handlePromise;
+            expect(button.classList.contains('fab-scan--loading')).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Scan de code-barres ISBN via la caméra (API native `BarcodeDetector`, Chrome Android)
- **Formulaires** : boutons scan à côté des champs ISBN (one-shot et tomes) → remplissage automatique + lookup API
- **Saisie rapide** : FAB scan sur la page d'accueil → lookup API → redirection formulaire pré-rempli
- Modal plein écran avec animation de balayage et retour haptique (vibration)

## Nouveaux fichiers
- `assets/controllers/barcode_scanner_controller.js` — caméra + BarcodeDetector + modal
- `assets/controllers/quick_scan_controller.js` — FAB scan → API → redirect
- `tests/js/controllers/barcode_scanner_controller.test.js` — 14 tests
- `tests/js/controllers/quick_scan_controller.test.js` — 5 tests

## Fichiers modifiés
- `comic_form_controller.js` — `handleBarcodeScan()`, `handleScanIsbnParam()`
- `_form.html.twig` — boutons scan ISBN
- `base.html.twig` — FAB stack (scan + add)
- `app.css` — styles scanner modal, FAB stack

## Test plan
- [x] Tests Vitest : 165 tests passent (dont 19 nouveaux)
- [x] Tests PHP : 356 tests passent
- [ ] Test manuel mobile : ouvrir la PWA → tester scan formulaire + scan rapide
- [ ] Vérifier que le scanner fonctionne hors ligne (caméra locale)

closes #1