### PR TITLE
feat(lookup): paralléliser les appels API des providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Lookup parallélisé** : Les appels API des providers sont désormais lancés en parallèle grâce au multiplexage natif de Symfony HttpClient (`curl_multi`)
+  - Interface deux phases : `prepareLookup`/`resolveLookup` (et `prepareEnrich`/`resolveEnrich` pour les enrichables)
+  - Timeout global configurable (15s par défaut) protège contre les providers lents
+  - Chaque provider en erreur est ignoré sans bloquer les autres
+  - Nouveau statut `ApiLookupStatus::TIMEOUT` pour les providers dépassant le timeout
+
 ### Added
 
 - **BnfLookup** : Nouveau provider de recherche via l'API SRU du catalogue général de la BnF

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,6 +7,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    app.lookup_global_timeout: 15.0
 
 services:
     # default configuration for services in *this* file

--- a/src/Enum/ApiLookupStatus.php
+++ b/src/Enum/ApiLookupStatus.php
@@ -13,4 +13,5 @@ enum ApiLookupStatus: string
     case NOT_FOUND = 'not_found';
     case RATE_LIMITED = 'rate_limited';
     case SUCCESS = 'success';
+    case TIMEOUT = 'timeout';
 }

--- a/src/Service/Lookup/AniListLookup.php
+++ b/src/Service/Lookup/AniListLookup.php
@@ -89,26 +89,30 @@ class AniListLookup implements LookupProviderInterface
         return 'anilist';
     }
 
-    public function lookup(string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+    public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed
     {
         $this->lastApiMessage = null;
 
         $searchTitle = $this->cleanTitle($query);
 
-        try {
-            $response = $this->httpClient->request('POST', self::API_URL, [
-                'headers' => [
-                    'Accept' => 'application/json',
-                    'Content-Type' => 'application/json',
-                ],
-                'json' => [
-                    'query' => self::GRAPHQL_QUERY,
-                    'variables' => ['search' => $searchTitle],
-                ],
-                'timeout' => 10,
-            ]);
+        return $this->httpClient->request('POST', self::API_URL, [
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+            ],
+            'json' => [
+                'query' => self::GRAPHQL_QUERY,
+                'variables' => ['search' => $searchTitle],
+            ],
+            'timeout' => 10,
+        ]);
+    }
 
-            $data = $response->toArray();
+    public function resolveLookup(mixed $state): ?LookupResult
+    {
+        /* @var \Symfony\Contracts\HttpClient\ResponseInterface $state */
+        try {
+            $data = $state->toArray();
             $media = $data['data']['Media'] ?? null;
 
             if (null === $media) {
@@ -154,9 +158,8 @@ class AniListLookup implements LookupProviderInterface
                 title: $title,
             );
         } catch (TransportExceptionInterface $e) {
-            $this->logger->error('Erreur réseau AniList pour "{title}": {error}', [
+            $this->logger->error('Erreur réseau AniList : {error}', [
                 'error' => $e->getMessage(),
-                'title' => $query,
             ]);
             $this->recordApiMessage(ApiLookupStatus::ERROR, 'Erreur de connexion');
 
@@ -168,16 +171,14 @@ class AniListLookup implements LookupProviderInterface
             } else {
                 $this->recordApiMessage(ApiLookupStatus::ERROR, \sprintf('Erreur HTTP (%d)', $code));
             }
-            $this->logger->warning('Erreur HTTP AniList pour "{title}": {error}', [
+            $this->logger->warning('Erreur HTTP AniList : {error}', [
                 'error' => $e->getMessage(),
-                'title' => $query,
             ]);
 
             return null;
         } catch (DecodingExceptionInterface $e) {
-            $this->logger->error('Réponse JSON invalide de AniList pour "{title}": {error}', [
+            $this->logger->error('Réponse JSON invalide de AniList : {error}', [
                 'error' => $e->getMessage(),
-                'title' => $query,
             ]);
             $this->recordApiMessage(ApiLookupStatus::ERROR, 'Réponse invalide');
 

--- a/src/Service/Lookup/BnfLookup.php
+++ b/src/Service/Lookup/BnfLookup.php
@@ -53,7 +53,7 @@ class BnfLookup implements LookupProviderInterface
         return 'bnf';
     }
 
-    public function lookup(string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+    public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed
     {
         $this->lastApiMessage = null;
 
@@ -61,19 +61,23 @@ class BnfLookup implements LookupProviderInterface
             ? \sprintf('bib.isbn adj "%s"', $query)
             : \sprintf('bib.title all "%s"', $query);
 
-        try {
-            $response = $this->httpClient->request('GET', self::API_URL, [
-                'query' => [
-                    'maximumRecords' => 1,
-                    'operation' => 'searchRetrieve',
-                    'query' => $sruQuery,
-                    'recordSchema' => 'dublincore',
-                    'version' => '1.2',
-                ],
-                'timeout' => 10,
-            ]);
+        return $this->httpClient->request('GET', self::API_URL, [
+            'query' => [
+                'maximumRecords' => 1,
+                'operation' => 'searchRetrieve',
+                'query' => $sruQuery,
+                'recordSchema' => 'dublincore',
+                'version' => '1.2',
+            ],
+            'timeout' => 10,
+        ]);
+    }
 
-            $content = $response->getContent();
+    public function resolveLookup(mixed $state): ?LookupResult
+    {
+        /* @var \Symfony\Contracts\HttpClient\ResponseInterface $state */
+        try {
+            $content = $state->getContent();
         } catch (TransportExceptionInterface $e) {
             $this->logger->error('Erreur réseau BnF : {error}', ['error' => $e->getMessage()]);
             $this->recordApiMessage(ApiLookupStatus::ERROR, 'Erreur de connexion');

--- a/src/Service/Lookup/EnrichableLookupProviderInterface.php
+++ b/src/Service/Lookup/EnrichableLookupProviderInterface.php
@@ -8,14 +8,25 @@ use App\Enum\ComicType;
 
 /**
  * Interface pour les providers capables d'enrichir des données existantes.
+ *
+ * Utilise un modèle deux phases (prepare/resolve) comme LookupProviderInterface.
  */
 interface EnrichableLookupProviderInterface extends LookupProviderInterface
 {
     /**
-     * Enrichit des données partielles avec des informations complémentaires.
+     * Phase 1 : prépare l'enrichissement (lance la requête).
      *
      * @param LookupResult   $partial Les données partielles à enrichir
      * @param ComicType|null $type    Le type de série
+     *
+     * @return mixed État intermédiaire
      */
-    public function enrich(LookupResult $partial, ?ComicType $type): ?LookupResult;
+    public function prepareEnrich(LookupResult $partial, ?ComicType $type): mixed;
+
+    /**
+     * Phase 2 : traite la réponse d'enrichissement.
+     *
+     * @param mixed $state État retourné par prepareEnrich()
+     */
+    public function resolveEnrich(mixed $state): ?LookupResult;
 }

--- a/src/Service/Lookup/GeminiLookup.php
+++ b/src/Service/Lookup/GeminiLookup.php
@@ -49,19 +49,6 @@ class GeminiLookup implements EnrichableLookupProviderInterface
     ) {
     }
 
-    public function enrich(LookupResult $partial, ?ComicType $type): ?LookupResult
-    {
-        $this->lastApiMessage = null;
-
-        if (null === $partial->title || '' === $partial->title) {
-            return null;
-        }
-
-        $cacheKey = 'gemini_enrich_'.\md5(\json_encode($partial->jsonSerialize()).($type?->value ?? ''));
-
-        return $this->cachedCall($cacheKey, fn () => $this->doEnrich($partial, $type));
-    }
-
     public function getLastApiMessage(): ?array
     {
         return $this->lastApiMessage;
@@ -77,13 +64,54 @@ class GeminiLookup implements EnrichableLookupProviderInterface
         return 'gemini';
     }
 
-    public function lookup(string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+    public function prepareEnrich(LookupResult $partial, ?ComicType $type): mixed
     {
         $this->lastApiMessage = null;
 
-        $cacheKey = 'gemini_'.\md5($query.$mode.($type?->value ?? ''));
+        if (null === $partial->title || '' === $partial->title) {
+            return null;
+        }
 
-        return $this->cachedCall($cacheKey, fn () => $this->doLookup($query, $type, $mode));
+        $cacheKey = 'gemini_enrich_'.\md5(\json_encode($partial->jsonSerialize()).(null !== $type ? $type->value : ''));
+
+        return $this->prepareWithCache($cacheKey, fn () => $this->buildEnrichPrompt($partial, $type));
+    }
+
+    public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed
+    {
+        $this->lastApiMessage = null;
+
+        $cacheKey = 'gemini_'.\md5($query.$mode.(null !== $type ? $type->value : ''));
+
+        return $this->prepareWithCache($cacheKey, fn () => $this->buildLookupPrompt($query, $type, $mode));
+    }
+
+    public function resolveEnrich(mixed $state): ?LookupResult
+    {
+        return $this->resolveLookup($state);
+    }
+
+    public function resolveLookup(mixed $state): ?LookupResult
+    {
+        if ($state instanceof LookupResult) {
+            return $state;
+        }
+
+        if (null === $state) {
+            return null;
+        }
+
+        /** @var array{cacheKey: string, prompt: string} $state */
+        $result = $this->callGemini($state['prompt']);
+
+        if (null !== $result) {
+            $item = $this->cache->getItem($state['cacheKey']);
+            $item->set($result);
+            $item->expiresAfter(2592000); // 30 jours
+            $this->cache->save($item);
+        }
+
+        return $result;
     }
 
     public function supports(string $mode, ?ComicType $type): bool
@@ -93,7 +121,7 @@ class GeminiLookup implements EnrichableLookupProviderInterface
 
     private function buildEnrichPrompt(LookupResult $partial, ?ComicType $type): string
     {
-        $typeLabel = $type?->value ?? 'bande dessinée/comics/manga';
+        $typeLabel = null !== $type ? $type->value : 'bande dessinée/comics/manga';
         $existingData = \json_encode(\array_filter($partial->jsonSerialize(), static fn ($v) => null !== $v));
 
         return <<<PROMPT
@@ -110,7 +138,7 @@ class GeminiLookup implements EnrichableLookupProviderInterface
 
     private function buildLookupPrompt(string $query, ?ComicType $type, string $mode): string
     {
-        $typeLabel = $type?->value ?? 'bande dessinée/comics/manga';
+        $typeLabel = null !== $type ? $type->value : 'bande dessinée/comics/manga';
         $searchBy = 'isbn' === $mode ? "l'ISBN {$query}" : "le titre \"{$query}\"";
 
         return <<<PROMPT
@@ -124,33 +152,6 @@ class GeminiLookup implements EnrichableLookupProviderInterface
             Pour le titre, retourne le titre de la SÉRIE (pas du tome individuel).
 
             PROMPT.self::JSON_INSTRUCTIONS;
-    }
-
-    /**
-     * Exécute un appel Gemini avec cache.
-     */
-    private function cachedCall(string $cacheKey, callable $callback): ?LookupResult
-    {
-        $item = $this->cache->getItem($cacheKey);
-
-        if ($item->isHit()) {
-            $cached = $item->get();
-            if ($cached instanceof LookupResult) {
-                $this->recordApiMessage(ApiLookupStatus::SUCCESS, 'Résultat depuis le cache');
-
-                return $cached;
-            }
-        }
-
-        $result = $callback();
-
-        if (null !== $result) {
-            $item->set($result);
-            $item->expiresAfter(2592000); // 30 jours
-            $this->cache->save($item);
-        }
-
-        return $result;
     }
 
     private function callGemini(string $prompt): ?LookupResult
@@ -229,26 +230,27 @@ class GeminiLookup implements EnrichableLookupProviderInterface
         return true;
     }
 
-    private function doEnrich(LookupResult $partial, ?ComicType $type): ?LookupResult
+    /**
+     * Vérifie le cache et le rate limit, retourne LookupResult|array|null.
+     */
+    private function prepareWithCache(string $cacheKey, callable $buildPrompt): mixed
     {
+        $item = $this->cache->getItem($cacheKey);
+
+        if ($item->isHit()) {
+            $cached = $item->get();
+            if ($cached instanceof LookupResult) {
+                $this->recordApiMessage(ApiLookupStatus::SUCCESS, 'Résultat depuis le cache');
+
+                return $cached;
+            }
+        }
+
         if (!$this->consumeRateLimit()) {
             return null;
         }
 
-        $prompt = $this->buildEnrichPrompt($partial, $type);
-
-        return $this->callGemini($prompt);
-    }
-
-    private function doLookup(string $query, ?ComicType $type, string $mode): ?LookupResult
-    {
-        if (!$this->consumeRateLimit()) {
-            return null;
-        }
-
-        $prompt = $this->buildLookupPrompt($query, $type, $mode);
-
-        return $this->callGemini($prompt);
+        return ['cacheKey' => $cacheKey, 'prompt' => $buildPrompt()];
     }
 
     /**

--- a/src/Service/Lookup/GoogleBooksLookup.php
+++ b/src/Service/Lookup/GoogleBooksLookup.php
@@ -47,22 +47,26 @@ class GoogleBooksLookup implements LookupProviderInterface
         return 'google_books';
     }
 
-    public function lookup(string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+    public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed
     {
         $this->lastApiMessage = null;
 
         $q = 'isbn' === $mode ? 'isbn:'.$query : $query;
 
-        try {
-            $response = $this->httpClient->request('GET', self::API_URL, [
-                'query' => [
-                    'maxResults' => 10,
-                    'q' => $q,
-                ],
-                'timeout' => 10,
-            ]);
+        return $this->httpClient->request('GET', self::API_URL, [
+            'query' => [
+                'maxResults' => 10,
+                'q' => $q,
+            ],
+            'timeout' => 10,
+        ]);
+    }
 
-            $data = $response->toArray();
+    public function resolveLookup(mixed $state): ?LookupResult
+    {
+        /* @var \Symfony\Contracts\HttpClient\ResponseInterface $state */
+        try {
+            $data = $state->toArray();
 
             if (empty($data['items'])) {
                 $this->recordApiMessage(ApiLookupStatus::NOT_FOUND, 'Aucun résultat');
@@ -75,9 +79,8 @@ class GoogleBooksLookup implements LookupProviderInterface
 
             return $result;
         } catch (TransportExceptionInterface $e) {
-            $this->logger->error('Erreur réseau Google Books pour "{query}": {error}', [
+            $this->logger->error('Erreur réseau Google Books : {error}', [
                 'error' => $e->getMessage(),
-                'query' => $query,
             ]);
             $this->recordApiMessage(ApiLookupStatus::ERROR, 'Erreur de connexion');
 
@@ -89,16 +92,14 @@ class GoogleBooksLookup implements LookupProviderInterface
             } else {
                 $this->recordApiMessage(ApiLookupStatus::ERROR, \sprintf('Erreur HTTP (%d)', $code));
             }
-            $this->logger->warning('Erreur HTTP Google Books pour "{query}": {error}', [
+            $this->logger->warning('Erreur HTTP Google Books : {error}', [
                 'error' => $e->getMessage(),
-                'query' => $query,
             ]);
 
             return null;
         } catch (DecodingExceptionInterface $e) {
-            $this->logger->error('Réponse JSON invalide de Google Books pour "{query}": {error}', [
+            $this->logger->error('Réponse JSON invalide de Google Books : {error}', [
                 'error' => $e->getMessage(),
-                'query' => $query,
             ]);
             $this->recordApiMessage(ApiLookupStatus::ERROR, 'Réponse invalide');
 

--- a/src/Service/Lookup/LookupOrchestrator.php
+++ b/src/Service/Lookup/LookupOrchestrator.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace App\Service\Lookup;
 
+use App\Enum\ApiLookupStatus;
 use App\Enum\ComicType;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
- * Coordonne les providers de lookup, fusionne les résultats et enrichit si nécessaire.
+ * Coordonne les providers de lookup en deux phases (prepare/resolve)
+ * pour exploiter le multiplexage HTTP natif de Symfony HttpClient.
  */
 class LookupOrchestrator
 {
@@ -19,9 +23,13 @@ class LookupOrchestrator
     private array $sources = [];
 
     /**
+     * @param float                             $globalTimeout Timeout global en secondes
      * @param iterable<LookupProviderInterface> $providers
      */
     public function __construct(
+        #[Autowire('%app.lookup_global_timeout%')]
+        private readonly float $globalTimeout,
+        private readonly LoggerInterface $logger,
         #[AutowireIterator('app.lookup_provider')]
         private readonly iterable $providers,
     ) {
@@ -82,24 +90,69 @@ class LookupOrchestrator
         $this->apiMessages = [];
         $this->sources = [];
 
-        /** @var list<array{LookupProviderInterface, LookupResult}> $providerResults */
-        $providerResults = [];
+        $startTime = \microtime(true);
+
+        // Phase 1 : lancer toutes les requêtes (non bloquant)
+        /** @var list<array{provider: LookupProviderInterface, state: mixed}> $prepared */
+        $prepared = [];
 
         foreach ($this->providers as $provider) {
             if (!$provider->supports($mode, $type)) {
                 continue;
             }
 
-            $result = $provider->lookup($query, $type, $mode);
-            $apiMessage = $provider->getLastApiMessage();
+            try {
+                $state = $provider->prepareLookup($query, $type, $mode);
+                $prepared[] = ['provider' => $provider, 'state' => $state];
+            } catch (\Throwable $e) {
+                $this->logger->error('Erreur prepareLookup {provider} : {error}', [
+                    'error' => $e->getMessage(),
+                    'provider' => $provider->getName(),
+                ]);
+                $this->apiMessages[$provider->getName()] = [
+                    'message' => $e->getMessage(),
+                    'status' => ApiLookupStatus::ERROR->value,
+                ];
+            }
+        }
 
-            if (null !== $apiMessage) {
-                $this->apiMessages[$provider->getName()] = $apiMessage;
+        // Phase 2 : résoudre les réponses (bloquant, avec timeout global)
+        /** @var list<array{LookupProviderInterface, LookupResult}> $providerResults */
+        $providerResults = [];
+
+        foreach ($prepared as ['provider' => $provider, 'state' => $state]) {
+            $elapsed = \microtime(true) - $startTime;
+
+            if ($elapsed >= $this->globalTimeout) {
+                $this->apiMessages[$provider->getName()] = [
+                    'message' => 'Timeout global dépassé',
+                    'status' => ApiLookupStatus::TIMEOUT->value,
+                ];
+
+                continue;
             }
 
-            if (null !== $result) {
-                $providerResults[] = [$provider, $result];
-                $this->sources[] = $provider->getName();
+            try {
+                $result = $provider->resolveLookup($state);
+                $apiMessage = $provider->getLastApiMessage();
+
+                if (null !== $apiMessage) {
+                    $this->apiMessages[$provider->getName()] = $apiMessage;
+                }
+
+                if (null !== $result) {
+                    $providerResults[] = [$provider, $result];
+                    $this->sources[] = $provider->getName();
+                }
+            } catch (\Throwable $e) {
+                $this->logger->error('Erreur resolveLookup {provider} : {error}', [
+                    'error' => $e->getMessage(),
+                    'provider' => $provider->getName(),
+                ]);
+                $this->apiMessages[$provider->getName()] = [
+                    'message' => $e->getMessage(),
+                    'status' => ApiLookupStatus::ERROR->value,
+                ];
             }
         }
 
@@ -160,33 +213,62 @@ class LookupOrchestrator
     }
 
     /**
-     * Tente d'enrichir les données via les providers enrichables.
-     *
-     * Collecte les résultats d'enrichissement puis les fusionne par priorité de champ.
-     * Les champs déjà remplis par le lookup principal sont conservés.
+     * Tente d'enrichir les données via les providers enrichables (deux phases).
      *
      * @param list<array{LookupProviderInterface, LookupResult}> $existingResults
      */
     private function tryEnrich(LookupResult $merged, array $existingResults, ?ComicType $type): LookupResult
     {
-        /** @var list<array{LookupProviderInterface, LookupResult}> $enrichResults */
-        $enrichResults = [];
+        // Phase 1 : préparer les enrichissements
+        /** @var list<array{provider: EnrichableLookupProviderInterface, state: mixed}> $prepared */
+        $prepared = [];
 
         foreach ($this->providers as $provider) {
             if (!$provider instanceof EnrichableLookupProviderInterface) {
                 continue;
             }
 
-            $enriched = $provider->enrich($merged, $type);
-            $apiMessage = $provider->getLastApiMessage();
-
-            if (null !== $apiMessage) {
-                $this->apiMessages[$provider->getName().'.enrich'] = $apiMessage;
+            try {
+                $state = $provider->prepareEnrich($merged, $type);
+                $prepared[] = ['provider' => $provider, 'state' => $state];
+            } catch (\Throwable $e) {
+                $this->logger->error('Erreur prepareEnrich {provider} : {error}', [
+                    'error' => $e->getMessage(),
+                    'provider' => $provider->getName(),
+                ]);
+                $this->apiMessages[$provider->getName().'.enrich'] = [
+                    'message' => $e->getMessage(),
+                    'status' => ApiLookupStatus::ERROR->value,
+                ];
             }
+        }
 
-            if (null !== $enriched) {
-                $enrichResults[] = [$provider, $enriched];
-                $this->sources[] = $enriched->source;
+        // Phase 2 : résoudre les enrichissements
+        /** @var list<array{LookupProviderInterface, LookupResult}> $enrichResults */
+        $enrichResults = [];
+
+        foreach ($prepared as ['provider' => $provider, 'state' => $state]) {
+            try {
+                $enriched = $provider->resolveEnrich($state);
+                $apiMessage = $provider->getLastApiMessage();
+
+                if (null !== $apiMessage) {
+                    $this->apiMessages[$provider->getName().'.enrich'] = $apiMessage;
+                }
+
+                if (null !== $enriched) {
+                    $enrichResults[] = [$provider, $enriched];
+                    $this->sources[] = $enriched->source;
+                }
+            } catch (\Throwable $e) {
+                $this->logger->error('Erreur resolveEnrich {provider} : {error}', [
+                    'error' => $e->getMessage(),
+                    'provider' => $provider->getName(),
+                ]);
+                $this->apiMessages[$provider->getName().'.enrich'] = [
+                    'message' => $e->getMessage(),
+                    'status' => ApiLookupStatus::ERROR->value,
+                ];
             }
         }
 

--- a/src/Service/Lookup/LookupProviderInterface.php
+++ b/src/Service/Lookup/LookupProviderInterface.php
@@ -8,6 +8,9 @@ use App\Enum\ComicType;
 
 /**
  * Interface pour les providers de recherche de données bibliographiques.
+ *
+ * Utilise un modèle deux phases (prepare/resolve) pour permettre
+ * le multiplexage HTTP via curl_multi de Symfony HttpClient.
  */
 interface LookupProviderInterface
 {
@@ -36,13 +39,22 @@ interface LookupProviderInterface
     public function getLastApiMessage(): ?array;
 
     /**
-     * Recherche des informations sur une série.
+     * Phase 1 : lance la requête HTTP (non bloquante) et retourne un état intermédiaire.
      *
      * @param string         $query ISBN ou titre selon le mode
      * @param ComicType|null $type  Le type de série
      * @param string         $mode  'isbn' ou 'title'
+     *
+     * @return mixed État intermédiaire (ResponseInterface, LookupResult depuis cache, null, etc.)
      */
-    public function lookup(string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult;
+    public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed;
+
+    /**
+     * Phase 2 : traite la réponse et retourne le résultat.
+     *
+     * @param mixed $state État retourné par prepareLookup()
+     */
+    public function resolveLookup(mixed $state): ?LookupResult;
 
     /**
      * Indique si le provider supporte le mode donné.

--- a/src/Service/Lookup/OpenLibraryLookup.php
+++ b/src/Service/Lookup/OpenLibraryLookup.php
@@ -47,16 +47,20 @@ class OpenLibraryLookup implements LookupProviderInterface
         return 'open_library';
     }
 
-    public function lookup(string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+    public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed
     {
         $this->lastApiMessage = null;
 
-        try {
-            $response = $this->httpClient->request('GET', self::API_URL.$query.'.json', [
-                'timeout' => 10,
-            ]);
+        return $this->httpClient->request('GET', self::API_URL.$query.'.json', [
+            'timeout' => 10,
+        ]);
+    }
 
-            $statusCode = $response->getStatusCode();
+    public function resolveLookup(mixed $state): ?LookupResult
+    {
+        /* @var \Symfony\Contracts\HttpClient\ResponseInterface $state */
+        try {
+            $statusCode = $state->getStatusCode();
 
             if (429 === $statusCode) {
                 $this->recordApiMessage(ApiLookupStatus::RATE_LIMITED, 'Quota dépassé (429)');
@@ -70,7 +74,7 @@ class OpenLibraryLookup implements LookupProviderInterface
                 return null;
             }
 
-            $data = $response->toArray();
+            $data = $state->toArray();
 
             if (empty($data['title'])) {
                 $this->recordApiMessage(ApiLookupStatus::NOT_FOUND, 'Aucun résultat');
@@ -103,9 +107,8 @@ class OpenLibraryLookup implements LookupProviderInterface
                 title: $data['title'],
             );
         } catch (TransportExceptionInterface $e) {
-            $this->logger->error('Erreur réseau Open Library pour ISBN {isbn}: {error}', [
+            $this->logger->error('Erreur réseau Open Library : {error}', [
                 'error' => $e->getMessage(),
-                'isbn' => $query,
             ]);
             $this->recordApiMessage(ApiLookupStatus::ERROR, 'Erreur de connexion');
 
@@ -117,16 +120,14 @@ class OpenLibraryLookup implements LookupProviderInterface
             } else {
                 $this->recordApiMessage(ApiLookupStatus::ERROR, \sprintf('Erreur HTTP (%d)', $code));
             }
-            $this->logger->warning('Erreur HTTP Open Library pour ISBN {isbn}: {error}', [
+            $this->logger->warning('Erreur HTTP Open Library : {error}', [
                 'error' => $e->getMessage(),
-                'isbn' => $query,
             ]);
 
             return null;
         } catch (DecodingExceptionInterface $e) {
-            $this->logger->error('Réponse JSON invalide de Open Library pour ISBN {isbn}: {error}', [
+            $this->logger->error('Réponse JSON invalide de Open Library : {error}', [
                 'error' => $e->getMessage(),
-                'isbn' => $query,
             ]);
             $this->recordApiMessage(ApiLookupStatus::ERROR, 'Réponse invalide');
 

--- a/src/Service/Lookup/WikipediaLookup.php
+++ b/src/Service/Lookup/WikipediaLookup.php
@@ -77,17 +77,6 @@ class WikipediaLookup implements EnrichableLookupProviderInterface
     ) {
     }
 
-    public function enrich(LookupResult $partial, ?ComicType $type): ?LookupResult
-    {
-        $this->lastApiMessage = null;
-
-        if (null === $partial->title || '' === $partial->title) {
-            return null;
-        }
-
-        return $this->lookup($partial->title, $type, 'title');
-    }
-
     public function getLastApiMessage(): ?array
     {
         return $this->lastApiMessage;
@@ -107,7 +96,18 @@ class WikipediaLookup implements EnrichableLookupProviderInterface
         return 'wikipedia';
     }
 
-    public function lookup(string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+    public function prepareEnrich(LookupResult $partial, ?ComicType $type): mixed
+    {
+        $this->lastApiMessage = null;
+
+        if (null === $partial->title || '' === $partial->title) {
+            return null;
+        }
+
+        return $this->prepareLookup($partial->title, $type, 'title');
+    }
+
+    public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed
     {
         $this->lastApiMessage = null;
 
@@ -124,10 +124,61 @@ class WikipediaLookup implements EnrichableLookupProviderInterface
             }
         }
 
+        if ('isbn' === $mode) {
+            $isbnProp = 13 === \strlen(\str_replace('-', '', $query)) ? 'P212' : 'P957';
+
+            $sparql = \sprintf(
+                'SELECT ?item WHERE { ?item wdt:%s "%s" . } LIMIT 1',
+                $isbnProp,
+                \addslashes($query),
+            );
+
+            $response = $this->httpClient->request('GET', self::WIKIDATA_SPARQL, [
+                'headers' => [
+                    'Accept' => 'application/sparql-results+json',
+                    'User-Agent' => self::USER_AGENT,
+                ],
+                'query' => ['query' => $sparql],
+                'timeout' => 15,
+            ]);
+        } else {
+            $response = $this->httpClient->request('GET', self::WIKIDATA_API, [
+                'headers' => ['User-Agent' => self::USER_AGENT],
+                'query' => [
+                    'action' => 'wbsearchentities',
+                    'format' => 'json',
+                    'language' => 'fr',
+                    'limit' => 5,
+                    'search' => $query,
+                    'type' => 'item',
+                ],
+                'timeout' => 10,
+            ]);
+        }
+
+        return ['cacheKey' => $cacheKey, 'mode' => $mode, 'response' => $response];
+    }
+
+    public function resolveEnrich(mixed $state): ?LookupResult
+    {
+        if (null === $state) {
+            return null;
+        }
+
+        return $this->resolveLookup($state);
+    }
+
+    public function resolveLookup(mixed $state): ?LookupResult
+    {
+        if ($state instanceof LookupResult) {
+            return $state;
+        }
+
+        /* @var array{cacheKey: string, mode: string, response: \Symfony\Contracts\HttpClient\ResponseInterface} $state */
         try {
-            $result = 'isbn' === $mode
-                ? $this->lookupByIsbn($query)
-                : $this->lookupByTitle($query);
+            $result = 'isbn' === $state['mode']
+                ? $this->resolveIsbnLookup($state['response'])
+                : $this->resolveTitleLookup($state['response']);
         } catch (ClientExceptionInterface|ServerExceptionInterface|RedirectionExceptionInterface $e) {
             $code = $e->getResponse()->getStatusCode();
             if (429 === $code) {
@@ -154,6 +205,7 @@ class WikipediaLookup implements EnrichableLookupProviderInterface
             return null;
         }
 
+        $item = $this->cache->getItem($state['cacheKey']);
         $item->set($result);
         $item->expiresAfter(self::CACHE_TTL);
         $this->cache->save($item);
@@ -401,28 +453,13 @@ class WikipediaLookup implements EnrichableLookupProviderInterface
     }
 
     /**
-     * Recherche par ISBN via SPARQL Wikidata.
+     * Traite la réponse SPARQL pour résoudre l'entité Wikidata.
      */
-    private function lookupByIsbn(string $isbn): ?LookupResult
+    /**
+     * @param \Symfony\Contracts\HttpClient\ResponseInterface $response
+     */
+    private function resolveIsbnLookup(mixed $response): ?LookupResult
     {
-        // Déterminer la propriété ISBN selon la longueur
-        $isbnProp = 13 === \strlen(\str_replace('-', '', $isbn)) ? 'P212' : 'P957';
-
-        $sparql = \sprintf(
-            'SELECT ?item WHERE { ?item wdt:%s "%s" . } LIMIT 1',
-            $isbnProp,
-            \addslashes($isbn),
-        );
-
-        $response = $this->httpClient->request('GET', self::WIKIDATA_SPARQL, [
-            'headers' => [
-                'Accept' => 'application/sparql-results+json',
-                'User-Agent' => self::USER_AGENT,
-            ],
-            'query' => ['query' => $sparql],
-            'timeout' => 15,
-        ]);
-
         $data = $response->toArray();
         $bindings = $data['results']['bindings'] ?? [];
 
@@ -432,7 +469,6 @@ class WikipediaLookup implements EnrichableLookupProviderInterface
             return null;
         }
 
-        // Extraire l'ID de l'entité depuis l'URI
         $firstBinding = $bindings[0] ?? [];
         $item = \is_array($firstBinding) && \is_array($firstBinding['item'] ?? null) ? $firstBinding['item'] : [];
         $entityUri = \is_string($item['value'] ?? null) ? $item['value'] : '';
@@ -448,23 +484,13 @@ class WikipediaLookup implements EnrichableLookupProviderInterface
     }
 
     /**
-     * Recherche par titre via wbsearchentities Wikidata.
+     * Traite la réponse wbsearchentities pour résoudre l'entité Wikidata.
      */
-    private function lookupByTitle(string $title): ?LookupResult
+    /**
+     * @param \Symfony\Contracts\HttpClient\ResponseInterface $response
+     */
+    private function resolveTitleLookup(mixed $response): ?LookupResult
     {
-        $response = $this->httpClient->request('GET', self::WIKIDATA_API, [
-            'headers' => ['User-Agent' => self::USER_AGENT],
-            'query' => [
-                'action' => 'wbsearchentities',
-                'format' => 'json',
-                'language' => 'fr',
-                'limit' => 5,
-                'search' => $title,
-                'type' => 'item',
-            ],
-            'timeout' => 10,
-        ]);
-
         $data = $response->toArray();
         $searchResults = $data['search'] ?? [];
 
@@ -474,7 +500,6 @@ class WikipediaLookup implements EnrichableLookupProviderInterface
             return null;
         }
 
-        // Tester chaque candidat pour trouver un résultat pertinent
         foreach ($searchResults as $candidate) {
             if (!\is_array($candidate)) {
                 continue;

--- a/tests/Service/Lookup/AniListLookupTest.php
+++ b/tests/Service/Lookup/AniListLookupTest.php
@@ -77,7 +77,7 @@ class AniListLookupTest extends TestCase
         ]));
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Solo Leveling', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'Solo Leveling', ComicType::MANGA, 'title');
 
         self::assertInstanceOf(LookupResult::class, $result);
         self::assertSame('Solo Leveling', $result->title);
@@ -112,7 +112,7 @@ class AniListLookupTest extends TestCase
         ]));
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Test Manga', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'Test Manga', ComicType::MANGA, 'title');
 
         self::assertSame('Writer Name, Artist Name', $result->authors);
     }
@@ -145,7 +145,7 @@ class AniListLookupTest extends TestCase
         ]));
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Test', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'Test', ComicType::MANGA, 'title');
 
         self::assertSame('Author', $result->authors);
     }
@@ -163,7 +163,7 @@ class AniListLookupTest extends TestCase
         ]));
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Test', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'Test', ComicType::MANGA, 'title');
 
         self::assertSame('2018-03-05', $result->publishedDate);
     }
@@ -181,7 +181,7 @@ class AniListLookupTest extends TestCase
         ]));
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Test', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'Test', ComicType::MANGA, 'title');
 
         self::assertSame('2020-07', $result->publishedDate);
     }
@@ -199,7 +199,7 @@ class AniListLookupTest extends TestCase
         ]));
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Test', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'Test', ComicType::MANGA, 'title');
 
         self::assertSame('2015', $result->publishedDate);
     }
@@ -217,7 +217,7 @@ class AniListLookupTest extends TestCase
         ]));
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Test', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'Test', ComicType::MANGA, 'title');
 
         self::assertTrue($result->isOneShot);
     }
@@ -237,7 +237,7 @@ class AniListLookupTest extends TestCase
         ]));
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Test', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'Test', ComicType::MANGA, 'title');
 
         self::assertTrue($result->isOneShot);
     }
@@ -257,7 +257,7 @@ class AniListLookupTest extends TestCase
         ]));
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Test', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'Test', ComicType::MANGA, 'title');
 
         self::assertFalse($result->isOneShot);
     }
@@ -277,7 +277,7 @@ class AniListLookupTest extends TestCase
         ]));
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('One Piece', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'One Piece', ComicType::MANGA, 'title');
 
         self::assertSame(109, $result->latestPublishedIssue);
     }
@@ -294,7 +294,7 @@ class AniListLookupTest extends TestCase
         ]));
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Test', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'Test', ComicType::MANGA, 'title');
 
         self::assertNull($result->latestPublishedIssue);
     }
@@ -311,7 +311,7 @@ class AniListLookupTest extends TestCase
         });
 
         $provider = new AniListLookup($mockClient, new NullLogger());
-        $provider->lookup('Solo Leveling Tome 2', ComicType::MANGA, 'title');
+        $this->doLookup($provider, 'Solo Leveling Tome 2', ComicType::MANGA, 'title');
 
         self::assertCount(1, $requestedBodies);
         $body = \json_decode($requestedBodies[0], true);
@@ -323,7 +323,7 @@ class AniListLookupTest extends TestCase
         $response = new MockResponse(\json_encode(['data' => ['Media' => null]]));
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Nonexistent Manga', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'Nonexistent Manga', ComicType::MANGA, 'title');
 
         self::assertNull($result);
         self::assertSame('not_found', $provider->getLastApiMessage()['status']);
@@ -334,7 +334,7 @@ class AniListLookupTest extends TestCase
         $response = new MockResponse('', ['error' => 'Connection failed']);
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Test', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'Test', ComicType::MANGA, 'title');
 
         self::assertNull($result);
         self::assertSame('error', $provider->getLastApiMessage()['status']);
@@ -345,7 +345,7 @@ class AniListLookupTest extends TestCase
         $response = new MockResponse('Rate limit', ['http_code' => 429]);
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Test', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'Test', ComicType::MANGA, 'title');
 
         self::assertNull($result);
         self::assertSame('rate_limited', $provider->getLastApiMessage()['status']);
@@ -367,7 +367,7 @@ class AniListLookupTest extends TestCase
         ]));
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Test', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'Test', ComicType::MANGA, 'title');
 
         self::assertSame('English Title', $result->title);
     }
@@ -388,8 +388,15 @@ class AniListLookupTest extends TestCase
         ]));
 
         $provider = new AniListLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Test', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'Test', ComicType::MANGA, 'title');
 
         self::assertSame('Romaji Title', $result->title);
+    }
+
+    private function doLookup(AniListLookup $provider, string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+    {
+        $state = $provider->prepareLookup($query, $type, $mode);
+
+        return $provider->resolveLookup($state);
     }
 }

--- a/tests/Service/Lookup/BnfLookupTest.php
+++ b/tests/Service/Lookup/BnfLookupTest.php
@@ -64,7 +64,7 @@ class BnfLookupTest extends TestCase
 
         $response = new MockResponse($xml, ['response_headers' => ['content-type' => 'text/xml']]);
         $provider = new BnfLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('9782012101333', ComicType::BD, 'isbn');
+        $result = $this->doLookup($provider, '9782012101333', ComicType::BD, 'isbn');
 
         self::assertInstanceOf(LookupResult::class, $result);
         self::assertSame('Astérix le Gaulois', $result->title);
@@ -86,7 +86,7 @@ class BnfLookupTest extends TestCase
 
         $response = new MockResponse($xml, ['response_headers' => ['content-type' => 'text/xml']]);
         $provider = new BnfLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('One Piece', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'One Piece', ComicType::MANGA, 'title');
 
         self::assertInstanceOf(LookupResult::class, $result);
         self::assertSame('One Piece. 56', $result->title);
@@ -105,7 +105,7 @@ class BnfLookupTest extends TestCase
 
         $response = new MockResponse($xml, ['response_headers' => ['content-type' => 'text/xml']]);
         $provider = new BnfLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('9782723428071', null, 'isbn');
+        $result = $this->doLookup($provider, '9782723428071', null, 'isbn');
 
         self::assertSame('La colère du papillon', $result->title);
     }
@@ -121,7 +121,7 @@ class BnfLookupTest extends TestCase
 
         $response = new MockResponse($xml, ['response_headers' => ['content-type' => 'text/xml']]);
         $provider = new BnfLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('9782203001190', null, 'isbn');
+        $result = $this->doLookup($provider, '9782203001190', null, 'isbn');
 
         self::assertSame('Hergé, Yves Rodier', $result->authors);
         self::assertSame('Casterman', $result->publisher);
@@ -137,7 +137,7 @@ class BnfLookupTest extends TestCase
 
         $response = new MockResponse($xml, ['response_headers' => ['content-type' => 'text/xml']]);
         $provider = new BnfLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('test', null, 'title');
+        $result = $this->doLookup($provider, 'test', null, 'title');
 
         self::assertSame('Hergé', $result->authors);
     }
@@ -155,7 +155,7 @@ XML;
 
         $response = new MockResponse($xml, ['response_headers' => ['content-type' => 'text/xml']]);
         $provider = new BnfLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('0000000000000', null, 'isbn');
+        $result = $this->doLookup($provider, '0000000000000', null, 'isbn');
 
         self::assertNull($result);
         self::assertSame('not_found', $provider->getLastApiMessage()['status']);
@@ -166,7 +166,7 @@ XML;
         $response = new MockResponse('', ['error' => 'Connection failed']);
 
         $provider = new BnfLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('9782012101333', null, 'isbn');
+        $result = $this->doLookup($provider, '9782012101333', null, 'isbn');
 
         self::assertNull($result);
         self::assertSame('error', $provider->getLastApiMessage()['status']);
@@ -177,7 +177,7 @@ XML;
         $response = new MockResponse('not xml at all', ['response_headers' => ['content-type' => 'text/xml']]);
 
         $provider = new BnfLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('9782012101333', null, 'isbn');
+        $result = $this->doLookup($provider, '9782012101333', null, 'isbn');
 
         self::assertNull($result);
         self::assertSame('error', $provider->getLastApiMessage()['status']);
@@ -192,7 +192,7 @@ XML;
 
         $response = new MockResponse($xml, ['response_headers' => ['content-type' => 'text/xml']]);
         $provider = new BnfLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('test', null, 'title');
+        $result = $this->doLookup($provider, 'test', null, 'title');
 
         self::assertSame('978-2-01-210133-3', $result->isbn);
     }
@@ -206,10 +206,17 @@ XML;
 
         $response = new MockResponse($xml, ['response_headers' => ['content-type' => 'text/xml']]);
         $provider = new BnfLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('test', null, 'isbn');
+        $result = $this->doLookup($provider, 'test', null, 'isbn');
 
         self::assertNull($result);
         self::assertSame('not_found', $provider->getLastApiMessage()['status']);
+    }
+
+    private function doLookup(BnfLookup $provider, string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+    {
+        $state = $provider->prepareLookup($query, $type, $mode);
+
+        return $provider->resolveLookup($state);
     }
 
     /**

--- a/tests/Service/Lookup/GeminiLookupTest.php
+++ b/tests/Service/Lookup/GeminiLookupTest.php
@@ -69,7 +69,7 @@ class GeminiLookupTest extends TestCase
         ]);
 
         $lookup = $this->createLookup(geminiClient: $geminiClient);
-        $result = $lookup->lookup('9782811607418', ComicType::MANGA, 'isbn');
+        $result = $this->doLookup($lookup, '9782811607418', ComicType::MANGA, 'isbn');
 
         self::assertInstanceOf(LookupResult::class, $result);
         self::assertSame('Hajime Isayama', $result->authors);
@@ -105,7 +105,7 @@ class GeminiLookupTest extends TestCase
         ]);
 
         $lookup = $this->createLookup(geminiClient: $geminiClient);
-        $result = $lookup->lookup('One Piece', ComicType::MANGA, 'title');
+        $result = $this->doLookup($lookup, 'One Piece', ComicType::MANGA, 'title');
 
         self::assertInstanceOf(LookupResult::class, $result);
         self::assertSame('Eiichiro Oda', $result->authors);
@@ -129,7 +129,7 @@ class GeminiLookupTest extends TestCase
         ]);
 
         $lookup = $this->createLookup(geminiClient: $geminiClient);
-        $result = $lookup->lookup('Garfield', null, 'title');
+        $result = $this->doLookup($lookup, 'Garfield', null, 'title');
 
         self::assertInstanceOf(LookupResult::class, $result);
         self::assertSame('Garfield', $result->title);
@@ -165,7 +165,7 @@ class GeminiLookupTest extends TestCase
         );
 
         $lookup = $this->createLookup(geminiClient: $geminiClient);
-        $result = $lookup->enrich($partial, ComicType::MANGA);
+        $result = $this->doEnrich($lookup, $partial, ComicType::MANGA);
 
         self::assertInstanceOf(LookupResult::class, $result);
         self::assertSame('Hajime Isayama', $result->authors);
@@ -179,7 +179,7 @@ class GeminiLookupTest extends TestCase
         $lookup = $this->createLookup();
         $partial = new LookupResult(source: 'google_books');
 
-        $result = $lookup->enrich($partial, null);
+        $result = $this->doEnrich($lookup, $partial, null);
 
         self::assertNull($result);
     }
@@ -207,7 +207,7 @@ class GeminiLookupTest extends TestCase
         ]);
 
         $lookup = $this->createLookup(geminiClient: $geminiClient);
-        $result = $lookup->lookup('One Piece', ComicType::MANGA, 'title');
+        $result = $this->doLookup($lookup, 'One Piece', ComicType::MANGA, 'title');
 
         self::assertInstanceOf(LookupResult::class, $result);
         self::assertSame(109, $result->latestPublishedIssue);
@@ -220,7 +220,7 @@ class GeminiLookupTest extends TestCase
         ]);
 
         $lookup = $this->createLookup(geminiClient: $geminiClient);
-        $result = $lookup->lookup('9781234567890', null, 'isbn');
+        $result = $this->doLookup($lookup, '9781234567890', null, 'isbn');
 
         self::assertNull($result);
         self::assertNotNull($lookup->getLastApiMessage());
@@ -235,7 +235,7 @@ class GeminiLookupTest extends TestCase
         ]);
 
         $lookup = $this->createLookup(geminiClient: $geminiClient);
-        $result = $lookup->lookup('9781234567890', null, 'isbn');
+        $result = $this->doLookup($lookup, '9781234567890', null, 'isbn');
 
         self::assertNull($result);
         self::assertNotNull($lookup->getLastApiMessage());
@@ -274,10 +274,10 @@ class GeminiLookupTest extends TestCase
         $lookup = $this->createLookup(geminiClient: $geminiClient, limiterFactory: $limiterFactory);
 
         // Premier appel : consomme le quota (limit=1)
-        $lookup->lookup('isbn1', null, 'isbn');
+        $this->doLookup($lookup, 'isbn1', null, 'isbn');
 
         // Deuxième appel : rate limited
-        $result = $lookup->lookup('isbn2', null, 'isbn');
+        $result = $this->doLookup($lookup, 'isbn2', null, 'isbn');
 
         self::assertNull($result);
         self::assertNotNull($lookup->getLastApiMessage());
@@ -308,9 +308,9 @@ class GeminiLookupTest extends TestCase
         $lookup = $this->createLookup(geminiClient: $geminiClient);
 
         // Premier appel
-        $result1 = $lookup->lookup('9781234567890', null, 'isbn');
+        $result1 = $this->doLookup($lookup, '9781234567890', null, 'isbn');
         // Deuxième appel (même query) — doit venir du cache
-        $result2 = $lookup->lookup('9781234567890', null, 'isbn');
+        $result2 = $this->doLookup($lookup, '9781234567890', null, 'isbn');
 
         self::assertInstanceOf(LookupResult::class, $result1);
         self::assertInstanceOf(LookupResult::class, $result2);
@@ -337,11 +337,25 @@ class GeminiLookupTest extends TestCase
         ]);
 
         $lookup = $this->createLookup(geminiClient: $geminiClient);
-        $result = $lookup->lookup('9781234567890', null, 'isbn');
+        $result = $this->doLookup($lookup, '9781234567890', null, 'isbn');
 
         self::assertNull($result);
         self::assertNotNull($lookup->getLastApiMessage());
         self::assertSame('not_found', $lookup->getLastApiMessage()['status']);
+    }
+
+    private function doEnrich(GeminiLookup $lookup, LookupResult $partial, ?ComicType $type): ?LookupResult
+    {
+        $state = $lookup->prepareEnrich($partial, $type);
+
+        return $lookup->resolveEnrich($state);
+    }
+
+    private function doLookup(GeminiLookup $lookup, string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+    {
+        $state = $lookup->prepareLookup($query, $type, $mode);
+
+        return $lookup->resolveLookup($state);
     }
 
     private function createLookup(

--- a/tests/Service/Lookup/GoogleBooksLookupTest.php
+++ b/tests/Service/Lookup/GoogleBooksLookupTest.php
@@ -60,7 +60,7 @@ class GoogleBooksLookupTest extends TestCase
         ]));
 
         $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('9781234567890', null, 'isbn');
+        $result = $this->doLookup($provider, '9781234567890', null, 'isbn');
 
         self::assertInstanceOf(LookupResult::class, $result);
         self::assertSame('Test Book', $result->title);
@@ -96,7 +96,7 @@ class GoogleBooksLookupTest extends TestCase
         ]));
 
         $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('2800152850', null, 'isbn');
+        $result = $this->doLookup($provider, '2800152850', null, 'isbn');
 
         self::assertNotNull($result);
         self::assertSame('L\'Agent 212', $result->title);
@@ -122,7 +122,7 @@ class GoogleBooksLookupTest extends TestCase
         ]));
 
         $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('1234567890', null, 'isbn');
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
 
         self::assertSame('https://example.com/large.jpg', $result->thumbnail);
     }
@@ -143,7 +143,7 @@ class GoogleBooksLookupTest extends TestCase
         ]));
 
         $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('1234567890', null, 'isbn');
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
 
         self::assertSame('https://example.com/small.jpg', $result->thumbnail);
     }
@@ -165,7 +165,7 @@ class GoogleBooksLookupTest extends TestCase
         ]));
 
         $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('1234567890', null, 'isbn');
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
 
         self::assertSame('9781234567890', $result->isbn);
     }
@@ -183,7 +183,7 @@ class GoogleBooksLookupTest extends TestCase
         ]));
 
         $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('1234567890', null, 'isbn');
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
 
         self::assertNull($result->isOneShot);
     }
@@ -202,7 +202,7 @@ class GoogleBooksLookupTest extends TestCase
         ]));
 
         $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('1234567890', null, 'isbn');
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
 
         self::assertFalse($result->isOneShot);
     }
@@ -221,7 +221,7 @@ class GoogleBooksLookupTest extends TestCase
         ]));
 
         $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('Found by Title', null, 'title');
+        $result = $this->doLookup($provider, 'Found by Title', null, 'title');
 
         self::assertNotNull($result);
         self::assertSame('Found by Title', $result->title);
@@ -240,7 +240,7 @@ class GoogleBooksLookupTest extends TestCase
         });
 
         $provider = new GoogleBooksLookup($mockClient, new NullLogger());
-        $provider->lookup('9781234567890', null, 'isbn');
+        $this->doLookup($provider, '9781234567890', null, 'isbn');
 
         self::assertCount(1, $requestedUrls);
         self::assertStringContainsString('isbn:9781234567890', $requestedUrls[0]);
@@ -258,7 +258,7 @@ class GoogleBooksLookupTest extends TestCase
         });
 
         $provider = new GoogleBooksLookup($mockClient, new NullLogger());
-        $provider->lookup('My Book Title', null, 'title');
+        $this->doLookup($provider, 'My Book Title', null, 'title');
 
         self::assertCount(1, $requestedUrls);
         self::assertStringNotContainsString('isbn:', $requestedUrls[0]);
@@ -270,7 +270,7 @@ class GoogleBooksLookupTest extends TestCase
         $response = new MockResponse(\json_encode(['items' => []]));
 
         $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('0000000000', null, 'isbn');
+        $result = $this->doLookup($provider, '0000000000', null, 'isbn');
 
         self::assertNull($result);
         self::assertNotNull($provider->getLastApiMessage());
@@ -282,7 +282,7 @@ class GoogleBooksLookupTest extends TestCase
         $response = new MockResponse('', ['error' => 'Connection failed']);
 
         $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('1234567890', null, 'isbn');
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
 
         self::assertNull($result);
         self::assertSame('error', $provider->getLastApiMessage()['status']);
@@ -293,7 +293,7 @@ class GoogleBooksLookupTest extends TestCase
         $response = new MockResponse('Rate limit exceeded', ['http_code' => 429]);
 
         $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('1234567890', null, 'isbn');
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
 
         self::assertNull($result);
         self::assertSame('rate_limited', $provider->getLastApiMessage()['status']);
@@ -304,7 +304,7 @@ class GoogleBooksLookupTest extends TestCase
         $response = new MockResponse('Internal Server Error', ['http_code' => 500]);
 
         $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('1234567890', null, 'isbn');
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
 
         self::assertNull($result);
         self::assertSame('error', $provider->getLastApiMessage()['status']);
@@ -315,9 +315,16 @@ class GoogleBooksLookupTest extends TestCase
         $response = new MockResponse('not json', ['http_code' => 200]);
 
         $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('1234567890', null, 'isbn');
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
 
         self::assertNull($result);
         self::assertSame('error', $provider->getLastApiMessage()['status']);
+    }
+
+    private function doLookup(GoogleBooksLookup $provider, string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+    {
+        $state = $provider->prepareLookup($query, $type, $mode);
+
+        return $provider->resolveLookup($state);
     }
 }

--- a/tests/Service/Lookup/LookupOrchestratorTest.php
+++ b/tests/Service/Lookup/LookupOrchestratorTest.php
@@ -10,6 +10,7 @@ use App\Service\Lookup\LookupOrchestrator;
 use App\Service\Lookup\LookupProviderInterface;
 use App\Service\Lookup\LookupResult;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 class LookupOrchestratorTest extends TestCase
 {
@@ -24,7 +25,7 @@ class LookupOrchestratorTest extends TestCase
             source: 'open_library',
         ));
 
-        $orchestrator = new LookupOrchestrator([$google, $openLibrary]);
+        $orchestrator = $this->createOrchestrator([$google, $openLibrary]);
         $result = $orchestrator->lookup('9781234567890');
 
         self::assertNotNull($result);
@@ -47,7 +48,7 @@ class LookupOrchestratorTest extends TestCase
             thumbnail: 'https://ol.jpg',
         ));
 
-        $orchestrator = new LookupOrchestrator([$google, $openLibrary]);
+        $orchestrator = $this->createOrchestrator([$google, $openLibrary]);
         $result = $orchestrator->lookup('9781234567890');
 
         self::assertNotNull($result);
@@ -65,7 +66,7 @@ class LookupOrchestratorTest extends TestCase
         $google = $this->createProvider('google_books', ['isbn'], null);
         $openLibrary = $this->createProvider('open_library', ['isbn'], null);
 
-        $orchestrator = new LookupOrchestrator([$google, $openLibrary]);
+        $orchestrator = $this->createOrchestrator([$google, $openLibrary]);
         $result = $orchestrator->lookup('0000000000');
 
         self::assertNull($result);
@@ -73,7 +74,7 @@ class LookupOrchestratorTest extends TestCase
 
     public function testLookupByIsbnWithEmptyQueryReturnsNull(): void
     {
-        $orchestrator = new LookupOrchestrator([]);
+        $orchestrator = $this->createOrchestrator([]);
 
         self::assertNull($orchestrator->lookup(''));
         self::assertNull($orchestrator->lookup('   '));
@@ -87,7 +88,7 @@ class LookupOrchestratorTest extends TestCase
             title: 'Test',
         ), $queryCaptured);
 
-        $orchestrator = new LookupOrchestrator([$google]);
+        $orchestrator = $this->createOrchestrator([$google]);
         $orchestrator->lookup('978-2-505-00123-4');
 
         self::assertSame('9782505001234', $queryCaptured);
@@ -100,7 +101,7 @@ class LookupOrchestratorTest extends TestCase
             title: 'Test',
         ));
 
-        $orchestrator = new LookupOrchestrator([$google]);
+        $orchestrator = $this->createOrchestrator([$google]);
         $result = $orchestrator->lookup('9781234567890');
 
         self::assertSame('9781234567890', $result->isbn);
@@ -118,7 +119,7 @@ class LookupOrchestratorTest extends TestCase
             thumbnail: 'https://anilist.jpg',
         ), ComicType::MANGA);
 
-        $orchestrator = new LookupOrchestrator([$google, $anilist]);
+        $orchestrator = $this->createOrchestrator([$google, $anilist]);
         $result = $orchestrator->lookupByTitle('Test Manga', ComicType::MANGA);
 
         self::assertNotNull($result);
@@ -138,7 +139,7 @@ class LookupOrchestratorTest extends TestCase
             thumbnail: 'https://anilist.jpg',
         ), requiredType: ComicType::MANGA, defaultPriority: 60, fieldPriorities: ['isOneShot' => 200, 'thumbnail' => 200]);
 
-        $orchestrator = new LookupOrchestrator([$google, $anilist]);
+        $orchestrator = $this->createOrchestrator([$google, $anilist]);
         $result = $orchestrator->lookupByTitle('Manga', ComicType::MANGA);
 
         self::assertSame('https://anilist.jpg', $result->thumbnail);
@@ -156,7 +157,7 @@ class LookupOrchestratorTest extends TestCase
             source: 'anilist',
         ), requiredType: ComicType::MANGA, defaultPriority: 60, fieldPriorities: ['isOneShot' => 200, 'thumbnail' => 200]);
 
-        $orchestrator = new LookupOrchestrator([$google, $anilist]);
+        $orchestrator = $this->createOrchestrator([$google, $anilist]);
         $result = $orchestrator->lookupByTitle('Manga', ComicType::MANGA);
 
         self::assertFalse($result->isOneShot);
@@ -176,7 +177,7 @@ class LookupOrchestratorTest extends TestCase
             source: 'anilist',
         ), requiredType: ComicType::MANGA, defaultPriority: 60, fieldPriorities: ['isOneShot' => 200, 'thumbnail' => 200]);
 
-        $orchestrator = new LookupOrchestrator([$google, $anilist]);
+        $orchestrator = $this->createOrchestrator([$google, $anilist]);
         $result = $orchestrator->lookupByTitle('Manga', ComicType::MANGA);
 
         self::assertSame('Google Author', $result->authors);
@@ -195,7 +196,7 @@ class LookupOrchestratorTest extends TestCase
             source: 'open_library',
         ));
 
-        $orchestrator = new LookupOrchestrator([$google, $openLibrary]);
+        $orchestrator = $this->createOrchestrator([$google, $openLibrary]);
         $result = $orchestrator->lookupByTitle('Test');
 
         self::assertNull($result->publisher);
@@ -209,7 +210,7 @@ class LookupOrchestratorTest extends TestCase
         ), null, ['message' => 'Données trouvées', 'status' => 'success']);
         $openLibrary = $this->createProvider('open_library', ['isbn'], null, null, ['message' => 'Aucun résultat', 'status' => 'not_found']);
 
-        $orchestrator = new LookupOrchestrator([$google, $openLibrary]);
+        $orchestrator = $this->createOrchestrator([$google, $openLibrary]);
         $orchestrator->lookup('1234567890');
 
         $messages = $orchestrator->getLastApiMessages();
@@ -226,7 +227,7 @@ class LookupOrchestratorTest extends TestCase
             title: 'Test',
         ), null, ['message' => 'Données trouvées', 'status' => 'success']);
 
-        $orchestrator = new LookupOrchestrator([$google]);
+        $orchestrator = $this->createOrchestrator([$google]);
         $orchestrator->lookup('1111111111');
         self::assertNotEmpty($orchestrator->getLastApiMessages());
 
@@ -247,7 +248,7 @@ class LookupOrchestratorTest extends TestCase
             source: 'gemini',
         ));
 
-        $orchestrator = new LookupOrchestrator([$google, $enrichable]);
+        $orchestrator = $this->createOrchestrator([$google, $enrichable]);
         $result = $orchestrator->lookup('1234567890');
 
         self::assertNotNull($result);
@@ -271,7 +272,7 @@ class LookupOrchestratorTest extends TestCase
         $enrichCalled = false;
         $enrichable = $this->createEnrichableProvider('gemini', ['isbn'], null, null, $enrichCalled);
 
-        $orchestrator = new LookupOrchestrator([$google, $enrichable]);
+        $orchestrator = $this->createOrchestrator([$google, $enrichable]);
         $result = $orchestrator->lookup('1234567890');
 
         self::assertNotNull($result);
@@ -286,7 +287,7 @@ class LookupOrchestratorTest extends TestCase
             title: 'OL Book',
         ));
 
-        $orchestrator = new LookupOrchestrator([$google, $openLibrary]);
+        $orchestrator = $this->createOrchestrator([$google, $openLibrary]);
         $result = $orchestrator->lookup('1234567890');
 
         self::assertNotNull($result);
@@ -304,7 +305,7 @@ class LookupOrchestratorTest extends TestCase
             source: 'open_library',
         ));
 
-        $orchestrator = new LookupOrchestrator([$google, $openLibrary]);
+        $orchestrator = $this->createOrchestrator([$google, $openLibrary]);
         $result = $orchestrator->lookup('1234567890');
 
         $sources = $orchestrator->getLastSources();
@@ -314,7 +315,7 @@ class LookupOrchestratorTest extends TestCase
 
     public function testLookupByTitleWithEmptyQueryReturnsNull(): void
     {
-        $orchestrator = new LookupOrchestrator([]);
+        $orchestrator = $this->createOrchestrator([]);
 
         self::assertNull($orchestrator->lookupByTitle(''));
         self::assertNull($orchestrator->lookupByTitle('   '));
@@ -338,7 +339,7 @@ class LookupOrchestratorTest extends TestCase
             title: 'Title B',
         ), defaultPriority: 50);
 
-        $orchestrator = new LookupOrchestrator([$providerA, $providerB]);
+        $orchestrator = $this->createOrchestrator([$providerA, $providerB]);
         $result = $orchestrator->lookup('9781234567890');
 
         self::assertNotNull($result);
@@ -364,7 +365,7 @@ class LookupOrchestratorTest extends TestCase
             source: 'google_books',
         ), defaultPriority: 100);
 
-        $orchestrator = new LookupOrchestrator([$wikipedia, $google]);
+        $orchestrator = $this->createOrchestrator([$wikipedia, $google]);
         $result = $orchestrator->lookup('9781234567890');
 
         self::assertNotNull($result);
@@ -389,7 +390,7 @@ class LookupOrchestratorTest extends TestCase
             source: 'google_books',
         ), defaultPriority: 100);
 
-        $orchestrator = new LookupOrchestrator([$wikipedia, $google]);
+        $orchestrator = $this->createOrchestrator([$wikipedia, $google]);
         $result = $orchestrator->lookup('9781234567890');
 
         self::assertNotNull($result);
@@ -424,7 +425,7 @@ class LookupOrchestratorTest extends TestCase
             defaultPriority: 40,
         );
 
-        $orchestrator = new LookupOrchestrator([$google, $wikipedia, $gemini]);
+        $orchestrator = $this->createOrchestrator([$google, $wikipedia, $gemini]);
         $result = $orchestrator->lookup('1234567890');
 
         self::assertNotNull($result);
@@ -451,7 +452,7 @@ class LookupOrchestratorTest extends TestCase
             source: 'gemini',
         ), $callOrder);
 
-        $orchestrator = new LookupOrchestrator([$google, $openLibrary, $gemini]);
+        $orchestrator = $this->createOrchestrator([$google, $openLibrary, $gemini]);
         $orchestrator->lookup('9781234567890');
 
         self::assertSame(['google_books', 'open_library', 'gemini'], $callOrder);
@@ -470,7 +471,7 @@ class LookupOrchestratorTest extends TestCase
             source: 'gemini',
         ));
 
-        $orchestrator = new LookupOrchestrator([$google, $gemini]);
+        $orchestrator = $this->createOrchestrator([$google, $gemini]);
         $result = $orchestrator->lookup('1234567890');
 
         self::assertNotNull($result);
@@ -495,7 +496,7 @@ class LookupOrchestratorTest extends TestCase
         $enrichCalled = false;
         $gemini = $this->createEnrichableProvider('gemini', ['isbn'], null, null, $enrichCalled);
 
-        $orchestrator = new LookupOrchestrator([$google, $gemini]);
+        $orchestrator = $this->createOrchestrator([$google, $gemini]);
         $orchestrator->lookup('1234567890');
 
         self::assertFalse($enrichCalled);
@@ -511,7 +512,7 @@ class LookupOrchestratorTest extends TestCase
             title: 'Found by Gemini',
         ), null);
 
-        $orchestrator = new LookupOrchestrator([$google, $openLibrary, $gemini]);
+        $orchestrator = $this->createOrchestrator([$google, $openLibrary, $gemini]);
         $result = $orchestrator->lookup('1234567890');
 
         self::assertNotNull($result);
@@ -528,14 +529,93 @@ class LookupOrchestratorTest extends TestCase
         // Gemini renvoie null en lookup (erreur) et ne casse pas le résultat
         $gemini = $this->createEnrichableProvider('gemini', ['isbn'], null, null);
 
-        $orchestrator = new LookupOrchestrator([$google, $gemini]);
+        $orchestrator = $this->createOrchestrator([$google, $gemini]);
         $result = $orchestrator->lookup('1234567890');
 
         self::assertNotNull($result);
         self::assertSame('Google Book', $result->title);
     }
 
+    // --- Error handling tests (two-phase) ---
+
+    public function testPrepareLookupExceptionSkipsProviderAndContinues(): void
+    {
+        $failing = $this->createThrowingProvider('failing_provider', ['isbn'], throwOnPrepare: true);
+        $working = $this->createProvider('working_provider', ['isbn'], new LookupResult(
+            source: 'working_provider',
+            title: 'Working Title',
+        ));
+
+        $orchestrator = $this->createOrchestrator([$failing, $working]);
+        $result = $orchestrator->lookup('1234567890');
+
+        self::assertNotNull($result);
+        self::assertSame('Working Title', $result->title);
+
+        // Le provider en erreur doit avoir un message API ERROR
+        $messages = $orchestrator->getLastApiMessages();
+        self::assertArrayHasKey('failing_provider', $messages);
+        self::assertSame('error', $messages['failing_provider']['status']);
+    }
+
+    public function testResolveLookupExceptionSkipsProviderAndContinues(): void
+    {
+        $failing = $this->createThrowingProvider('failing_provider', ['isbn'], throwOnResolve: true);
+        $working = $this->createProvider('working_provider', ['isbn'], new LookupResult(
+            source: 'working_provider',
+            title: 'Working Title',
+        ));
+
+        $orchestrator = $this->createOrchestrator([$failing, $working]);
+        $result = $orchestrator->lookup('1234567890');
+
+        self::assertNotNull($result);
+        self::assertSame('Working Title', $result->title);
+
+        $messages = $orchestrator->getLastApiMessages();
+        self::assertArrayHasKey('failing_provider', $messages);
+        self::assertSame('error', $messages['failing_provider']['status']);
+    }
+
+    public function testGlobalTimeoutSkipsRemainingProviders(): void
+    {
+        // Le premier provider consomme le budget de timeout
+        $slow = $this->createSlowProvider('slow_provider', ['isbn'], new LookupResult(
+            source: 'slow_provider',
+            title: 'Slow Title',
+        ), resolveDelay: 0.2);
+        // Le second provider n'aura plus le temps d'être résolu
+        $late = $this->createProvider('late_provider', ['isbn'], new LookupResult(
+            source: 'late_provider',
+            title: 'Late Title',
+        ));
+
+        // Timeout de 0.1s → slow_provider résout (check passe avant resolve),
+        // puis late_provider est skippé car le budget est épuisé
+        $orchestrator = $this->createOrchestrator([$slow, $late], globalTimeout: 0.1);
+        $result = $orchestrator->lookup('1234567890');
+
+        self::assertNotNull($result);
+        self::assertSame('Slow Title', $result->title);
+
+        $messages = $orchestrator->getLastApiMessages();
+        self::assertArrayHasKey('late_provider', $messages);
+        self::assertSame('timeout', $messages['late_provider']['status']);
+    }
+
     // --- Helper methods ---
+
+    /**
+     * @param list<LookupProviderInterface> $providers
+     */
+    private function createOrchestrator(array $providers, float $globalTimeout = 15.0): LookupOrchestrator
+    {
+        return new LookupOrchestrator(
+            globalTimeout: $globalTimeout,
+            logger: new NullLogger(),
+            providers: $providers,
+        );
+    }
 
     /**
      * @param list<string>                                $supportedModes
@@ -578,9 +658,14 @@ class LookupOrchestratorTest extends TestCase
                 return $this->name;
             }
 
-            public function lookup(string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+            public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed
             {
-                return $this->result;
+                return ['result' => $this->result];
+            }
+
+            public function resolveLookup(mixed $state): ?LookupResult
+            {
+                return $state['result'] ?? null;
             }
 
             public function supports(string $mode, ?ComicType $type): bool
@@ -595,7 +680,7 @@ class LookupOrchestratorTest extends TestCase
     }
 
     /**
-     * @param list<string>  $supportedModes
+     * @param list<string> $supportedModes
      * @param list<string> &$callOrder
      */
     private function createOrderTrackingProvider(
@@ -628,11 +713,16 @@ class LookupOrchestratorTest extends TestCase
                 return $this->name;
             }
 
-            public function lookup(string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+            public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed
             {
                 $this->callOrder[] = $this->name;
 
-                return $this->result;
+                return ['result' => $this->result];
+            }
+
+            public function resolveLookup(mixed $state): ?LookupResult
+            {
+                return $state['result'] ?? null;
             }
 
             public function supports(string $mode, ?ComicType $type): bool
@@ -675,11 +765,16 @@ class LookupOrchestratorTest extends TestCase
                 return $this->name;
             }
 
-            public function lookup(string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+            public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed
             {
                 $this->capturedQuery = $query;
 
-                return $this->result;
+                return ['result' => $this->result];
+            }
+
+            public function resolveLookup(mixed $state): ?LookupResult
+            {
+                return $state['result'] ?? null;
             }
 
             public function supports(string $mode, ?ComicType $type): bool
@@ -690,8 +785,8 @@ class LookupOrchestratorTest extends TestCase
     }
 
     /**
-     * @param list<string>        $supportedModes
-     * @param array<string, int>  $fieldPriorities
+     * @param list<string>       $supportedModes
+     * @param array<string, int> $fieldPriorities
      */
     private function createEnrichableProvider(
         string $name,
@@ -714,13 +809,6 @@ class LookupOrchestratorTest extends TestCase
             ) {
             }
 
-            public function enrich(LookupResult $partial, ?ComicType $type): ?LookupResult
-            {
-                $this->enrichCalled = true;
-
-                return $this->enrichResult;
-            }
-
             public function getFieldPriority(string $field, ?ComicType $type = null): int
             {
                 return $this->fieldPriorities[$field] ?? $this->defaultPriority;
@@ -736,9 +824,140 @@ class LookupOrchestratorTest extends TestCase
                 return $this->name;
             }
 
-            public function lookup(string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+            public function prepareEnrich(LookupResult $partial, ?ComicType $type): mixed
             {
-                return $this->lookupResult;
+                $this->enrichCalled = true;
+
+                return ['result' => $this->enrichResult];
+            }
+
+            public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed
+            {
+                return ['result' => $this->lookupResult];
+            }
+
+            public function resolveEnrich(mixed $state): ?LookupResult
+            {
+                return $state['result'] ?? null;
+            }
+
+            public function resolveLookup(mixed $state): ?LookupResult
+            {
+                return $state['result'] ?? null;
+            }
+
+            public function supports(string $mode, ?ComicType $type): bool
+            {
+                return \in_array($mode, $this->supportedModes, true);
+            }
+        };
+    }
+
+    /**
+     * Crée un provider qui lance une exception dans prepareLookup ou resolveLookup.
+     *
+     * @param list<string> $supportedModes
+     */
+    private function createThrowingProvider(
+        string $name,
+        array $supportedModes,
+        bool $throwOnPrepare = false,
+        bool $throwOnResolve = false,
+    ): LookupProviderInterface {
+        return new class($name, $supportedModes, $throwOnPrepare, $throwOnResolve) implements LookupProviderInterface {
+            public function __construct(
+                private readonly string $name,
+                private readonly array $supportedModes,
+                private readonly bool $throwOnPrepare,
+                private readonly bool $throwOnResolve,
+            ) {
+            }
+
+            public function getFieldPriority(string $field, ?ComicType $type = null): int
+            {
+                return 0;
+            }
+
+            public function getLastApiMessage(): ?array
+            {
+                return null;
+            }
+
+            public function getName(): string
+            {
+                return $this->name;
+            }
+
+            public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed
+            {
+                if ($this->throwOnPrepare) {
+                    throw new \RuntimeException('prepareLookup failed');
+                }
+
+                return ['result' => null];
+            }
+
+            public function resolveLookup(mixed $state): ?LookupResult
+            {
+                if ($this->throwOnResolve) {
+                    throw new \RuntimeException('resolveLookup failed');
+                }
+
+                return null;
+            }
+
+            public function supports(string $mode, ?ComicType $type): bool
+            {
+                return \in_array($mode, $this->supportedModes, true);
+            }
+        };
+    }
+
+    /**
+     * Crée un provider dont le resolveLookup est lent (pour tester le timeout global).
+     *
+     * @param list<string> $supportedModes
+     */
+    private function createSlowProvider(
+        string $name,
+        array $supportedModes,
+        ?LookupResult $result,
+        float $resolveDelay,
+    ): LookupProviderInterface {
+        return new class($name, $supportedModes, $result, $resolveDelay) implements LookupProviderInterface {
+            public function __construct(
+                private readonly string $name,
+                private readonly array $supportedModes,
+                private readonly ?LookupResult $result,
+                private readonly float $resolveDelay,
+            ) {
+            }
+
+            public function getFieldPriority(string $field, ?ComicType $type = null): int
+            {
+                return 0;
+            }
+
+            public function getLastApiMessage(): ?array
+            {
+                return null;
+            }
+
+            public function getName(): string
+            {
+                return $this->name;
+            }
+
+            public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed
+            {
+                return ['result' => $this->result];
+            }
+
+            public function resolveLookup(mixed $state): ?LookupResult
+            {
+                \usleep((int) ($this->resolveDelay * 1_000_000));
+
+                return $state['result'] ?? null;
             }
 
             public function supports(string $mode, ?ComicType $type): bool

--- a/tests/Service/Lookup/OpenLibraryLookupTest.php
+++ b/tests/Service/Lookup/OpenLibraryLookupTest.php
@@ -50,7 +50,7 @@ class OpenLibraryLookupTest extends TestCase
         ]));
 
         $provider = new OpenLibraryLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('1234567890', null, 'isbn');
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
 
         self::assertInstanceOf(LookupResult::class, $result);
         self::assertSame('Open Library Book', $result->title);
@@ -78,7 +78,7 @@ class OpenLibraryLookupTest extends TestCase
             new MockHttpClient([$bookResponse, $authorResponse1, $authorResponse2]),
             new NullLogger(),
         );
-        $result = $provider->lookup('1234567890', null, 'isbn');
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
 
         self::assertNotNull($result);
         self::assertSame('Author One, Author Two', $result->authors);
@@ -89,7 +89,7 @@ class OpenLibraryLookupTest extends TestCase
         $response = new MockResponse('', ['http_code' => 404]);
 
         $provider = new OpenLibraryLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('0000000000', null, 'isbn');
+        $result = $this->doLookup($provider, '0000000000', null, 'isbn');
 
         self::assertNull($result);
         self::assertSame('not_found', $provider->getLastApiMessage()['status']);
@@ -102,7 +102,7 @@ class OpenLibraryLookupTest extends TestCase
         ]));
 
         $provider = new OpenLibraryLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('1234567890', null, 'isbn');
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
 
         self::assertNull($result);
         self::assertSame('not_found', $provider->getLastApiMessage()['status']);
@@ -113,7 +113,7 @@ class OpenLibraryLookupTest extends TestCase
         $response = new MockResponse('', ['error' => 'Connection failed']);
 
         $provider = new OpenLibraryLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('1234567890', null, 'isbn');
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
 
         self::assertNull($result);
         self::assertSame('error', $provider->getLastApiMessage()['status']);
@@ -124,9 +124,16 @@ class OpenLibraryLookupTest extends TestCase
         $response = new MockResponse('Rate limit', ['http_code' => 429]);
 
         $provider = new OpenLibraryLookup(new MockHttpClient([$response]), new NullLogger());
-        $result = $provider->lookup('1234567890', null, 'isbn');
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
 
         self::assertNull($result);
         self::assertSame('rate_limited', $provider->getLastApiMessage()['status']);
+    }
+
+    private function doLookup(OpenLibraryLookup $provider, string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+    {
+        $state = $provider->prepareLookup($query, $type, $mode);
+
+        return $provider->resolveLookup($state);
     }
 }

--- a/tests/Service/Lookup/WikipediaLookupTest.php
+++ b/tests/Service/Lookup/WikipediaLookupTest.php
@@ -60,7 +60,7 @@ class WikipediaLookupTest extends TestCase
         $mockClient = new MockHttpClient($this->createTitleLookupResponder());
 
         $provider = $this->createProvider($mockClient);
-        $result = $provider->lookup('One Piece', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'One Piece', ComicType::MANGA, 'title');
 
         self::assertInstanceOf(LookupResult::class, $result);
         self::assertSame('One Piece', $result->title);
@@ -80,7 +80,7 @@ class WikipediaLookupTest extends TestCase
         $mockClient = new MockHttpClient($this->createIsbnLookupResponder());
 
         $provider = $this->createProvider($mockClient);
-        $result = $provider->lookup('9782723428262', null, 'isbn');
+        $result = $this->doLookup($provider, '9782723428262', null, 'isbn');
 
         self::assertInstanceOf(LookupResult::class, $result);
         self::assertSame('Astérix', $result->title);
@@ -142,7 +142,7 @@ class WikipediaLookupTest extends TestCase
         });
 
         $provider = $this->createProvider($mockClient);
-        $result = $provider->lookup('9782012101340', null, 'isbn');
+        $result = $this->doLookup($provider, '9782012101340', null, 'isbn');
 
         self::assertInstanceOf(LookupResult::class, $result);
         self::assertSame('Astérix', $result->title);
@@ -161,7 +161,7 @@ class WikipediaLookupTest extends TestCase
         });
 
         $provider = $this->createProvider($mockClient);
-        $result = $provider->lookup('ZZZZZZ', null, 'title');
+        $result = $this->doLookup($provider, 'ZZZZZZ', null, 'title');
 
         self::assertNull($result);
         self::assertNotNull($provider->getLastApiMessage());
@@ -181,7 +181,7 @@ class WikipediaLookupTest extends TestCase
         });
 
         $provider = $this->createProvider($mockClient);
-        $result = $provider->lookup('0000000000000', null, 'isbn');
+        $result = $this->doLookup($provider, '0000000000000', null, 'isbn');
 
         self::assertNull($result);
         self::assertNotNull($provider->getLastApiMessage());
@@ -193,7 +193,7 @@ class WikipediaLookupTest extends TestCase
         $mockClient = new MockHttpClient(static fn (): MockResponse => new MockResponse('', ['error' => 'Connection failed']));
 
         $provider = $this->createProvider($mockClient);
-        $result = $provider->lookup('One Piece', null, 'title');
+        $result = $this->doLookup($provider, 'One Piece', null, 'title');
 
         self::assertNull($result);
         self::assertNotNull($provider->getLastApiMessage());
@@ -205,7 +205,7 @@ class WikipediaLookupTest extends TestCase
         $mockClient = new MockHttpClient(static fn (): MockResponse => new MockResponse('Too Many Requests', ['http_code' => 429]));
 
         $provider = $this->createProvider($mockClient);
-        $result = $provider->lookup('One Piece', null, 'title');
+        $result = $this->doLookup($provider, 'One Piece', null, 'title');
 
         self::assertNull($result);
         self::assertNotNull($provider->getLastApiMessage());
@@ -217,7 +217,7 @@ class WikipediaLookupTest extends TestCase
         $mockClient = new MockHttpClient(static fn (): MockResponse => new MockResponse('Internal Server Error', ['http_code' => 500]));
 
         $provider = $this->createProvider($mockClient);
-        $result = $provider->lookup('One Piece', null, 'title');
+        $result = $this->doLookup($provider, 'One Piece', null, 'title');
 
         self::assertNull($result);
         self::assertNotNull($provider->getLastApiMessage());
@@ -234,7 +234,7 @@ class WikipediaLookupTest extends TestCase
         );
 
         $provider = $this->createProvider($mockClient);
-        $result = $provider->enrich($partial, ComicType::MANGA);
+        $result = $this->doEnrich($provider, $partial, ComicType::MANGA);
 
         self::assertInstanceOf(LookupResult::class, $result);
         self::assertSame('One Piece', $result->title);
@@ -246,7 +246,7 @@ class WikipediaLookupTest extends TestCase
         $provider = $this->createProvider(new MockHttpClient());
 
         $partial = new LookupResult(source: 'google_books');
-        $result = $provider->enrich($partial, null);
+        $result = $this->doEnrich($provider, $partial, null);
 
         self::assertNull($result);
     }
@@ -264,13 +264,13 @@ class WikipediaLookupTest extends TestCase
         $provider = $this->createProvider($mockClient, $cache);
 
         // Premier appel → requêtes HTTP
-        $result1 = $provider->lookup('One Piece', ComicType::MANGA, 'title');
+        $result1 = $this->doLookup($provider, 'One Piece', ComicType::MANGA, 'title');
         $firstCallCount = $callCount;
         self::assertNotNull($result1);
         self::assertGreaterThan(0, $firstCallCount);
 
         // Deuxième appel → depuis le cache, pas de nouvelles requêtes
-        $result2 = $provider->lookup('One Piece', ComicType::MANGA, 'title');
+        $result2 = $this->doLookup($provider, 'One Piece', ComicType::MANGA, 'title');
         self::assertNotNull($result2);
         self::assertSame($firstCallCount, $callCount);
         self::assertSame($result1->title, $result2->title);
@@ -332,7 +332,7 @@ class WikipediaLookupTest extends TestCase
         });
 
         $provider = $this->createProvider($mockClient);
-        $result = $provider->lookup('One Piece', ComicType::MANGA, 'title');
+        $result = $this->doLookup($provider, 'One Piece', ComicType::MANGA, 'title');
 
         self::assertInstanceOf(LookupResult::class, $result);
         // Doit avoir pris Q222 (manga series), pas Q111 (film)
@@ -374,7 +374,7 @@ class WikipediaLookupTest extends TestCase
         });
 
         $provider = $this->createProvider($mockClient);
-        $result = $provider->lookup('Maus', ComicType::BD, 'title');
+        $result = $this->doLookup($provider, 'Maus', ComicType::BD, 'title');
 
         self::assertInstanceOf(LookupResult::class, $result);
         self::assertTrue($result->isOneShot);
@@ -408,7 +408,7 @@ class WikipediaLookupTest extends TestCase
         });
 
         $provider = $this->createProvider($mockClient);
-        $result = $provider->lookup('Test', null, 'title');
+        $result = $this->doLookup($provider, 'Test', null, 'title');
 
         self::assertNotNull($result);
         self::assertNotNull($result->thumbnail);
@@ -431,6 +431,20 @@ class WikipediaLookupTest extends TestCase
     private function claimTimeValue(string $time): array
     {
         return ['mainsnak' => ['datavalue' => ['value' => ['time' => $time]]]];
+    }
+
+    private function doEnrich(WikipediaLookup $provider, LookupResult $partial, ?ComicType $type): ?LookupResult
+    {
+        $state = $provider->prepareEnrich($partial, $type);
+
+        return $provider->resolveEnrich($state);
+    }
+
+    private function doLookup(WikipediaLookup $provider, string $query, ?ComicType $type, string $mode = 'title'): ?LookupResult
+    {
+        $state = $provider->prepareLookup($query, $type, $mode);
+
+        return $provider->resolveLookup($state);
     }
 
     private function createIsbnLookupResponder(): \Closure


### PR DESCRIPTION
## Summary
- **Interface deux phases** : `prepareLookup`/`resolveLookup` (et `prepareEnrich`/`resolveEnrich` pour les enrichables) remplacent les anciennes méthodes `lookup()`/`enrich()`, exploitant le multiplexage natif de Symfony HttpClient (`curl_multi`)
- **Timeout global configurable** (15s par défaut) protège contre les providers lents — nouveau statut `ApiLookupStatus::TIMEOUT`
- **Résilience** : chaque provider en erreur est ignoré sans bloquer les autres (`try/catch \Throwable` sur chaque phase)
- Tous les 6 providers adaptés : GoogleBooks, OpenLibrary, BnF, AniList, Wikipedia, Gemini

## Test plan
- [x] 492 tests passent (134 tests lookup)
- [x] PHP-CS-Fixer clean
- [x] PHPStan : aucune nouvelle erreur (35 pré-existants)

fixes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)