### PR TITLE
fix(css): corriger le spinner qui bouge en diagonale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Fixed
 
+- **Icône de chargement** : Correction du spinner qui se déplaçait en diagonale lors d'une recherche par titre ou ISBN — conflit entre deux `@keyframes spin` (btn-icon vs fab-scan)
 - **Lookup ISBN tome** : La recherche ISBN depuis un tome ne remplit plus que les champs pertinents au niveau série (auteurs, éditeur, couverture) — les champs volume-spécifiques (titre, date, description) et le flag one-shot sont ignorés
 - **Actions liste** : Les boutons "Supprimer" et "Ajouter à la bibliothèque" fonctionnent depuis la liste (tokens CSRF inclus dans l'API)
 - **Tests Panther flaky** : Correction des 5 tests `OneShotFormTest`/`TomeManagementTest` qui échouaient aléatoirement

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -2170,7 +2170,7 @@ body[data-connection-status="OFFLINE"] .offline-indicator {
 }
 
 .fab-scan--loading::after {
-    animation: spin 1s linear infinite;
+    animation: spin-centered 1s linear infinite;
     border: 2px solid transparent;
     border-radius: 50%;
     border-top-color: var(--md-on-primary);
@@ -2187,7 +2187,7 @@ body[data-connection-status="OFFLINE"] .offline-indicator {
     visibility: hidden;
 }
 
-@keyframes spin {
+@keyframes spin-centered {
     to { transform: translate(-50%, -50%) rotate(360deg); }
 }
 


### PR DESCRIPTION
## Summary

- Renomme `@keyframes spin` en `@keyframes spin-centered` pour `.fab-scan--loading` afin de supprimer le conflit avec le `@keyframes spin` utilisé par `.btn-icon--loading`
- Le `translate(-50%, -50%)` de `fab-scan` s'appliquait aux spinners des boutons de recherche titre/ISBN, les décalant en diagonale

## Root Cause

Deux `@keyframes spin` déclarées dans `app.css` : la seconde (avec `translate(-50%, -50%)`) écrasait la première (rotation simple), affectant tous les éléments utilisant `animation: spin`.

## Test plan

- [ ] Ouvrir le formulaire de création de série
- [ ] Saisir un titre et cliquer sur le bouton recherche — le spinner doit rester fixe
- [ ] Vérifier que le FAB scan fonctionne toujours (spinner centré dans le bouton rond)

fixes #46