### PR TITLE
fix(lookup): mettre à jour latestPublishedIssue systématiquement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
-### Changed
-
-- **Boutons de formulaire sticky** : Les boutons « Enregistrer » et « Annuler » restent visibles en bas de l'écran lors du scroll sur les formulaires longs
-
 ### Added
 
 - **Enrichissement Gemini IA** : Intégration de l'API Google Gemini pour enrichir les données des séries
@@ -58,6 +54,8 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Fixed
 
+- **Détection one-shot Google Books** : Ne marque plus les séries comme one-shot par défaut quand l'information `seriesInfo` est absente de l'API
+- **Cache lookup périmé** : Gestion de la désérialisation d'objets en cache après l'ajout de nouvelles propriétés (évite les erreurs de connexion)
 - **Date de publication** : Remplacement du champ texte par un datepicker Flatpickr en français (DD/MM/YYYY) avec bouton d'effacement — supprime l'heure inutile et normalise le format en YYYY-MM-DD
 - **Icône de chargement** : Correction du spinner qui se déplaçait en diagonale lors d'une recherche par titre ou ISBN — conflit entre deux `@keyframes spin` (btn-icon vs fab-scan)
 - **Lookup ISBN tome** : La recherche ISBN depuis un tome ne remplit plus que les champs pertinents au niveau série (auteurs, éditeur, couverture) — les champs volume-spécifiques (titre, date, description) et le flag one-shot sont ignorés
@@ -69,6 +67,8 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
+- **Nombre de tomes parus** : Le champ « Dernier tome paru » est désormais mis à jour systématiquement lors de l'enrichissement, même s'il est déjà renseigné
+- **Boutons de formulaire sticky** : Les boutons « Enregistrer » et « Annuler » restent visibles en bas de l'écran lors du scroll sur les formulaires longs
 - **Refactoring architecture lookup** : Extraction du service monolithique `IsbnLookupService` en architecture provider-based
   - Interface `LookupProviderInterface` avec méthode `supports()` pour filtrer les providers par mode (ISBN/titre) et type
   - Providers individuels : `GoogleBooksLookup`, `OpenLibraryLookup`, `AniListLookup`, `GeminiLookup`

--- a/assets/controllers/comic_form_controller.js
+++ b/assets/controllers/comic_form_controller.js
@@ -42,6 +42,7 @@ export default class extends Controller {
         coverUrl: 'Couverture',
         description: 'Description',
         isOneShot: 'One-shot',
+        latestPublishedIssue: 'Dernier tome paru',
         publishedDate: 'Date de publication',
         publisher: 'Éditeur',
         title: 'Titre',
@@ -322,6 +323,7 @@ export default class extends Controller {
             if (this.fillAuthors(data.authors)) filledFields.push('authors');
             if (this.fillField('publisher', data.publisher)) filledFields.push('publisher');
             if (this.fillField('coverUrl', data.thumbnail)) filledFields.push('coverUrl');
+            if (this.forceUpdateField('latestPublishedIssue', data.latestPublishedIssue)) filledFields.push('latestPublishedIssue');
 
             // Gère le one-shot détecté (uniquement en mode normal)
             if (!fromTome && data.isOneShot === true && this.hasIsOneShotTarget && !this.isOneShotTarget.checked) {
@@ -390,6 +392,7 @@ export default class extends Controller {
             if (this.fillField('publishedDate', data.publishedDate)) filledFields.push('publishedDate');
             if (this.fillField('description', data.description)) filledFields.push('description');
             if (this.fillField('coverUrl', data.thumbnail)) filledFields.push('coverUrl');
+            if (this.forceUpdateField('latestPublishedIssue', data.latestPublishedIssue)) filledFields.push('latestPublishedIssue');
 
             // Gère le one-shot détecté
             if (data.isOneShot === true && this.hasIsOneShotTarget && !this.isOneShotTarget.checked) {
@@ -515,6 +518,7 @@ export default class extends Controller {
             if (this.fillField('description', data.description)) filledFields.push('description');
             if (this.fillField('coverUrl', data.thumbnail)) filledFields.push('coverUrl');
             if (this.fillSelect('type', data.type)) filledFields.push('type');
+            if (this.forceUpdateField('latestPublishedIssue', data.latestPublishedIssue)) filledFields.push('latestPublishedIssue');
 
             // Gère le one-shot détecté
             if (data.isOneShot === true && this.hasIsOneShotTarget && !this.isOneShotTarget.checked) {
@@ -610,6 +614,28 @@ export default class extends Controller {
         }
 
         this[target].value = normalizedValue;
+        this.highlightField(this[target]);
+        return true;
+    }
+
+    /**
+     * Met à jour un champ même s'il est déjà rempli.
+     * @returns {boolean} true si le champ a été mis à jour
+     */
+    forceUpdateField(targetName, value) {
+        const targetMethod = `has${targetName.charAt(0).toUpperCase() + targetName.slice(1)}Target`;
+        const target = `${targetName}Target`;
+
+        if (!this[targetMethod] || value === null || value === undefined) {
+            return false;
+        }
+
+        const stringValue = String(value);
+        if (this[target].value === stringValue) {
+            return false;
+        }
+
+        this[target].value = stringValue;
         this.highlightField(this[target]);
         return true;
     }

--- a/src/Service/Lookup/AniListLookup.php
+++ b/src/Service/Lookup/AniListLookup.php
@@ -138,6 +138,7 @@ class AniListLookup implements LookupProviderInterface
                 authors: $authors,
                 description: $description,
                 isOneShot: $isOneShot,
+                latestPublishedIssue: \is_int($volumes) ? $volumes : null,
                 publishedDate: $publishedDate,
                 source: 'anilist',
                 thumbnail: $thumbnail,

--- a/src/Service/Lookup/GeminiLookup.php
+++ b/src/Service/Lookup/GeminiLookup.php
@@ -31,6 +31,7 @@ class GeminiLookup implements EnrichableLookupProviderInterface
         - "description" (string|null) : synopsis de la série
         - "thumbnail" (string|null) : URL image de couverture
         - "isOneShot" (boolean|null) : true = tome unique, false = série multi-tomes
+        - "latestPublishedIssue" (integer|null) : nombre de tomes parus
         TEXT;
 
     private const string MODEL = 'gemini-2.5-flash';
@@ -185,6 +186,7 @@ class GeminiLookup implements EnrichableLookupProviderInterface
                 authors: \is_string($data['authors'] ?? null) ? $data['authors'] : null,
                 description: \is_string($data['description'] ?? null) ? $data['description'] : null,
                 isOneShot: \is_bool($data['isOneShot'] ?? null) ? $data['isOneShot'] : null,
+                latestPublishedIssue: \is_int($data['latestPublishedIssue'] ?? null) ? $data['latestPublishedIssue'] : null,
                 publishedDate: \is_string($data['publishedDate'] ?? null) ? $data['publishedDate'] : null,
                 publisher: \is_string($data['publisher'] ?? null) ? $data['publisher'] : null,
                 source: 'gemini',

--- a/src/Service/Lookup/GoogleBooksLookup.php
+++ b/src/Service/Lookup/GoogleBooksLookup.php
@@ -184,8 +184,8 @@ class GoogleBooksLookup implements LookupProviderInterface
                 $isbn = $this->extractIsbnFromIdentifiers($volumeInfo['industryIdentifiers']);
             }
 
-            if (null === $isOneShot && \is_array($volumeInfo)) {
-                $isOneShot = !\array_key_exists('seriesInfo', $volumeInfo) || null === $volumeInfo['seriesInfo'];
+            if (null === $isOneShot && \is_array($volumeInfo) && \array_key_exists('seriesInfo', $volumeInfo) && null !== $volumeInfo['seriesInfo']) {
+                $isOneShot = false;
             }
 
             if (null !== $authors && null !== $description && null !== $publishedDate && null !== $publisher && null !== $thumbnail && null !== $title) {

--- a/src/Service/Lookup/LookupResult.php
+++ b/src/Service/Lookup/LookupResult.php
@@ -14,12 +14,32 @@ class LookupResult implements \JsonSerializable
         public readonly ?string $description = null,
         public readonly ?string $isbn = null,
         public readonly ?bool $isOneShot = null,
+        public readonly ?int $latestPublishedIssue = null,
         public readonly ?string $publishedDate = null,
         public readonly ?string $publisher = null,
         public readonly string $source = '',
         public readonly ?string $thumbnail = null,
         public readonly ?string $title = null,
     ) {
+    }
+
+    /**
+     * Gère la désérialisation d'objets mis en cache avant l'ajout de nouvelles propriétés.
+     *
+     * @param array<string, mixed> $data
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->authors = $data['authors'] ?? null;
+        $this->description = $data['description'] ?? null;
+        $this->isbn = $data['isbn'] ?? null;
+        $this->isOneShot = $data['isOneShot'] ?? null;
+        $this->latestPublishedIssue = $data['latestPublishedIssue'] ?? null;
+        $this->publishedDate = $data['publishedDate'] ?? null;
+        $this->publisher = $data['publisher'] ?? null;
+        $this->source = $data['source'] ?? '';
+        $this->thumbnail = $data['thumbnail'] ?? null;
+        $this->title = $data['title'] ?? null;
     }
 
     /**
@@ -42,7 +62,7 @@ class LookupResult implements \JsonSerializable
      */
     public function mergeWith(self $other, array $overrideFields = []): self
     {
-        $fields = ['authors', 'description', 'isbn', 'isOneShot', 'publishedDate', 'publisher', 'thumbnail', 'title'];
+        $fields = ['authors', 'description', 'isbn', 'isOneShot', 'latestPublishedIssue', 'publishedDate', 'publisher', 'thumbnail', 'title'];
         $values = [];
 
         foreach ($fields as $field) {
@@ -58,6 +78,7 @@ class LookupResult implements \JsonSerializable
             description: $values['description'],
             isbn: $values['isbn'],
             isOneShot: $values['isOneShot'],
+            latestPublishedIssue: $values['latestPublishedIssue'],
             publishedDate: $values['publishedDate'],
             publisher: $values['publisher'],
             source: $this->source,
@@ -67,7 +88,7 @@ class LookupResult implements \JsonSerializable
     }
 
     /**
-     * @return array{authors: ?string, description: ?string, isbn: ?string, isOneShot: ?bool, publishedDate: ?string, publisher: ?string, thumbnail: ?string, title: ?string}
+     * @return array{authors: ?string, description: ?string, isbn: ?string, isOneShot: ?bool, latestPublishedIssue: ?int, publishedDate: ?string, publisher: ?string, thumbnail: ?string, title: ?string}
      */
     public function jsonSerialize(): array
     {
@@ -76,6 +97,7 @@ class LookupResult implements \JsonSerializable
             'description' => $this->description,
             'isbn' => $this->isbn,
             'isOneShot' => $this->isOneShot,
+            'latestPublishedIssue' => $this->latestPublishedIssue,
             'publishedDate' => $this->publishedDate,
             'publisher' => $this->publisher,
             'thumbnail' => $this->thumbnail,
@@ -93,6 +115,7 @@ class LookupResult implements \JsonSerializable
             description: $this->description,
             isbn: $isbn,
             isOneShot: $this->isOneShot,
+            latestPublishedIssue: $this->latestPublishedIssue,
             publishedDate: $this->publishedDate,
             publisher: $this->publisher,
             source: $this->source,

--- a/tests/Service/Lookup/AniListLookupTest.php
+++ b/tests/Service/Lookup/AniListLookupTest.php
@@ -243,6 +243,43 @@ class AniListLookupTest extends TestCase
         self::assertFalse($result->isOneShot);
     }
 
+    public function testLookupReturnsLatestPublishedIssue(): void
+    {
+        $response = new MockResponse(\json_encode([
+            'data' => [
+                'Media' => [
+                    'coverImage' => ['large' => 'https://cover.jpg'],
+                    'format' => 'MANGA',
+                    'status' => 'RELEASING',
+                    'title' => ['romaji' => 'One Piece'],
+                    'volumes' => 109,
+                ],
+            ],
+        ]));
+
+        $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
+        $result = $provider->lookup('One Piece', ComicType::MANGA, 'title');
+
+        self::assertSame(109, $result->latestPublishedIssue);
+    }
+
+    public function testLookupReturnsNullLatestPublishedIssueWhenNotAvailable(): void
+    {
+        $response = new MockResponse(\json_encode([
+            'data' => [
+                'Media' => [
+                    'coverImage' => ['large' => 'https://cover.jpg'],
+                    'title' => ['romaji' => 'Test'],
+                ],
+            ],
+        ]));
+
+        $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
+        $result = $provider->lookup('Test', ComicType::MANGA, 'title');
+
+        self::assertNull($result->latestPublishedIssue);
+    }
+
     public function testLookupCleansTitleSuffixes(): void
     {
         $requestedBodies = [];

--- a/tests/Service/Lookup/GeminiLookupTest.php
+++ b/tests/Service/Lookup/GeminiLookupTest.php
@@ -13,7 +13,6 @@ use Gemini\Testing\ClientFake;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
@@ -174,6 +173,35 @@ class GeminiLookupTest extends TestCase
         $result = $lookup->enrich($partial, null);
 
         self::assertNull($result);
+    }
+
+    public function testLookupReturnsLatestPublishedIssue(): void
+    {
+        $geminiClient = new ClientFake([
+            GenerateContentResponse::fake([
+                'candidates' => [
+                    [
+                        'content' => [
+                            'parts' => [
+                                [
+                                    'text' => \json_encode([
+                                        'authors' => 'Eiichiro Oda',
+                                        'latestPublishedIssue' => 109,
+                                        'title' => 'One Piece',
+                                    ]),
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $lookup = $this->createLookup(geminiClient: $geminiClient);
+        $result = $lookup->lookup('One Piece', ComicType::MANGA, 'title');
+
+        self::assertInstanceOf(LookupResult::class, $result);
+        self::assertSame(109, $result->latestPublishedIssue);
     }
 
     public function testLookupReturnsNullOnApiError(): void

--- a/tests/Service/Lookup/GoogleBooksLookupTest.php
+++ b/tests/Service/Lookup/GoogleBooksLookupTest.php
@@ -160,13 +160,13 @@ class GoogleBooksLookupTest extends TestCase
         self::assertSame('9781234567890', $result->isbn);
     }
 
-    public function testLookupByIsbnDetectsOneShot(): void
+    public function testLookupByIsbnReturnsNullOneShotWhenNoSeriesInfo(): void
     {
         $response = new MockResponse(\json_encode([
             'items' => [
                 [
                     'volumeInfo' => [
-                        'title' => 'One Shot Book',
+                        'title' => 'Aquablue',
                     ],
                 ],
             ],
@@ -175,7 +175,7 @@ class GoogleBooksLookupTest extends TestCase
         $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
         $result = $provider->lookup('1234567890', null, 'isbn');
 
-        self::assertTrue($result->isOneShot);
+        self::assertNull($result->isOneShot);
     }
 
     public function testLookupByIsbnDetectsSeriesAsNotOneShot(): void

--- a/tests/Service/Lookup/LookupResultTest.php
+++ b/tests/Service/Lookup/LookupResultTest.php
@@ -16,6 +16,7 @@ class LookupResultTest extends TestCase
             description: 'A great book',
             isbn: '9781234567890',
             isOneShot: false,
+            latestPublishedIssue: 10,
             publishedDate: '2020-01-01',
             publisher: 'Great Publisher',
             source: 'google_books',
@@ -27,6 +28,7 @@ class LookupResultTest extends TestCase
         self::assertSame('A great book', $result->description);
         self::assertSame('9781234567890', $result->isbn);
         self::assertFalse($result->isOneShot);
+        self::assertSame(10, $result->latestPublishedIssue);
         self::assertSame('2020-01-01', $result->publishedDate);
         self::assertSame('Great Publisher', $result->publisher);
         self::assertSame('google_books', $result->source);
@@ -42,6 +44,7 @@ class LookupResultTest extends TestCase
         self::assertNull($result->description);
         self::assertNull($result->isbn);
         self::assertNull($result->isOneShot);
+        self::assertNull($result->latestPublishedIssue);
         self::assertNull($result->publishedDate);
         self::assertNull($result->publisher);
         self::assertSame('open_library', $result->source);
@@ -77,6 +80,7 @@ class LookupResultTest extends TestCase
         $other = new LookupResult(
             authors: 'Author B',
             description: 'A description',
+            latestPublishedIssue: 15,
             publisher: 'Publisher X',
             source: 'open_library',
             thumbnail: 'https://img.jpg',
@@ -89,6 +93,7 @@ class LookupResultTest extends TestCase
         self::assertSame('My Book', $merged->title);
         // Missing fields filled from other
         self::assertSame('A description', $merged->description);
+        self::assertSame(15, $merged->latestPublishedIssue);
         self::assertSame('Publisher X', $merged->publisher);
         self::assertSame('https://img.jpg', $merged->thumbnail);
         // Source stays from base
@@ -159,12 +164,26 @@ class LookupResultTest extends TestCase
 
     public function testWithIsbnReturnsNewInstanceWithIsbn(): void
     {
-        $result = new LookupResult(source: 'test', title: 'Book');
+        $result = new LookupResult(latestPublishedIssue: 5, source: 'test', title: 'Book');
         $withIsbn = $result->withIsbn('9781234567890');
 
         self::assertNull($result->isbn);
         self::assertSame('9781234567890', $withIsbn->isbn);
         self::assertSame('Book', $withIsbn->title);
+        self::assertSame(5, $withIsbn->latestPublishedIssue);
+    }
+
+    public function testUnserializeHandlesMissingProperties(): void
+    {
+        // Simule un objet sérialisé avant l'ajout de latestPublishedIssue (cache périmé)
+        $oldSerialized = 'O:31:"App\Service\Lookup\LookupResult":9:{s:7:"authors";s:9:"Jim Davis";s:11:"description";s:7:"Un chat";s:4:"isbn";N;s:9:"isOneShot";N;s:13:"publishedDate";N;s:9:"publisher";N;s:6:"source";s:6:"gemini";s:9:"thumbnail";N;s:5:"title";s:8:"Garfield";}';
+
+        $result = \unserialize($oldSerialized);
+
+        self::assertInstanceOf(LookupResult::class, $result);
+        self::assertSame('Jim Davis', $result->authors);
+        self::assertSame('Garfield', $result->title);
+        self::assertNull($result->latestPublishedIssue);
     }
 
     public function testJsonSerializeReturnsAllFieldsExceptSource(): void
@@ -174,6 +193,7 @@ class LookupResultTest extends TestCase
             description: 'A great book',
             isbn: '9781234567890',
             isOneShot: false,
+            latestPublishedIssue: 10,
             publishedDate: '2020-01-01',
             publisher: 'Great Publisher',
             source: 'google_books',
@@ -188,6 +208,7 @@ class LookupResultTest extends TestCase
             'description' => 'A great book',
             'isbn' => '9781234567890',
             'isOneShot' => false,
+            'latestPublishedIssue' => 10,
             'publishedDate' => '2020-01-01',
             'publisher' => 'Great Publisher',
             'thumbnail' => 'https://example.com/cover.jpg',

--- a/tests/js/controllers/comic_form_controller.test.js
+++ b/tests/js/controllers/comic_form_controller.test.js
@@ -279,6 +279,7 @@ describe('comic_form_controller', () => {
                     description: 'Ninja manga',
                     isbn: null,
                     isOneShot: false,
+                    latestPublishedIssue: 72,
                     publishedDate: '1999',
                     publisher: 'Kana',
                     sources: ['google_books'],
@@ -296,6 +297,43 @@ describe('comic_form_controller', () => {
             expect(document.querySelector('[data-comic-form-target="publisher"]').value).toBe('Kana');
             expect(document.querySelector('[data-comic-form-target="description"]').value).toBe('Ninja manga');
             expect(document.querySelector('[data-comic-form-target="coverUrl"]').value).toBe('http://img.jpg');
+            expect(document.querySelector('[data-comic-form-target="latestPublishedIssue"]').value).toBe('72');
+        });
+
+        it('met à jour latestPublishedIssue même si déjà renseigné', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    latestPublishedIssue: 109,
+                    sources: ['anilist'],
+                    title: 'One Piece',
+                }),
+                ok: true,
+            });
+
+            const controller = await setup();
+            document.querySelector('[data-comic-form-target="latestPublishedIssue"]').value = '100';
+            await controller.performIsbnLookup('978-123', null);
+
+            expect(document.querySelector('[data-comic-form-target="latestPublishedIssue"]').value).toBe('109');
+        });
+
+        it('ne met pas à jour latestPublishedIssue si l\'API ne le fournit pas', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    latestPublishedIssue: null,
+                    sources: ['google_books'],
+                    title: 'Test',
+                }),
+                ok: true,
+            });
+
+            const controller = await setup();
+            document.querySelector('[data-comic-form-target="latestPublishedIssue"]').value = '5';
+            await controller.performIsbnLookup('978-123', null);
+
+            expect(document.querySelector('[data-comic-form-target="latestPublishedIssue"]').value).toBe('5');
         });
 
         it('affiche une erreur si l\'API retourne une erreur', async () => {
@@ -472,6 +510,24 @@ describe('comic_form_controller', () => {
             const flash = document.querySelector('.api-lookup-flash');
             expect(flash).not.toBeNull();
             expect(flash.textContent).toContain('Veuillez saisir un titre');
+        });
+
+        it('met à jour latestPublishedIssue même si déjà renseigné', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                json: () => Promise.resolve({
+                    apiMessages: {},
+                    latestPublishedIssue: 50,
+                    sources: ['anilist'],
+                }),
+                ok: true,
+            });
+
+            const controller = await setup();
+            document.querySelector('[data-comic-form-target="title"]').value = 'Naruto';
+            document.querySelector('[data-comic-form-target="latestPublishedIssue"]').value = '40';
+            await controller.lookupByTitle();
+
+            expect(document.querySelector('[data-comic-form-target="latestPublishedIssue"]').value).toBe('50');
         });
 
         it('pré-remplit l\'ISBN du tome si one-shot détecté', async () => {


### PR DESCRIPTION
## Summary
- Ajoute `latestPublishedIssue` au DTO `LookupResult` et à tous les providers (AniList, Gemini, Google Books)
- Force la mise à jour du champ côté frontend même s'il est déjà renseigné (`forceUpdateField`)
- Corrige la détection one-shot Google Books qui marquait les séries comme one-shot par défaut
- Gère la désérialisation d'objets en cache sérialisés avant l'ajout de la nouvelle propriété (`__unserialize`)

## Test plan
- [x] Test unitaire : `LookupResult` inclut `latestPublishedIssue` dans construction, merge, serialization JSON, et `withIsbn`
- [x] Test unitaire : désérialisation d'objets cache périmés (`testUnserializeHandlesMissingProperties`)
- [x] Test unitaire : AniList retourne `latestPublishedIssue` depuis `volumes`
- [x] Test unitaire : Gemini retourne `latestPublishedIssue`
- [x] Test unitaire : Google Books ne marque plus les séries comme one-shot par défaut
- [x] Test JS : `forceUpdateField` met à jour même si déjà renseigné
- [x] 448 tests PHP passent, 200 tests JS passent
- [x] PHP-CS-Fixer clean

fixes #50