### PR TITLE
fix(entity): ajouter les index manquants en BDD

### DIFF
--- a/migrations/Version20260208134016.php
+++ b/migrations/Version20260208134016.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260208134016 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajout des index sur les colonnes fréquemment filtrées (status, type, title, isbn, on_nas)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE INDEX idx_comic_series_status ON comic_series (status)');
+        $this->addSql('CREATE INDEX idx_comic_series_title ON comic_series (title)');
+        $this->addSql('CREATE INDEX idx_comic_series_type ON comic_series (type)');
+        $this->addSql('CREATE INDEX idx_tome_isbn ON tome (isbn)');
+        $this->addSql('CREATE INDEX idx_tome_on_nas ON tome (on_nas)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX idx_comic_series_status ON comic_series');
+        $this->addSql('DROP INDEX idx_comic_series_title ON comic_series');
+        $this->addSql('DROP INDEX idx_comic_series_type ON comic_series');
+        $this->addSql('DROP INDEX idx_tome_isbn ON tome');
+        $this->addSql('DROP INDEX idx_tome_on_nas ON tome');
+    }
+}

--- a/src/Entity/ComicSeries.php
+++ b/src/Entity/ComicSeries.php
@@ -17,6 +17,9 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
 
 #[ORM\Entity(repositoryClass: ComicSeriesRepository::class)]
 #[ORM\HasLifecycleCallbacks]
+#[ORM\Index(columns: ['status'], name: 'idx_comic_series_status')]
+#[ORM\Index(columns: ['title'], name: 'idx_comic_series_title')]
+#[ORM\Index(columns: ['type'], name: 'idx_comic_series_type')]
 #[Vich\Uploadable]
 class ComicSeries
 {

--- a/src/Entity/Tome.php
+++ b/src/Entity/Tome.php
@@ -13,6 +13,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 #[ORM\Entity(repositoryClass: TomeRepository::class)]
 #[ORM\HasLifecycleCallbacks]
+#[ORM\Index(columns: ['isbn'], name: 'idx_tome_isbn')]
+#[ORM\Index(columns: ['on_nas'], name: 'idx_tome_on_nas')]
 class Tome
 {
     #[ORM\Id]


### PR DESCRIPTION
## Summary
- Ajout de 5 index sur les colonnes fréquemment filtrées/recherchées
  - `comic_series.status` — filtré dans `findWithFilters()`, `findByStatus()`
  - `comic_series.title` — trié et recherché partout
  - `comic_series.type` — filtré dans `findWithFilters()`
  - `tome.isbn` — recherché dans `findWithFilters()`, `search()`
  - `tome.on_nas` — filtré dans `findWithFilters()`
- `author.name` a déjà un index UNIQUE, pas besoin d'en ajouter

## Test plan
- [x] Migration générée et exécutée avec succès
- [x] 14 tests repository passent

fixes #20