### PR TITLE
refactor(isbn-lookup): paralléliser les appels API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
   - Nouveau trait `PantherTestHelper` mutualisant driver, login et exécution SQL entre les 3 fichiers de tests Panther
   - Remplacement des `usleep()`/`sleep()` par des WebDriver waits explicites
 
+### Changed
+
+- **Lookup ISBN parallélisé** : Les appels Google Books et Open Library sont désormais lancés en parallèle (lazy responses de Symfony HttpClient), réduisant le temps d'attente de Google + OpenLibrary à ~max(Google, OpenLibrary). Les fetches d'auteurs Open Library sont également parallélisés.
+
 ### Removed
 
 - **Wizard multi-étapes** : Suppression du formulaire multi-étapes (FormFlow) pour la création de séries

--- a/src/Service/IsbnLookupService.php
+++ b/src/Service/IsbnLookupService.php
@@ -13,6 +13,7 @@ use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * Service de recherche d'informations sur un livre/BD/manga par ISBN ou titre.
@@ -63,9 +64,13 @@ class IsbnLookupService
             return null;
         }
 
-        // Interroge Google Books et Open Library par ISBN
-        $googleResult = $this->lookupGoogleBooks($isbn);
-        $openLibraryResult = $this->lookupOpenLibrary($isbn);
+        // Lance les deux requêtes en parallèle (Symfony HttpClient est lazy)
+        $googleResponse = $this->requestGoogleBooks($isbn);
+        $openLibraryResponse = $this->requestOpenLibrary($isbn);
+
+        // Traite les réponses (les requêtes s'exécutent en parallèle pendant ce temps)
+        $googleResult = $this->processGoogleBooksResponse($googleResponse, $isbn);
+        $openLibraryResult = $this->processOpenLibraryResponse($openLibraryResponse, $isbn);
 
         // Si aucune API n'a de résultat
         if (null === $googleResult && null === $openLibraryResult) {
@@ -260,20 +265,27 @@ class IsbnLookupService
     }
 
     /**
-     * Recherche sur Google Books API.
-     * Récupère plusieurs résultats et les fusionne pour obtenir les données les plus complètes.
+     * Lance la requête Google Books par ISBN (non bloquant).
      */
-    private function lookupGoogleBooks(string $isbn): ?array
+    private function requestGoogleBooks(string $isbn): ResponseInterface
+    {
+        return $this->httpClient->request('GET', self::GOOGLE_BOOKS_API, [
+            'query' => [
+                'q' => 'isbn:'.$isbn,
+                'maxResults' => 10,
+            ],
+            'timeout' => 10,
+        ]);
+    }
+
+    /**
+     * Traite la réponse Google Books et extrait les données.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function processGoogleBooksResponse(ResponseInterface $response, string $isbn): ?array
     {
         try {
-            $response = $this->httpClient->request('GET', self::GOOGLE_BOOKS_API, [
-                'query' => [
-                    'q' => 'isbn:'.$isbn,
-                    'maxResults' => 10,
-                ],
-                'timeout' => 10,
-            ]);
-
             $data = $response->toArray();
 
             if (empty($data['items'])) {
@@ -282,7 +294,6 @@ class IsbnLookupService
                 return null;
             }
 
-            // Fusionne les informations de tous les résultats pour maximiser les données
             $result = $this->mergeGoogleBooksItems($data['items']);
             $this->recordApiMessage('google_books', ApiLookupStatus::SUCCESS, 'Données trouvées');
 
@@ -435,15 +446,24 @@ class IsbnLookupService
     }
 
     /**
-     * Recherche sur Open Library API.
+     * Lance la requête Open Library par ISBN (non bloquant).
      */
-    private function lookupOpenLibrary(string $isbn): ?array
+    private function requestOpenLibrary(string $isbn): ResponseInterface
+    {
+        return $this->httpClient->request('GET', self::OPEN_LIBRARY_API.$isbn.'.json', [
+            'timeout' => 10,
+        ]);
+    }
+
+    /**
+     * Traite la réponse Open Library et extrait les données.
+     * Les requêtes d'auteurs sont également parallélisées.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function processOpenLibraryResponse(ResponseInterface $response, string $isbn): ?array
     {
         try {
-            $response = $this->httpClient->request('GET', self::OPEN_LIBRARY_API.$isbn.'.json', [
-                'timeout' => 10,
-            ]);
-
             if (200 !== $response->getStatusCode()) {
                 $this->recordApiMessage('open_library', ApiLookupStatus::NOT_FOUND, 'Aucun résultat');
 
@@ -458,19 +478,10 @@ class IsbnLookupService
                 return null;
             }
 
-            // Récupère les auteurs si disponibles
+            // Récupère les auteurs en parallèle si disponibles
             $authors = null;
             if (!empty($data['authors'])) {
-                $authorNames = [];
-                foreach ($data['authors'] as $author) {
-                    if (isset($author['key'])) {
-                        $authorData = $this->fetchOpenLibraryAuthor($author['key']);
-                        if ($authorData) {
-                            $authorNames[] = $authorData;
-                        }
-                    }
-                }
-                $authors = \implode(', ', $authorNames);
+                $authors = $this->fetchOpenLibraryAuthorsParallel($data['authors']);
             }
 
             // Récupère l'éditeur
@@ -533,40 +544,50 @@ class IsbnLookupService
     }
 
     /**
-     * Récupère le nom d'un auteur depuis Open Library.
+     * Récupère les noms des auteurs Open Library en parallèle.
+     * Lance toutes les requêtes d'abord, puis lit les réponses.
+     *
+     * @param array<int, array{key?: string}> $authorRefs
      */
-    private function fetchOpenLibraryAuthor(string $authorKey): ?string
+    private function fetchOpenLibraryAuthorsParallel(array $authorRefs): ?string
     {
-        try {
-            $response = $this->httpClient->request('GET', 'https://openlibrary.org'.$authorKey.'.json', [
-                'timeout' => 5,
-            ]);
-
-            $data = $response->toArray();
-
-            return $data['name'] ?? null;
-        } catch (TransportExceptionInterface $e) {
-            $this->logger->debug('Erreur réseau lors de la récupération de l\'auteur Open Library "{key}": {error}', [
-                'error' => $e->getMessage(),
-                'key' => $authorKey,
-            ]);
-
-            return null;
-        } catch (ClientExceptionInterface|ServerExceptionInterface|RedirectionExceptionInterface $e) {
-            $this->logger->debug('Erreur HTTP lors de la récupération de l\'auteur Open Library "{key}": {error}', [
-                'error' => $e->getMessage(),
-                'key' => $authorKey,
-            ]);
-
-            return null;
-        } catch (DecodingExceptionInterface $e) {
-            $this->logger->debug('Réponse JSON invalide pour l\'auteur Open Library "{key}": {error}', [
-                'error' => $e->getMessage(),
-                'key' => $authorKey,
-            ]);
-
-            return null;
+        // Phase 1 : lance toutes les requêtes (non bloquant)
+        $responses = [];
+        foreach ($authorRefs as $author) {
+            if (isset($author['key'])) {
+                $responses[$author['key']] = $this->httpClient->request('GET', 'https://openlibrary.org'.$author['key'].'.json', [
+                    'timeout' => 5,
+                ]);
+            }
         }
+
+        // Phase 2 : lit les réponses (les requêtes s'exécutent en parallèle)
+        $authorNames = [];
+        foreach ($responses as $authorKey => $response) {
+            try {
+                $data = $response->toArray();
+                if (!empty($data['name'])) {
+                    $authorNames[] = $data['name'];
+                }
+            } catch (TransportExceptionInterface $e) {
+                $this->logger->debug('Erreur réseau lors de la récupération de l\'auteur Open Library "{key}": {error}', [
+                    'error' => $e->getMessage(),
+                    'key' => $authorKey,
+                ]);
+            } catch (ClientExceptionInterface|ServerExceptionInterface|RedirectionExceptionInterface $e) {
+                $this->logger->debug('Erreur HTTP lors de la récupération de l\'auteur Open Library "{key}": {error}', [
+                    'error' => $e->getMessage(),
+                    'key' => $authorKey,
+                ]);
+            } catch (DecodingExceptionInterface $e) {
+                $this->logger->debug('Réponse JSON invalide pour l\'auteur Open Library "{key}": {error}', [
+                    'error' => $e->getMessage(),
+                    'key' => $authorKey,
+                ]);
+            }
+        }
+
+        return \count($authorNames) > 0 ? \implode(', ', $authorNames) : null;
     }
 
     /**

--- a/tests/Service/IsbnLookupServiceTest.php
+++ b/tests/Service/IsbnLookupServiceTest.php
@@ -960,4 +960,84 @@ class IsbnLookupServiceTest extends TestCase
         // google_books ne doit pas être présent car AniList a trouvé
         self::assertArrayNotHasKey('google_books', $messages);
     }
+
+    /**
+     * Teste que les requêtes Google Books et Open Library sont lancées en parallèle.
+     * Les deux request() doivent être appelés avant que les réponses ne soient lues.
+     */
+    public function testLookupLaunchesBothRequestsBeforeProcessing(): void
+    {
+        $requestLog = [];
+
+        $googleResponse = new MockResponse(\json_encode([
+            'items' => [['volumeInfo' => ['title' => 'Parallel Test']]],
+        ]));
+
+        $openLibraryResponse = new MockResponse('', ['http_code' => 404]);
+
+        $responses = [$googleResponse, $openLibraryResponse];
+
+        $mockClient = new MockHttpClient(static function (string $method, string $url) use (&$requestLog, &$responses): MockResponse {
+            $requestLog[] = $url;
+
+            return \array_shift($responses);
+        });
+
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+        $result = $service->lookup('1234567890');
+
+        self::assertNotNull($result);
+        self::assertSame('Parallel Test', $result['title']);
+        // Les deux requêtes ont bien été émises
+        self::assertCount(2, $requestLog);
+        // Google Books en premier
+        self::assertStringContainsString('googleapis.com', $requestLog[0]);
+        // Open Library en second
+        self::assertStringContainsString('openlibrary.org', $requestLog[1]);
+    }
+
+    /**
+     * Teste que les requêtes d'auteurs Open Library sont lancées en parallèle.
+     * Tous les request() d'auteurs doivent être émis avant que les réponses ne soient lues.
+     */
+    public function testLookupParallelizesOpenLibraryAuthorFetches(): void
+    {
+        $requestLog = [];
+
+        $googleResponse = new MockResponse(\json_encode(['items' => []]));
+
+        $openLibraryResponse = new MockResponse(\json_encode([
+            'authors' => [
+                ['key' => '/authors/OL1A'],
+                ['key' => '/authors/OL2A'],
+                ['key' => '/authors/OL3A'],
+            ],
+            'title' => 'Multi Author Book',
+        ]));
+
+        $authorResponse1 = new MockResponse(\json_encode(['name' => 'Author One']));
+        $authorResponse2 = new MockResponse(\json_encode(['name' => 'Author Two']));
+        $authorResponse3 = new MockResponse(\json_encode(['name' => 'Author Three']));
+
+        $responses = [$googleResponse, $openLibraryResponse, $authorResponse1, $authorResponse2, $authorResponse3];
+
+        $mockClient = new MockHttpClient(static function (string $method, string $url) use (&$requestLog, &$responses): MockResponse {
+            $requestLog[] = $url;
+
+            return \array_shift($responses);
+        });
+
+        $service = new IsbnLookupService($mockClient, new NullLogger());
+        $result = $service->lookup('1234567890');
+
+        self::assertNotNull($result);
+        self::assertSame('Author One, Author Two, Author Three', $result['authors']);
+
+        // 5 requêtes : Google Books + Open Library ISBN + 3 auteurs
+        self::assertCount(5, $requestLog);
+        // Les 3 requêtes d'auteurs sont consécutives (lancées ensemble)
+        self::assertStringContainsString('/authors/OL1A', $requestLog[2]);
+        self::assertStringContainsString('/authors/OL2A', $requestLog[3]);
+        self::assertStringContainsString('/authors/OL3A', $requestLog[4]);
+    }
 }


### PR DESCRIPTION
## Summary

- **Parallélisation Google Books + Open Library** : les deux requêtes ISBN sont lancées simultanément via les réponses lazy de Symfony HttpClient, réduisant le temps d'attente de `Google + OpenLibrary` à `~max(Google, OpenLibrary)`
- **Parallélisation des fetches d'auteurs** : les N requêtes d'auteurs Open Library sont également lancées en parallèle
- **Zéro dépendance ajoutée** : exploite le comportement natif async de `HttpClientInterface::request()`

## Test plan

- [x] 34 tests `IsbnLookupServiceTest` passent (dont 2 nouveaux pour la parallélisation)
- [x] 360 tests total passent
- [ ] Test manuel : lookup ISBN via l'interface et vérifier résultats identiques

Fixes #22