### PR TITLE
feat(scan): type picker avant scan rapide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Type picker avant scan rapide** : Sélection du type (BD, Comics, Manga, Livre) via bottom sheet avant d'ouvrir le scanner depuis la page d'accueil, permettant un lookup ISBN ciblé par type
+
 - **Scan ISBN via caméra** : Scanner de code-barres ISBN via l'API native BarcodeDetector (Chrome Android)
   - Scan depuis les formulaires (champ ISBN one-shot et tomes)
   - Saisie rapide : bouton scan sur la page d'accueil → pré-remplissage automatique du formulaire

--- a/assets/controllers/comic_form_controller.js
+++ b/assets/controllers/comic_form_controller.js
@@ -76,6 +76,12 @@ export default class extends Controller {
             return;
         }
 
+        // Pré-sélectionne le type si fourni (avant le lookup qui utilise getSelectedType())
+        const scanType = params.get('type');
+        if (scanType && this.hasTypeTarget) {
+            this.fillSelect('type', scanType);
+        }
+
         // Pré-remplit le champ ISBN
         if (this.hasIsbnTarget) {
             this.isbnTarget.value = scanIsbn;
@@ -84,8 +90,9 @@ export default class extends Controller {
         // Déclenche le lookup
         this.performIsbnLookup(scanIsbn, null);
 
-        // Nettoie le paramètre de l'URL
+        // Nettoie les paramètres de l'URL
         params.delete('scan_isbn');
+        params.delete('type');
         const newUrl = params.toString()
             ? `${window.location.pathname}?${params}`
             : window.location.pathname;

--- a/assets/controllers/quick_scan_controller.js
+++ b/assets/controllers/quick_scan_controller.js
@@ -2,21 +2,34 @@ import { Controller } from '@hotwired/stimulus';
 
 /**
  * Contrôleur pour la saisie rapide via scan ISBN depuis la page d'accueil.
- * Ouvre le scanner barcode, appelle l'API, et redirige vers le formulaire.
+ * Affiche un type picker, ouvre le scanner, appelle l'API, et redirige vers le formulaire.
  */
 export default class extends Controller {
+    static types = [
+        { label: 'BD', value: 'bd' },
+        { label: 'Comics', value: 'comics' },
+        { label: 'Manga', value: 'manga' },
+        { label: 'Livre', value: 'livre' },
+    ];
+
     /**
-     * Ouvre le scanner en dispatchant un événement.
+     * Affiche le type picker avant d'ouvrir le scanner.
      */
     scan() {
-        this.dispatch('open-scanner');
+        // Empêche les doublons
+        if (document.querySelector('.type-picker')) {
+            return;
+        }
+
+        this.createTypePicker();
     }
 
     /**
-     * Gère la détection d'un code-barres : appelle l'API et redirige.
+     * Gère la détection d'un code-barres : appelle l'API avec le type et redirige.
      */
     async handleDetected(event) {
         const isbn = event.detail.rawValue;
+        const type = this.selectedType;
         const button = this.element.querySelector('.fab-scan');
 
         if (button) {
@@ -24,7 +37,8 @@ export default class extends Controller {
         }
 
         try {
-            await fetch(`/api/isbn-lookup?isbn=${encodeURIComponent(isbn)}`);
+            const apiUrl = `/api/isbn-lookup?isbn=${encodeURIComponent(isbn)}${type ? `&type=${type}` : ''}`;
+            await fetch(apiUrl);
         } catch {
             // Ignore les erreurs réseau, on redirige quand même
         } finally {
@@ -33,6 +47,72 @@ export default class extends Controller {
             }
         }
 
-        window.location.assign(`/comic/new?scan_isbn=${encodeURIComponent(isbn)}`);
+        const redirectUrl = `/comic/new?scan_isbn=${encodeURIComponent(isbn)}${type ? `&type=${type}` : ''}`;
+        window.location.assign(redirectUrl);
+    }
+
+    /**
+     * Crée le type picker (bottom sheet) dans le DOM.
+     */
+    createTypePicker() {
+        const overlay = document.createElement('div');
+        overlay.className = 'type-picker';
+
+        const sheet = document.createElement('div');
+        sheet.className = 'type-picker__sheet';
+
+        // Empêche les clics sur le sheet de fermer l'overlay
+        sheet.addEventListener('click', (e) => e.stopPropagation());
+
+        const title = document.createElement('h3');
+        title.className = 'type-picker__title';
+        title.textContent = 'Type de série';
+
+        const options = document.createElement('div');
+        options.className = 'type-picker__options';
+
+        this.constructor.types.forEach(({ label, value }) => {
+            const button = document.createElement('button');
+            button.className = `type-picker__option type-picker__option--${value}`;
+            button.type = 'button';
+            button.textContent = label;
+            button.addEventListener('click', () => this.selectType(value));
+            options.appendChild(button);
+        });
+
+        const closeButton = document.createElement('button');
+        closeButton.className = 'type-picker__close';
+        closeButton.type = 'button';
+        closeButton.textContent = 'Annuler';
+        closeButton.addEventListener('click', () => this.closePicker());
+
+        sheet.appendChild(title);
+        sheet.appendChild(options);
+        sheet.appendChild(closeButton);
+        overlay.appendChild(sheet);
+
+        // Ferme le picker en cliquant sur l'overlay
+        overlay.addEventListener('click', () => this.closePicker());
+
+        document.body.appendChild(overlay);
+    }
+
+    /**
+     * Sélectionne un type, ferme le picker et ouvre le scanner.
+     */
+    selectType(value) {
+        this.selectedType = value;
+        this.closePicker();
+        this.dispatch('open-scanner');
+    }
+
+    /**
+     * Ferme le type picker.
+     */
+    closePicker() {
+        const picker = document.querySelector('.type-picker');
+        if (picker) {
+            picker.remove();
+        }
     }
 }

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -2250,6 +2250,120 @@ body[data-connection-status="OFFLINE"] .offline-indicator {
     color: var(--md-primary);
 }
 
+/* Type Picker (bottom sheet) */
+.type-picker {
+    align-items: flex-end;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    inset: 0;
+    justify-content: center;
+    position: fixed;
+    z-index: 1000;
+}
+
+.type-picker__sheet {
+    animation: typePickerSlideUp 0.3s ease-out;
+    background-color: var(--md-surface);
+    border-radius: var(--md-radius-lg) var(--md-radius-lg) 0 0;
+    max-width: 400px;
+    padding: var(--md-spacing-lg);
+    padding-bottom: calc(var(--md-spacing-lg) + env(safe-area-inset-bottom, 0px));
+    width: 100%;
+}
+
+.type-picker__title {
+    color: var(--md-text-high);
+    font-size: 1.25rem;
+    font-weight: 500;
+    margin-bottom: var(--md-spacing-lg);
+    text-align: center;
+}
+
+.type-picker__options {
+    display: grid;
+    gap: var(--md-spacing-md);
+    grid-template-columns: 1fr 1fr;
+    margin-bottom: var(--md-spacing-lg);
+}
+
+.type-picker__option {
+    border: 2px solid transparent;
+    border-radius: var(--md-radius-md);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 1rem;
+    font-weight: 500;
+    min-height: 56px;
+    transition: all 0.2s;
+}
+
+.type-picker__option:active {
+    transform: scale(0.95);
+}
+
+.type-picker__option--bd {
+    background-color: #fff3e0;
+    color: #e65100;
+}
+
+.type-picker__option--bd:hover {
+    border-color: #e65100;
+}
+
+.type-picker__option--comics {
+    background-color: #e3f2fd;
+    color: #1565c0;
+}
+
+.type-picker__option--comics:hover {
+    border-color: #1565c0;
+}
+
+.type-picker__option--manga {
+    background-color: #fce4ec;
+    color: #c2185b;
+}
+
+.type-picker__option--manga:hover {
+    border-color: #c2185b;
+}
+
+.type-picker__option--livre {
+    background-color: #e8f5e9;
+    color: #2e7d32;
+}
+
+.type-picker__option--livre:hover {
+    border-color: #2e7d32;
+}
+
+.type-picker__close {
+    background: none;
+    border: 1px solid var(--md-divider);
+    border-radius: var(--md-radius-full);
+    color: var(--md-text-medium);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    height: 40px;
+    transition: all 0.2s;
+    width: 100%;
+}
+
+.type-picker__close:hover {
+    background-color: var(--md-background);
+}
+
+@keyframes typePickerSlideUp {
+    from {
+        transform: translateY(100%);
+    }
+    to {
+        transform: translateY(0);
+    }
+}
+
 /* Desktop */
 @media (min-width: 768px) {
     .fab-stack {

--- a/tests/js/controllers/barcode-scan-integration.test.js
+++ b/tests/js/controllers/barcode-scan-integration.test.js
@@ -246,8 +246,8 @@ describe('Intégration : scan code-barres → formulaire', () => {
         });
     });
 
-    describe('Saisie rapide : FAB scan → API → redirection', () => {
-        it('scanne un ISBN depuis le FAB, appelle l\'API et redirige vers le formulaire', async () => {
+    describe('Saisie rapide : FAB scan → type picker → API → redirection', () => {
+        it('affiche le type picker, scanne un ISBN, appelle l\'API avec le type et redirige', async () => {
             global.fetch = vi.fn().mockResolvedValue({
                 json: () => Promise.resolve({ title: 'Naruto' }),
                 ok: true,
@@ -266,37 +266,48 @@ describe('Intégration : scan code-barres → formulaire', () => {
             ));
 
             const container = document.querySelector('[data-controller*="quick-scan"]');
+            const quickScanController = application.getControllerForElementAndIdentifier(container, 'quick-scan');
             const scannerController = application.getControllerForElementAndIdentifier(container, 'barcode-scanner');
 
-            // 1. Ouvre le scanner
+            // 1. Clique sur le FAB → affiche le type picker
+            quickScanController.scan();
+            expect(document.querySelector('.type-picker')).not.toBeNull();
+
+            // 2. Sélectionne "Manga" → ferme le picker, ouvre le scanner
+            const mangaButton = Array.from(document.querySelectorAll('.type-picker__option'))
+                .find(btn => btn.textContent.trim() === 'Manga');
+            mangaButton.click();
+            expect(document.querySelector('.type-picker')).toBeNull();
+
+            // 3. Ouvre le scanner (déclenché par l'événement open-scanner)
             await scannerController.open();
             expect(document.querySelector('.scanner-modal')).not.toBeNull();
 
-            // 2. Simule la détection
+            // 4. Simule la détection
             mockDetector.detect.mockResolvedValueOnce([
                 { rawValue: '9782505044123', format: 'ean_13' },
             ]);
             await scannerController.detectBarcode();
 
-            // 3. Le modal est fermé
+            // 5. Le modal est fermé
             expect(document.querySelector('.scanner-modal')).toBeNull();
 
-            // 4. L'API est appelée avec l'ISBN
+            // 6. L'API est appelée avec l'ISBN ET le type
             await vi.waitFor(() => {
                 expect(global.fetch).toHaveBeenCalledWith(
-                    '/api/isbn-lookup?isbn=9782505044123'
+                    '/api/isbn-lookup?isbn=9782505044123&type=manga'
                 );
             });
 
-            // 5. Redirection vers le formulaire avec scan_isbn
+            // 7. Redirection vers le formulaire avec scan_isbn ET type
             await vi.waitFor(() => {
                 expect(assignMock).toHaveBeenCalledWith(
-                    '/comic/new?scan_isbn=9782505044123'
+                    '/comic/new?scan_isbn=9782505044123&type=manga'
                 );
             });
         });
 
-        it('redirige même si l\'API retourne une erreur réseau', async () => {
+        it('redirige avec le type même si l\'API retourne une erreur réseau', async () => {
             global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
 
             const assignMock = vi.fn();
@@ -312,7 +323,14 @@ describe('Intégration : scan code-barres → formulaire', () => {
             ));
 
             const container = document.querySelector('[data-controller*="quick-scan"]');
+            const quickScanController = application.getControllerForElementAndIdentifier(container, 'quick-scan');
             const scannerController = application.getControllerForElementAndIdentifier(container, 'barcode-scanner');
+
+            // Sélectionne un type BD
+            quickScanController.scan();
+            const bdButton = Array.from(document.querySelectorAll('.type-picker__option'))
+                .find(btn => btn.textContent.trim() === 'BD');
+            bdButton.click();
 
             await scannerController.open();
             mockDetector.detect.mockResolvedValueOnce([
@@ -320,10 +338,10 @@ describe('Intégration : scan code-barres → formulaire', () => {
             ]);
             await scannerController.detectBarcode();
 
-            // Même en erreur réseau, la redirection a lieu
+            // Même en erreur réseau, la redirection a lieu avec le type
             await vi.waitFor(() => {
                 expect(assignMock).toHaveBeenCalledWith(
-                    '/comic/new?scan_isbn=9782505044123'
+                    '/comic/new?scan_isbn=9782505044123&type=bd'
                 );
             });
         });

--- a/tests/js/controllers/comic_form_controller.test.js
+++ b/tests/js/controllers/comic_form_controller.test.js
@@ -654,6 +654,79 @@ describe('comic_form_controller', () => {
             window.history.replaceState({}, '', window.location.pathname);
         });
 
+        it('pré-sélectionne le type si présent dans l\'URL', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    sources: ['google_books'],
+                    title: 'Naruto',
+                }),
+                ok: true,
+            });
+
+            const url = new URL(window.location.href);
+            url.searchParams.set('scan_isbn', '9782723456789');
+            url.searchParams.set('type', 'manga');
+            window.history.replaceState({}, '', url.toString());
+
+            await setup();
+
+            const typeSelect = document.querySelector('[data-comic-form-target="type"]');
+            expect(typeSelect.value).toBe('manga');
+
+            // Nettoie l'URL
+            window.history.replaceState({}, '', window.location.pathname);
+        });
+
+        it('inclut le type dans l\'appel API du lookup automatique', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    sources: ['google_books'],
+                    title: 'Naruto',
+                }),
+                ok: true,
+            });
+
+            const url = new URL(window.location.href);
+            url.searchParams.set('scan_isbn', '9782723456789');
+            url.searchParams.set('type', 'manga');
+            window.history.replaceState({}, '', url.toString());
+
+            await setup();
+
+            await vi.waitFor(() => {
+                expect(global.fetch).toHaveBeenCalledWith(
+                    expect.stringContaining('type=manga')
+                );
+            });
+
+            // Nettoie l'URL
+            window.history.replaceState({}, '', window.location.pathname);
+        });
+
+        it('nettoie aussi le paramètre type de l\'URL', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    sources: [],
+                }),
+                ok: true,
+            });
+
+            const url = new URL(window.location.href);
+            url.searchParams.set('scan_isbn', '9782723456789');
+            url.searchParams.set('type', 'manga');
+            window.history.replaceState({}, '', url.toString());
+
+            await setup();
+
+            expect(window.location.search).toBe('');
+
+            // Nettoie l'URL
+            window.history.replaceState({}, '', window.location.pathname);
+        });
+
         it('remplit le champ ISBN avant le lookup', async () => {
             global.fetch = vi.fn().mockResolvedValue({
                 json: () => Promise.resolve({

--- a/tests/js/controllers/quick_scan_controller.test.js
+++ b/tests/js/controllers/quick_scan_controller.test.js
@@ -14,6 +14,8 @@ describe('quick_scan_controller', () => {
 
     afterEach(() => {
         if (application) stopStimulusController(application);
+        // Nettoie le type picker s'il reste dans le DOM
+        document.querySelector('.type-picker')?.remove();
     });
 
     function getController() {
@@ -30,43 +32,113 @@ describe('quick_scan_controller', () => {
     }
 
     describe('scan', () => {
-        it('dispatche un événement pour ouvrir le scanner', async () => {
+        it('affiche le type picker au lieu d\'ouvrir le scanner', async () => {
+            const controller = await setup();
+
+            controller.scan();
+
+            expect(document.querySelector('.type-picker')).not.toBeNull();
+            expect(document.querySelector('.type-picker__title').textContent).toBe('Type de série');
+        });
+
+        it('affiche les 4 types : BD, Comics, Manga, Livre', async () => {
+            const controller = await setup();
+
+            controller.scan();
+
+            const options = document.querySelectorAll('.type-picker__option');
+            expect(options).toHaveLength(4);
+
+            const labels = Array.from(options).map(o => o.textContent.trim());
+            expect(labels).toEqual(['BD', 'Comics', 'Manga', 'Livre']);
+        });
+
+        it('ne crée pas de doublon si le picker est déjà ouvert', async () => {
+            const controller = await setup();
+
+            controller.scan();
+            controller.scan();
+
+            const pickers = document.querySelectorAll('.type-picker');
+            expect(pickers).toHaveLength(1);
+        });
+    });
+
+    describe('sélection de type', () => {
+        it('stocke le type sélectionné et ouvre le scanner', async () => {
             const controller = await setup();
             const openSpy = vi.fn();
             controller.element.addEventListener('quick-scan:open-scanner', openSpy);
 
             controller.scan();
 
+            // Clique sur "Manga"
+            const mangaButton = Array.from(document.querySelectorAll('.type-picker__option'))
+                .find(btn => btn.textContent.trim() === 'Manga');
+            mangaButton.click();
+
+            expect(openSpy).toHaveBeenCalled();
+            expect(document.querySelector('.type-picker')).toBeNull();
+        });
+
+        it('stocke le type bd quand on clique sur BD', async () => {
+            const controller = await setup();
+            const openSpy = vi.fn();
+            controller.element.addEventListener('quick-scan:open-scanner', openSpy);
+
+            controller.scan();
+
+            const bdButton = Array.from(document.querySelectorAll('.type-picker__option'))
+                .find(btn => btn.textContent.trim() === 'BD');
+            bdButton.click();
+
             expect(openSpy).toHaveBeenCalled();
         });
     });
 
-    describe('handleDetected', () => {
-        it('appelle l\'API isbn-lookup avec l\'ISBN scanné', async () => {
-            global.fetch = vi.fn().mockResolvedValue({
-                json: () => Promise.resolve({ title: 'Naruto' }),
-                ok: true,
-            });
-
+    describe('fermeture du picker', () => {
+        it('ferme le picker en cliquant sur le bouton fermer', async () => {
             const controller = await setup();
-            const event = new CustomEvent('barcode-scanner:detected', {
-                detail: { rawValue: '9782723456789', format: 'ean_13' },
-            });
 
-            await controller.handleDetected(event);
+            controller.scan();
+            expect(document.querySelector('.type-picker')).not.toBeNull();
 
-            expect(global.fetch).toHaveBeenCalledWith(
-                '/api/isbn-lookup?isbn=9782723456789'
-            );
+            document.querySelector('.type-picker__close').click();
+            expect(document.querySelector('.type-picker')).toBeNull();
         });
 
-        it('redirige vers le formulaire avec scan_isbn si trouvé', async () => {
+        it('ferme le picker en cliquant sur l\'overlay', async () => {
+            const controller = await setup();
+
+            controller.scan();
+            expect(document.querySelector('.type-picker')).not.toBeNull();
+
+            // Clique sur l'overlay (l'élément racine .type-picker)
+            document.querySelector('.type-picker').click();
+            expect(document.querySelector('.type-picker')).toBeNull();
+        });
+
+        it('ne ferme pas le picker en cliquant sur le sheet', async () => {
+            const controller = await setup();
+
+            controller.scan();
+
+            // Clique sur le sheet lui-même (pas l'overlay)
+            const clickEvent = new Event('click', { bubbles: true });
+            document.querySelector('.type-picker__sheet').dispatchEvent(clickEvent);
+
+            // Le picker est toujours visible (le stopPropagation empêche la fermeture)
+            expect(document.querySelector('.type-picker')).not.toBeNull();
+        });
+    });
+
+    describe('handleDetected', () => {
+        it('inclut le type dans l\'appel API', async () => {
             global.fetch = vi.fn().mockResolvedValue({
                 json: () => Promise.resolve({ title: 'Naruto' }),
                 ok: true,
             });
 
-            // Mock window.location
             const assignMock = vi.fn();
             Object.defineProperty(window, 'location', {
                 configurable: true,
@@ -75,18 +147,55 @@ describe('quick_scan_controller', () => {
             });
 
             const controller = await setup();
+
+            // Simule la sélection du type manga puis la détection
+            controller.scan();
+            const mangaButton = Array.from(document.querySelectorAll('.type-picker__option'))
+                .find(btn => btn.textContent.trim() === 'Manga');
+            mangaButton.click();
+
             const event = new CustomEvent('barcode-scanner:detected', {
                 detail: { rawValue: '9782723456789', format: 'ean_13' },
             });
-
             await controller.handleDetected(event);
 
-            expect(assignMock).toHaveBeenCalledWith(
-                '/comic/new?scan_isbn=9782723456789'
+            expect(global.fetch).toHaveBeenCalledWith(
+                '/api/isbn-lookup?isbn=9782723456789&type=manga'
             );
         });
 
-        it('redirige aussi si l\'ISBN n\'est pas trouvé', async () => {
+        it('inclut le type dans l\'URL de redirection', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({ title: 'Naruto' }),
+                ok: true,
+            });
+
+            const assignMock = vi.fn();
+            Object.defineProperty(window, 'location', {
+                configurable: true,
+                value: { ...window.location, assign: assignMock },
+                writable: true,
+            });
+
+            const controller = await setup();
+
+            // Simule la sélection du type manga
+            controller.scan();
+            const mangaButton = Array.from(document.querySelectorAll('.type-picker__option'))
+                .find(btn => btn.textContent.trim() === 'Manga');
+            mangaButton.click();
+
+            const event = new CustomEvent('barcode-scanner:detected', {
+                detail: { rawValue: '9782723456789', format: 'ean_13' },
+            });
+            await controller.handleDetected(event);
+
+            expect(assignMock).toHaveBeenCalledWith(
+                '/comic/new?scan_isbn=9782723456789&type=manga'
+            );
+        });
+
+        it('redirige aussi si l\'ISBN n\'est pas trouvé (avec type)', async () => {
             global.fetch = vi.fn().mockResolvedValue({
                 json: () => Promise.resolve({ error: 'Not found' }),
                 ok: false,
@@ -100,14 +209,20 @@ describe('quick_scan_controller', () => {
             });
 
             const controller = await setup();
+
+            // Simule la sélection du type bd
+            controller.scan();
+            const bdButton = Array.from(document.querySelectorAll('.type-picker__option'))
+                .find(btn => btn.textContent.trim() === 'BD');
+            bdButton.click();
+
             const event = new CustomEvent('barcode-scanner:detected', {
                 detail: { rawValue: '9782723456789', format: 'ean_13' },
             });
-
             await controller.handleDetected(event);
 
             expect(assignMock).toHaveBeenCalledWith(
-                '/comic/new?scan_isbn=9782723456789'
+                '/comic/new?scan_isbn=9782723456789&type=bd'
             );
         });
 
@@ -119,15 +234,22 @@ describe('quick_scan_controller', () => {
 
             const controller = await setup();
             const button = document.querySelector('.fab-scan');
-            const event = new CustomEvent('barcode-scanner:detected', {
-                detail: { rawValue: '9782723456789', format: 'ean_13' },
-            });
+
+            // Simule la sélection d'un type
+            controller.scan();
+            const mangaButton = Array.from(document.querySelectorAll('.type-picker__option'))
+                .find(btn => btn.textContent.trim() === 'Manga');
+            mangaButton.click();
 
             // Mock location pour éviter l'erreur
             Object.defineProperty(window, 'location', {
                 configurable: true,
                 value: { ...window.location, assign: vi.fn() },
                 writable: true,
+            });
+
+            const event = new CustomEvent('barcode-scanner:detected', {
+                detail: { rawValue: '9782723456789', format: 'ean_13' },
             });
 
             const handlePromise = controller.handleDetected(event);


### PR DESCRIPTION
## Summary
- Ajoute un **bottom sheet de sélection du type** (BD, Comics, Manga, Livre) avant d'ouvrir le scanner depuis le FAB de la page d'accueil
- Le type sélectionné est transmis à l'API `isbn-lookup` (meilleur ciblage des sources) et au formulaire via les paramètres URL (`scan_isbn` + `type`)
- Le formulaire pré-sélectionne le type et lance le lookup avec ce type

## Fichiers modifiés
- `assets/controllers/quick_scan_controller.js` — Type picker (bottom sheet), type dans API call et redirect
- `assets/controllers/comic_form_controller.js` — `handleScanIsbnParam()` lit aussi `type` depuis l'URL
- `assets/styles/app.css` — Styles bottom sheet type picker
- Tests : 180 tests Vitest passent (12 nouveaux/modifiés)

## Test plan
- [ ] FAB scan → bottom sheet s'affiche avec 4 types
- [ ] Sélection d'un type → scanner s'ouvre
- [ ] Scan ISBN → API appelée avec `&type=xxx`
- [ ] Redirection vers formulaire avec `?scan_isbn=xxx&type=xxx`
- [ ] Formulaire : type pré-sélectionné + lookup avec type
- [ ] Fermeture picker via bouton Annuler ou clic overlay
- [ ] `ddev exec npm test` — 180 tests passent

Fixes #19