### PR TITLE
fix(repository): corriger les requêtes N+1

### DIFF
--- a/src/Repository/ComicSeriesRepository.php
+++ b/src/Repository/ComicSeriesRepository.php
@@ -36,7 +36,8 @@ class ComicSeriesRepository extends ServiceEntityRepository
     public function findWithFilters(array $filters = []): array
     {
         $qb = $this->createQueryBuilder('c')
-            ->leftJoin('c.tomes', 't');
+            ->leftJoin('c.tomes', 't')
+            ->addSelect('t');
 
         // Wishlist filter : isWishlist est calculé à partir du statut
         if (isset($filters['isWishlist'])) {
@@ -104,6 +105,7 @@ class ComicSeriesRepository extends ServiceEntityRepository
     {
         return $this->createQueryBuilder('c')
             ->leftJoin('c.tomes', 't')
+            ->addSelect('t')
             ->andWhere('c.title LIKE :query OR t.isbn LIKE :query')
             ->setParameter('query', '%'.$query.'%')
             ->distinct()

--- a/tests/Repository/ComicSeriesRepositoryTest.php
+++ b/tests/Repository/ComicSeriesRepositoryTest.php
@@ -10,6 +10,7 @@ use App\Enum\ComicStatus;
 use App\Enum\ComicType;
 use App\Repository\ComicSeriesRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\PersistentCollection;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -248,6 +249,55 @@ class ComicSeriesRepositoryTest extends KernelTestCase
         self::assertNotNull($asterixIndex);
         self::assertNotNull($zorroIndex);
         self::assertGreaterThan($zorroIndex, $asterixIndex);
+    }
+
+    /**
+     * Teste que findWithFilters eager-load les tomes (pas de N+1).
+     */
+    public function testFindWithFiltersEagerLoadsTomes(): void
+    {
+        $series = $this->createSeries('Eager Load Test', false);
+        $tome = new Tome();
+        $tome->setNumber(1);
+        $tome->setBought(true);
+        $series->addTome($tome);
+        $this->em->flush();
+        $this->em->clear();
+
+        $results = $this->repository->findWithFilters(['isWishlist' => false]);
+
+        $testSeries = null;
+        foreach ($results as $s) {
+            if ('Eager Load Test' === $s->getTitle()) {
+                $testSeries = $s;
+                break;
+            }
+        }
+
+        self::assertNotNull($testSeries);
+        $tomes = $testSeries->getTomes();
+        self::assertInstanceOf(PersistentCollection::class, $tomes);
+        self::assertTrue($tomes->isInitialized(), 'Les tomes doivent être eager-loadés par findWithFilters()');
+    }
+
+    /**
+     * Teste que search() eager-load les tomes (pas de N+1).
+     */
+    public function testSearchEagerLoadsTomes(): void
+    {
+        $series = $this->createSeries('Eager Search XYZ99', false);
+        $tome = new Tome();
+        $tome->setNumber(1);
+        $series->addTome($tome);
+        $this->em->flush();
+        $this->em->clear();
+
+        $results = $this->repository->search('Eager Search XYZ99');
+
+        self::assertCount(1, $results);
+        $tomes = $results[0]->getTomes();
+        self::assertInstanceOf(PersistentCollection::class, $tomes);
+        self::assertTrue($tomes->isInitialized(), 'Les tomes doivent être eager-loadés par search()');
     }
 
     /**


### PR DESCRIPTION
## Summary
- Ajout de `addSelect('t')` dans `findWithFilters()` et `search()` pour eager-loader les tomes
- Avant : 1 requête SQL par série pour charger les tomes (N+1)
- Après : 1 seule requête SQL avec JOIN + SELECT

## Test plan
- [x] Tests d'eager loading ajoutés (`testFindWithFiltersEagerLoadsTomes`, `testSearchEagerLoadsTomes`)
- [x] 14 tests repository passent
- [x] 27 tests contrôleurs (Home, Wishlist, Search) passent

fixes #21