### PR TITLE
feat(pwa): notification de mise à jour du Service Worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Notification mise à jour SW** : Bandeau "Nouvelle version disponible — Rafraîchir" affiché automatiquement quand le Service Worker se met à jour, avec bouton de rechargement et possibilité de fermer
 - **BnfLookup** : Nouveau provider de recherche via l'API SRU du catalogue général de la BnF
   - Recherche par ISBN (`bib.isbn`) et par titre (`bib.title`)
   - Extraction des métadonnées (titre, auteurs, éditeur, date, ISBN) au format Dublin Core

--- a/assets/controllers/sw_update_controller.js
+++ b/assets/controllers/sw_update_controller.js
@@ -1,0 +1,46 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Affiche un bandeau de notification quand le Service Worker se met a jour.
+ * Ecoute l'evenement `controllerchange` sur navigator.serviceWorker.
+ */
+export default class extends Controller {
+    connect() {
+        if (!('serviceWorker' in navigator)) return;
+        if (!navigator.serviceWorker.controller) return;
+
+        this.handleControllerChange = this.handleControllerChange.bind(this);
+        navigator.serviceWorker.addEventListener('controllerchange', this.handleControllerChange);
+    }
+
+    disconnect() {
+        if ('serviceWorker' in navigator && this.handleControllerChange) {
+            navigator.serviceWorker.removeEventListener('controllerchange', this.handleControllerChange);
+        }
+    }
+
+    handleControllerChange() {
+        if (this.element.querySelector('.sw-update-banner')) return;
+
+        const banner = document.createElement('div');
+        banner.className = 'sw-update-banner';
+        banner.setAttribute('role', 'alert');
+
+        const text = document.createElement('span');
+        text.textContent = 'Nouvelle version disponible';
+
+        const refreshBtn = document.createElement('button');
+        refreshBtn.className = 'sw-update-banner__refresh';
+        refreshBtn.textContent = 'Rafraîchir';
+        refreshBtn.addEventListener('click', () => window.location.reload());
+
+        const closeBtn = document.createElement('button');
+        closeBtn.className = 'sw-update-banner__close';
+        closeBtn.setAttribute('aria-label', 'Fermer');
+        closeBtn.textContent = '\u00d7';
+        closeBtn.addEventListener('click', () => banner.remove());
+
+        banner.append(text, refreshBtn, closeBtn);
+        this.element.appendChild(banner);
+    }
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1017,6 +1017,51 @@ body[data-connection-status="OFFLINE"] .offline-indicator {
     display: block;
 }
 
+/* SW Update Banner */
+.sw-update-banner {
+    align-items: center;
+    animation: slideDown 0.3s ease-out;
+    background-color: var(--md-primary);
+    color: var(--md-on-primary);
+    display: flex;
+    font-size: 0.875rem;
+    gap: var(--md-spacing-sm);
+    justify-content: center;
+    left: 0;
+    padding: var(--md-spacing-sm) var(--md-spacing-md);
+    position: fixed;
+    right: 0;
+    top: 0;
+    z-index: 101;
+}
+
+.sw-update-banner__refresh {
+    background-color: var(--md-on-primary);
+    border: none;
+    border-radius: var(--md-radius-full);
+    color: var(--md-primary);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    padding: var(--md-spacing-xs) var(--md-spacing-md);
+}
+
+.sw-update-banner__close {
+    background: none;
+    border: none;
+    color: var(--md-on-primary);
+    cursor: pointer;
+    font-size: 1.25rem;
+    line-height: 1;
+    opacity: 0.8;
+    padding: var(--md-spacing-xs);
+}
+
+.sw-update-banner__close:hover {
+    opacity: 1;
+}
+
 /* ISBN Lookup */
 .isbn-field {
     flex: 1;

--- a/docs/fonctionnalites/pwa.md
+++ b/docs/fonctionnalites/pwa.md
@@ -122,11 +122,15 @@ Quand une page non mise en cache est demandée hors-ligne :
 
 ## Mise à jour
 
-### Mise à jour automatique
+### Notification de mise à jour
 
-1. À chaque visite, le navigateur vérifie les mises à jour du Service Worker
-2. Si une nouvelle version existe, elle est téléchargée en arrière-plan
-3. Au prochain rechargement, la nouvelle version s'active
+Quand une nouvelle version du Service Worker est détectée :
+
+1. Le navigateur télécharge la mise à jour en arrière-plan
+2. Le nouveau SW s'active automatiquement (`skipWaiting` + `clients.claim`)
+3. Un bandeau bleu **"Nouvelle version disponible — Rafraîchir"** apparaît en haut de l'écran
+4. Cliquez sur **Rafraîchir** pour recharger la page avec la nouvelle version
+5. Vous pouvez aussi fermer le bandeau (×) et continuer sans recharger
 
 ### Forcer une mise à jour
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -27,6 +27,7 @@
             urls: [path('api_comics'), path('app_home'), path('app_wishlist'), path('app_comic_new')]
         }) }} hidden></div>
         {% endif %}
+        <div data-controller="sw-update"></div>
         <div class="app-container">
             {% if app.user %}
             {# Top App Bar - Desktop only #}

--- a/tests/js/controllers/sw_update_controller.test.js
+++ b/tests/js/controllers/sw_update_controller.test.js
@@ -1,0 +1,118 @@
+import { startStimulusController, stopStimulusController } from '../helpers/stimulus-helper.js';
+import SwUpdateController from '../../../assets/controllers/sw_update_controller.js';
+
+describe('sw_update_controller', () => {
+    let application;
+    let element;
+    let controllerChangeListeners;
+
+    function mockServiceWorker() {
+        controllerChangeListeners = [];
+        Object.defineProperty(navigator, 'serviceWorker', {
+            configurable: true,
+            value: {
+                addEventListener: vi.fn((event, handler) => {
+                    if (event === 'controllerchange') {
+                        controllerChangeListeners.push(handler);
+                    }
+                }),
+                controller: { scriptURL: '/sw.js' },
+                removeEventListener: vi.fn(),
+            },
+        });
+    }
+
+    function triggerControllerChange() {
+        controllerChangeListeners.forEach((fn) => fn());
+    }
+
+    beforeEach(() => {
+        mockServiceWorker();
+    });
+
+    afterEach(() => {
+        if (application) stopStimulusController(application);
+        delete navigator.serviceWorker;
+    });
+
+    async function startController() {
+        const result = await startStimulusController(
+            SwUpdateController,
+            'sw-update',
+            '<div data-controller="sw-update"></div>',
+        );
+        application = result.application;
+        element = result.element;
+    }
+
+    it('affiche un bandeau quand le SW se met a jour', async () => {
+        await startController();
+
+        triggerControllerChange();
+
+        const banner = element.querySelector('.sw-update-banner');
+        expect(banner).not.toBeNull();
+        expect(banner.textContent).toContain('Nouvelle version disponible');
+    });
+
+    it('contient un bouton Rafraichir qui recharge la page', async () => {
+        await startController();
+        const originalLocation = window.location;
+        const reloadMock = vi.fn();
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { reload: reloadMock },
+        });
+
+        triggerControllerChange();
+
+        const refreshBtn = element.querySelector('.sw-update-banner__refresh');
+        expect(refreshBtn).not.toBeNull();
+        refreshBtn.click();
+        expect(reloadMock).toHaveBeenCalled();
+
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: originalLocation,
+        });
+    });
+
+    it('contient un bouton fermer qui supprime le bandeau', async () => {
+        await startController();
+
+        triggerControllerChange();
+
+        const closeBtn = element.querySelector('.sw-update-banner__close');
+        expect(closeBtn).not.toBeNull();
+        closeBtn.click();
+        expect(element.querySelector('.sw-update-banner')).toBeNull();
+    });
+
+    it('ne fait rien si serviceWorker non supporte', async () => {
+        delete navigator.serviceWorker;
+
+        await startController();
+
+        expect(element.querySelector('.sw-update-banner')).toBeNull();
+    });
+
+    it('ne fait rien si aucun SW controleur actif (premier install)', async () => {
+        navigator.serviceWorker.controller = null;
+
+        await startController();
+
+        triggerControllerChange();
+
+        expect(element.querySelector('.sw-update-banner')).toBeNull();
+    });
+
+    it('n\'affiche qu\'un seul bandeau meme si controllerchange fire plusieurs fois', async () => {
+        await startController();
+
+        triggerControllerChange();
+        triggerControllerChange();
+
+        const banners = element.querySelectorAll('.sw-update-banner');
+        expect(banners.length).toBe(1);
+    });
+});


### PR DESCRIPTION
## Summary
- Nouveau Stimulus controller `sw_update_controller` qui écoute l'événement `controllerchange` sur `navigator.serviceWorker`
- Affiche un bandeau fixe en haut de page "Nouvelle version disponible — Rafraîchir" quand le SW se met à jour
- Bouton Rafraîchir → `window.location.reload()`, bouton × pour fermer le bandeau
- Protection contre les faux positifs : ne s'active que s'il y avait déjà un SW actif (pas au premier install)

## Test plan
- [x] 6 tests Vitest couvrant : affichage du bandeau, bouton rafraîchir, bouton fermer, SW non supporté, premier install, double trigger
- [x] 206 tests JS passent (14 fichiers)
- [x] 492 tests PHP passent

fixes #30