### PR TITLE
fix(datepicker): datepicker Flatpickr pour la date de publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Fixed
 
+- **Date de publication** : Remplacement du champ texte par un datepicker Flatpickr en français (DD/MM/YYYY) avec bouton d'effacement — supprime l'heure inutile et normalise le format en YYYY-MM-DD
 - **Icône de chargement** : Correction du spinner qui se déplaçait en diagonale lors d'une recherche par titre ou ISBN — conflit entre deux `@keyframes spin` (btn-icon vs fab-scan)
 - **Lookup ISBN tome** : La recherche ISBN depuis un tome ne remplit plus que les champs pertinents au niveau série (auteurs, éditeur, couverture) — les champs volume-spécifiques (titre, date, description) et le flag one-shot sont ignorés
 - **Actions liste** : Les boutons "Supprimer" et "Ajouter à la bibliothèque" fonctionnent depuis la liste (tokens CSRF inclus dans l'API)

--- a/assets/controllers/comic_form_controller.js
+++ b/assets/controllers/comic_form_controller.js
@@ -602,9 +602,46 @@ export default class extends Controller {
             return false;
         }
 
-        this[target].value = value;
+        // Normalise la date pour le champ date natif (YYYY-MM-DD)
+        const normalizedValue = targetName === 'publishedDate' ? this.normalizeDate(value) : value;
+
+        if (!normalizedValue) {
+            return false;
+        }
+
+        this[target].value = normalizedValue;
         this.highlightField(this[target]);
         return true;
+    }
+
+    /**
+     * Normalise une date en format YYYY-MM-DD pour le champ date natif.
+     * @param {string} date - Date dans un format variable (YYYY, YYYY-MM, YYYY-MM-DD, etc.)
+     * @returns {string|null} Date au format YYYY-MM-DD ou null
+     */
+    normalizeDate(date) {
+        if (!date) return null;
+
+        // Déjà au format YYYY-MM-DD
+        if (/^\d{4}-\d{2}-\d{2}$/.test(date)) return date;
+
+        // Format YYYY-MM-DD suivi d'une heure
+        const dateTimeMatch = date.match(/^(\d{4}-\d{2}-\d{2})\s/);
+        if (dateTimeMatch) return dateTimeMatch[1];
+
+        // Format YYYY-MM
+        if (/^\d{4}-\d{2}$/.test(date)) return `${date}-01`;
+
+        // Format YYYY
+        if (/^\d{4}$/.test(date)) return `${date}-01-01`;
+
+        // Tente un parsing générique
+        const parsed = new Date(date);
+        if (!isNaN(parsed.getTime())) {
+            return parsed.toISOString().slice(0, 10);
+        }
+
+        return null;
     }
 
     /**

--- a/assets/controllers/datepicker_controller.js
+++ b/assets/controllers/datepicker_controller.js
@@ -1,0 +1,77 @@
+import { Controller } from '@hotwired/stimulus';
+import flatpickr from 'flatpickr';
+import { French } from 'flatpickr/dist/l10n/fr.js';
+
+/**
+ * Contrôleur Stimulus pour initialiser Flatpickr sur un champ de date.
+ *
+ * Usage : <input data-controller="datepicker" type="text">
+ *
+ * La valeur soumise au serveur est en format YYYY-MM-DD (dateFormat).
+ * L'affichage utilisateur est en format DD/MM/YYYY (altFormat).
+ * Un bouton "effacer" apparaît quand une date est sélectionnée.
+ * Une icône calendrier permet d'ouvrir le datepicker.
+ */
+export default class extends Controller {
+    connect() {
+        this.picker = flatpickr(this.element, {
+            allowInput: true,
+            altFormat: 'd/m/Y',
+            altInput: true,
+            dateFormat: 'Y-m-d',
+            locale: French,
+            onChange: () => this.toggleClearButton(),
+        });
+
+        this.createIcons();
+        this.toggleClearButton();
+    }
+
+    disconnect() {
+        if (this.iconsWrapper) {
+            this.iconsWrapper.remove();
+            this.iconsWrapper = null;
+        }
+
+        if (this.picker) {
+            this.picker.destroy();
+        }
+    }
+
+    createIcons() {
+        this.iconsWrapper = document.createElement('span');
+        this.iconsWrapper.className = 'datepicker-icons';
+
+        // Bouton effacer
+        this.clearBtn = document.createElement('button');
+        this.clearBtn.type = 'button';
+        this.clearBtn.className = 'datepicker-clear';
+        this.clearBtn.setAttribute('aria-label', 'Effacer la date');
+        this.clearBtn.textContent = '\u00d7';
+        this.clearBtn.addEventListener('click', () => {
+            this.picker.clear();
+            this.toggleClearButton();
+        });
+
+        // Icône calendrier
+        const calendarBtn = document.createElement('button');
+        calendarBtn.type = 'button';
+        calendarBtn.className = 'datepicker-calendar';
+        calendarBtn.setAttribute('aria-label', 'Ouvrir le calendrier');
+        calendarBtn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18"><path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM9 10H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2z"/></svg>';
+        calendarBtn.addEventListener('click', () => this.picker.open());
+
+        this.iconsWrapper.appendChild(this.clearBtn);
+        this.iconsWrapper.appendChild(calendarBtn);
+
+        // Insère après l'altInput (l'input visible créé par Flatpickr)
+        const altInput = this.picker.altInput || this.element;
+        altInput.parentNode.insertBefore(this.iconsWrapper, altInput.nextSibling);
+    }
+
+    toggleClearButton() {
+        if (this.clearBtn) {
+            this.clearBtn.style.display = this.element.value ? '' : 'none';
+        }
+    }
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -746,6 +746,48 @@ body {
     padding: var(--md-spacing-sm);
 }
 
+/* Datepicker */
+.flatpickr-wrapper {
+    position: relative;
+    width: 100%;
+}
+
+.datepicker-icons {
+    align-items: center;
+    display: flex;
+    gap: 2px;
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+.datepicker-clear,
+.datepicker-calendar {
+    align-items: center;
+    background: none;
+    border: none;
+    color: var(--md-text-medium);
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    padding: var(--md-spacing-xs);
+}
+
+.datepicker-clear {
+    font-size: 1.2rem;
+    line-height: 1;
+}
+
+.datepicker-calendar svg {
+    fill: currentColor;
+}
+
+.datepicker-clear:hover,
+.datepicker-calendar:hover {
+    color: var(--md-text-high);
+}
+
 /* Checkbox Field */
 .mdc-checkbox-field {
     align-items: center;

--- a/importmap.php
+++ b/importmap.php
@@ -62,4 +62,14 @@ return [
     '@symfony/ux-dropzone' => [
         'version' => '2.32.0',
     ],
+    'flatpickr' => [
+        'version' => '4.6.13',
+    ],
+    'flatpickr/dist/l10n/fr.js' => [
+        'version' => '4.6.13',
+    ],
+    'flatpickr/dist/flatpickr.min.css' => [
+        'version' => '4.6.13',
+        'type' => 'css',
+    ],
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@hotwired/stimulus": "^3.2.2",
         "@playwright/test": "^1.58.1",
+        "flatpickr": "^4.6.13",
         "jsdom": "^28.0.0",
         "vitest": "^4.0.18"
       }
@@ -145,6 +146,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -185,6 +187,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1381,6 +1384,13 @@
         }
       }
     },
+    "node_modules/flatpickr": {
+      "version": "4.6.13",
+      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
+      "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1450,6 +1460,7 @@
       "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -1581,6 +1592,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1871,6 +1883,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@playwright/test": "^1.58.1",
+    "flatpickr": "^4.6.13",
     "jsdom": "^28.0.0",
     "vitest": "^4.0.18"
   }

--- a/src/Service/ComicSeriesMapper.php
+++ b/src/Service/ComicSeriesMapper.php
@@ -91,7 +91,7 @@ class ComicSeriesMapper
         $input->latestPublishedIssueComplete = $entity->isLatestPublishedIssueComplete();
         $input->isOneShot = $entity->isOneShot();
         $input->description = $entity->getDescription();
-        $input->publishedDate = $entity->getPublishedDate();
+        $input->publishedDate = $this->normalizeDate($entity->getPublishedDate());
         $input->publisher = $entity->getPublisher();
         $input->coverUrl = $entity->getCoverUrl();
         $input->coverImage = $entity->getCoverImage();
@@ -155,6 +155,45 @@ class ComicSeriesMapper
                 $tome = $this->mapper->map($tomeInput, Tome::class);
                 $entity->addTome($tome);
             }
+        }
+    }
+
+    /**
+     * Normalise une date en format YYYY-MM-DD pour le champ DateType.
+     */
+    private function normalizeDate(?string $date): ?string
+    {
+        if (null === $date || '' === $date) {
+            return null;
+        }
+
+        // Déjà au format YYYY-MM-DD
+        if (\preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+            return $date;
+        }
+
+        // Format YYYY-MM-DD suivi d'une heure (ex: "2023-01-15 10:30:00")
+        if (\preg_match('/^(\d{4}-\d{2}-\d{2})\s/', $date)) {
+            return \substr($date, 0, 10);
+        }
+
+        // Format YYYY-MM (ex: "2023-06")
+        if (\preg_match('/^\d{4}-\d{2}$/', $date)) {
+            return $date.'-01';
+        }
+
+        // Format YYYY (ex: "2023")
+        if (\preg_match('/^\d{4}$/', $date)) {
+            return $date.'-01-01';
+        }
+
+        // Tente un parsing générique
+        try {
+            $parsed = new \DateTimeImmutable($date);
+
+            return $parsed->format('Y-m-d');
+        } catch (\Exception) {
+            return null;
         }
     }
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -10,6 +10,7 @@
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
         {% block stylesheets %}
+            <link rel="stylesheet" href="{{ asset('vendor/flatpickr/dist/flatpickr.min.css') }}">
             <link rel="stylesheet" href="{{ asset('styles/app.css') }}">
         {% endblock %}
 

--- a/templates/comic/_form.html.twig
+++ b/templates/comic/_form.html.twig
@@ -67,7 +67,7 @@
     <div class="form-row">
         <div class="mdc-text-field">
             <label for="{{ form.publishedDate.vars.id }}">Date de publication</label>
-            {{ form_widget(form.publishedDate, {attr: {'data-comic-form-target': 'publishedDate'}}) }}
+            {{ form_widget(form.publishedDate, {attr: {'data-comic-form-target': 'publishedDate', 'data-controller': 'datepicker'}}) }}
             {{ form_errors(form.publishedDate) }}
         </div>
 

--- a/tests/Form/ComicSeriesTypeTest.php
+++ b/tests/Form/ComicSeriesTypeTest.php
@@ -10,6 +10,7 @@ use App\Enum\ComicType;
 use App\Form\ComicSeriesType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormFactoryInterface;
 
 /**
@@ -194,6 +195,49 @@ class ComicSeriesTypeTest extends KernelTestCase
         self::assertSame('978-2-1234-5678-9', $form->get('isbn')->getData());
         // Le DTO n'a pas de propriété isbn — la soumission ne crashe pas
         self::assertSame('Test ISBN', $input->title);
+    }
+
+    /**
+     * Teste que publishedDate est un TextType (Flatpickr gère le widget côté JS).
+     */
+    public function testPublishedDateIsTextType(): void
+    {
+        $form = $this->formFactory->create(ComicSeriesType::class);
+        $publishedDateConfig = $form->get('publishedDate')->getConfig();
+
+        self::assertInstanceOf(TextType::class, $publishedDateConfig->getType()->getInnerType());
+    }
+
+    /**
+     * Teste la soumission d'une date au format YYYY-MM-DD.
+     */
+    public function testPublishedDateSubmitsCorrectly(): void
+    {
+        $input = new ComicSeriesInput();
+        $form = $this->formFactory->create(ComicSeriesType::class, $input);
+        $form->submit([
+            'publishedDate' => '2023-06-15',
+            'status' => 'buying',
+            'title' => 'Test',
+            'type' => 'bd',
+        ]);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertSame('2023-06-15', $input->publishedDate);
+    }
+
+    /**
+     * Teste que le champ date se pré-remplit correctement.
+     */
+    public function testPublishedDatePrefillsCorrectly(): void
+    {
+        $input = new ComicSeriesInput();
+        $input->publishedDate = '2024-03-20';
+
+        $form = $this->formFactory->create(ComicSeriesType::class, $input);
+        $view = $form->createView();
+
+        self::assertSame('2024-03-20', $view->children['publishedDate']->vars['value']);
     }
 
     /**

--- a/tests/Service/ComicSeriesMapperTest.php
+++ b/tests/Service/ComicSeriesMapperTest.php
@@ -491,6 +491,76 @@ class ComicSeriesMapperTest extends TestCase
     }
 
     /**
+     * Teste que mapToInput normalise une date avec heure en date seule.
+     */
+    public function testMapToInputNormalizesDateWithTime(): void
+    {
+        $entity = new ComicSeries();
+        $entity->setTitle('Test');
+        $entity->setPublishedDate('2023-01-15 10:30:00');
+
+        $input = $this->mapper->mapToInput($entity);
+
+        self::assertSame('2023-01-15', $input->publishedDate);
+    }
+
+    /**
+     * Teste que mapToInput normalise une année seule en date complète.
+     */
+    public function testMapToInputNormalizesYearOnlyDate(): void
+    {
+        $entity = new ComicSeries();
+        $entity->setTitle('Test');
+        $entity->setPublishedDate('2023');
+
+        $input = $this->mapper->mapToInput($entity);
+
+        self::assertSame('2023-01-01', $input->publishedDate);
+    }
+
+    /**
+     * Teste que mapToInput normalise une date année-mois en date complète.
+     */
+    public function testMapToInputNormalizesYearMonthDate(): void
+    {
+        $entity = new ComicSeries();
+        $entity->setTitle('Test');
+        $entity->setPublishedDate('2023-06');
+
+        $input = $this->mapper->mapToInput($entity);
+
+        self::assertSame('2023-06-01', $input->publishedDate);
+    }
+
+    /**
+     * Teste que mapToInput conserve une date déjà au bon format.
+     */
+    public function testMapToInputKeepsValidDate(): void
+    {
+        $entity = new ComicSeries();
+        $entity->setTitle('Test');
+        $entity->setPublishedDate('2024-01-15');
+
+        $input = $this->mapper->mapToInput($entity);
+
+        self::assertSame('2024-01-15', $input->publishedDate);
+    }
+
+    /**
+     * Teste que mapToInput gère une date nulle.
+     */
+    public function testMapToInputHandlesNullDate(): void
+    {
+        $entity = new ComicSeries();
+        $entity->setTitle('Test');
+        $entity->setPublishedDate(null);
+
+        $input = $this->mapper->mapToInput($entity);
+
+        self::assertNull($input->publishedDate);
+    }
+
+    /**
      * Teste que les auteurs sont effacés avant réassignation.
      */
     public function testMapToEntityClearsExistingAuthors(): void

--- a/tests/js/controllers/barcode-scan-integration.test.js
+++ b/tests/js/controllers/barcode-scan-integration.test.js
@@ -157,7 +157,7 @@ describe('Intégration : scan code-barres → formulaire', () => {
                 expect(form.querySelector('[data-comic-form-target="title"]').value).toBe('One Piece');
             });
             expect(form.querySelector('[data-comic-form-target="publisher"]').value).toBe('Glénat');
-            expect(form.querySelector('[data-comic-form-target="publishedDate"]').value).toBe('1997');
+            expect(form.querySelector('[data-comic-form-target="publishedDate"]').value).toBe('1997-01-01');
             expect(form.querySelector('[data-comic-form-target="description"]').value).toBe('Aventure pirate');
             expect(form.querySelector('[data-comic-form-target="coverUrl"]').value).toBe('https://covers.example.com/onepiece.jpg');
         });

--- a/tests/js/controllers/comic_form_controller.test.js
+++ b/tests/js/controllers/comic_form_controller.test.js
@@ -181,6 +181,34 @@ describe('comic_form_controller', () => {
         });
     });
 
+    describe('normalizeDate', () => {
+        it('garde une date déjà au format YYYY-MM-DD', async () => {
+            const controller = await setup();
+            expect(controller.normalizeDate('2023-01-15')).toBe('2023-01-15');
+        });
+
+        it('supprime l\'heure d\'une date avec heure', async () => {
+            const controller = await setup();
+            expect(controller.normalizeDate('2023-01-15 10:30:00')).toBe('2023-01-15');
+        });
+
+        it('complète une année seule', async () => {
+            const controller = await setup();
+            expect(controller.normalizeDate('1999')).toBe('1999-01-01');
+        });
+
+        it('complète une date année-mois', async () => {
+            const controller = await setup();
+            expect(controller.normalizeDate('2023-06')).toBe('2023-06-01');
+        });
+
+        it('retourne null pour une valeur vide', async () => {
+            const controller = await setup();
+            expect(controller.normalizeDate(null)).toBeNull();
+            expect(controller.normalizeDate('')).toBeNull();
+        });
+    });
+
     describe('fillSelect', () => {
         it('remplit un select avec une valeur valide', async () => {
             const controller = await setup();
@@ -381,7 +409,7 @@ describe('comic_form_controller', () => {
             await controller.performIsbnLookup('978-123', button);
 
             expect(document.querySelector('[data-comic-form-target="title"]').value).toBe('Naruto');
-            expect(document.querySelector('[data-comic-form-target="publishedDate"]').value).toBe('1999');
+            expect(document.querySelector('[data-comic-form-target="publishedDate"]').value).toBe('1999-01-01');
             expect(document.querySelector('[data-comic-form-target="description"]').value).toBe('Ninja manga');
             expect(document.querySelector('[data-comic-form-target="publisher"]').value).toBe('Kana');
             expect(document.querySelector('[data-comic-form-target="coverUrl"]').value).toBe('http://img.jpg');

--- a/tests/js/controllers/datepicker_controller.test.js
+++ b/tests/js/controllers/datepicker_controller.test.js
@@ -1,0 +1,104 @@
+import DatepickerController from '../../../assets/controllers/datepicker_controller.js';
+import { startStimulusController, stopStimulusController } from '../helpers/stimulus-helper.js';
+
+function buildHtml() {
+    return `
+        <div>
+            <input type="text" data-controller="datepicker" value="">
+        </div>
+    `;
+}
+
+let app;
+
+async function setup() {
+    const { application } = await startStimulusController(DatepickerController, 'datepicker', buildHtml());
+    app = application;
+}
+
+describe('DatepickerController', () => {
+    afterEach(() => {
+        if (app) {
+            stopStimulusController(app);
+            app = null;
+        }
+    });
+
+    it('exporte un contrôleur Stimulus valide', () => {
+        expect(DatepickerController).toBeDefined();
+        expect(typeof DatepickerController.prototype.connect).toBe('function');
+        expect(typeof DatepickerController.prototype.disconnect).toBe('function');
+    });
+
+    it('initialise Flatpickr sur l\'élément', async () => {
+        await setup();
+
+        const input = document.querySelector('[data-controller="datepicker"]');
+        expect(input.classList.contains('flatpickr-input')).toBe(true);
+        expect(input._flatpickr).toBeTruthy();
+    });
+
+    it('configure le format YYYY-MM-DD pour la soumission', async () => {
+        await setup();
+
+        const input = document.querySelector('[data-controller="datepicker"]');
+        expect(input._flatpickr.config.dateFormat).toBe('Y-m-d');
+    });
+
+    it('configure altInput avec le format français dd/mm/yyyy', async () => {
+        await setup();
+
+        const input = document.querySelector('[data-controller="datepicker"]');
+        expect(input._flatpickr.config.altInput).toBe(true);
+        expect(input._flatpickr.config.altFormat).toBe('d/m/Y');
+    });
+
+    it('crée un bouton effacer et une icône calendrier', async () => {
+        await setup();
+
+        const iconsWrapper = document.querySelector('.datepicker-icons');
+        expect(iconsWrapper).not.toBeNull();
+
+        const clearBtn = document.querySelector('.datepicker-clear');
+        expect(clearBtn).not.toBeNull();
+        expect(clearBtn.type).toBe('button');
+        expect(clearBtn.getAttribute('aria-label')).toBe('Effacer la date');
+        expect(clearBtn.textContent).toBe('\u00d7');
+
+        const calendarBtn = document.querySelector('.datepicker-calendar');
+        expect(calendarBtn).not.toBeNull();
+        expect(calendarBtn.type).toBe('button');
+        expect(calendarBtn.getAttribute('aria-label')).toBe('Ouvrir le calendrier');
+        expect(calendarBtn.querySelector('svg')).not.toBeNull();
+    });
+
+    it('masque le bouton effacer quand aucune date n\'est sélectionnée', async () => {
+        await setup();
+
+        const clearBtn = document.querySelector('.datepicker-clear');
+        expect(clearBtn.style.display).toBe('none');
+    });
+
+    it('affiche le bouton effacer quand une date est sélectionnée', async () => {
+        await setup();
+
+        const input = document.querySelector('[data-controller="datepicker"]');
+        input._flatpickr.setDate('2024-06-15', true);
+
+        const clearBtn = document.querySelector('.datepicker-clear');
+        expect(clearBtn.style.display).toBe('');
+    });
+
+    it('efface la date au clic sur le bouton', async () => {
+        await setup();
+
+        const input = document.querySelector('[data-controller="datepicker"]');
+        input._flatpickr.setDate('2024-06-15', true);
+
+        const clearBtn = document.querySelector('.datepicker-clear');
+        clearBtn.click();
+
+        expect(input.value).toBe('');
+        expect(clearBtn.style.display).toBe('none');
+    });
+});


### PR DESCRIPTION
## Summary
- Remplace le champ texte de date de publication par un datepicker **Flatpickr** en français (DD/MM/YYYY) avec icône calendrier et bouton d'effacement
- Normalise les dates API (YYYY, YYYY-MM, datetime) en YYYY-MM-DD côté PHP (`ComicSeriesMapper`) et JS (`comic_form_controller`)
- Ajoute un contrôleur Stimulus `datepicker_controller` réutilisable

## Test plan
- [x] 197 tests JS passent (dont 8 tests datepicker + normalizeDate)
- [x] 444 tests PHP passent (dont 5 tests normalisation date + 3 tests form)
- [x] Lint clean

fixes #47