### PR TITLE
fix(form): boutons sauvegarder/annuler sticky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Boutons de formulaire sticky** : Les boutons « Enregistrer » et « Annuler » restent visibles en bas de l'écran lors du scroll sur les formulaires longs
+
 ### Added
 
 - **Enrichissement Gemini IA** : Intégration de l'API Google Gemini pour enrichir les données des séries

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -62,7 +62,7 @@ body {
     font-family: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     line-height: 1.5;
     min-height: 100vh;
-    overflow-x: hidden;
+    overflow-x: clip;
     padding-bottom: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px));
 }
 
@@ -657,13 +657,13 @@ body {
     box-shadow: var(--md-elevation-1);
     margin: 0 auto;
     max-width: 600px;
-    overflow-x: hidden;
+    overflow-x: clip;
     padding: var(--md-spacing-lg);
 }
 
 /* Prevent horizontal scroll on forms */
 .comic-form {
-    overflow-x: hidden;
+    overflow-x: clip;
 }
 
 /* Material Text Field */
@@ -871,11 +871,17 @@ body {
 
 /* Form Actions */
 .form-actions {
+    background: var(--md-surface);
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
+    bottom: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px));
+    box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.1);
     display: flex;
     gap: var(--md-spacing-md);
     justify-content: flex-end;
     margin-top: var(--md-spacing-lg);
-    padding-top: var(--md-spacing-md);
+    padding: var(--md-spacing-md) 0;
+    position: sticky;
+    z-index: 10;
 }
 
 /* Checkboxes Row */
@@ -1185,6 +1191,10 @@ body[data-connection-status="OFFLINE"] .offline-indicator {
 
     .bottom-nav {
         display: none;
+    }
+
+    .form-actions {
+        bottom: 0;
     }
 
     .fab {


### PR DESCRIPTION
## Summary

- Les boutons « Enregistrer » et « Annuler » du formulaire restent visibles en bas de l'écran lors du scroll
- Mobile : positionnés au-dessus de la bottom nav
- Desktop : collés en bas du viewport
- Bordure et ombre pour distinguer la barre du contenu

## Détails techniques

- `position: sticky; bottom: calc(var(--bottom-nav-height) + ...)` sur mobile
- `bottom: 0` sur desktop (breakpoint 768px)
- `overflow-x: clip` remplace `hidden` sur body, `.form-container` et `.comic-form` (nécessaire pour que sticky fonctionne)

## Test plan

- [x] Testé via Panther (mobile 375x812 + desktop 1280x720) : boutons visibles, pas de chevauchement avec la bottom nav

Fixes #48