### PR TITLE
feat(tome): suivi de lecture (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Suivi de lecture** : Nouveau champ `read` sur les tomes pour suivre la progression de lecture
+  - Propriété `read` (lu) sur `Tome` avec checkbox dans le formulaire d'édition
+  - Méthodes calculées sur `ComicSeries` : `getLastRead()`, `isLastReadComplete()`, `getReadTomesCount()`, `isCurrentlyReading()`, `isFullyRead()`
+  - Filtre "Lecture" sur la page d'accueil (Tous / En cours / Lus / Non lus)
+  - Statistique "Lecture" et indicateur visuel (bordure verte) sur la fiche série
+  - Données de lecture exposées dans l'API PWA
 - **Notification mise à jour SW** : Bandeau "Nouvelle version disponible — Rafraîchir" affiché automatiquement quand le Service Worker se met à jour, avec bouton de rechargement et possibilité de fermer
 - **BnfLookup** : Nouveau provider de recherche via l'API SRU du catalogue général de la BnF
   - Recherche par ISBN (`bib.isbn`) et par titre (`bib.title`)

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -2124,6 +2124,10 @@ body[data-connection-status="OFFLINE"] .offline-indicator {
     background-color: #512da8;
 }
 
+.legend-dot--read {
+    background-color: #2e7d32;
+}
+
 .tomes-grid {
     display: grid;
     gap: var(--md-spacing-sm);
@@ -2158,6 +2162,10 @@ body[data-connection-status="OFFLINE"] .offline-indicator {
     background-color: #e3f2fd;
     border-color: #1565c0;
     border-left: 3px solid #512da8;
+}
+
+.tome-cell--read {
+    border-bottom: 3px solid #2e7d32;
 }
 
 .tome-cell-number {

--- a/migrations/Version20260215162502.php
+++ b/migrations/Version20260215162502.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260215162502 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE tome ADD `read` TINYINT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE tome DROP `read`');
+    }
+}

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -23,6 +23,7 @@ class HomeController extends AbstractController
         $comics = $comicSeriesRepository->findWithFilters([
             'isWishlist' => false,
             'onNas' => $filters->getOnNas(),
+            'reading' => $filters->getReading(),
             'search' => $filters->getSearch(),
             'sort' => $filters->sort,
             'status' => $filters->getStatus(),
@@ -38,6 +39,7 @@ class HomeController extends AbstractController
         return $this->render('home/index.html.twig', [
             'comics' => $comics,
             'currentNas' => $filters->nas,
+            'currentReading' => $filters->reading,
             'currentSearch' => $filters->q ?? '',
             'currentSort' => $filters->sort,
             'currentStatus' => $filters->getStatus(),

--- a/src/Dto/ComicFilters.php
+++ b/src/Dto/ComicFilters.php
@@ -19,6 +19,7 @@ class ComicFilters
     public function __construct(
         public ?string $nas = null,
         public ?string $q = null,
+        public ?string $reading = null,
         public string $sort = 'title_asc',
         public ?string $status = null,
         public ?string $type = null,
@@ -33,6 +34,17 @@ class ComicFilters
         return match ($this->nas) {
             '1' => true,
             '0' => false,
+            default => null,
+        };
+    }
+
+    /**
+     * Retourne la valeur du filtre lecture (null si invalide ou non défini).
+     */
+    public function getReading(): ?string
+    {
+        return match ($this->reading) {
+            'read', 'reading', 'unread' => $this->reading,
             default => null,
         };
     }

--- a/src/Dto/Input/TomeInput.php
+++ b/src/Dto/Input/TomeInput.php
@@ -24,6 +24,8 @@ class TomeInput
 
     public bool $onNas = false;
 
+    public bool $read = false;
+
     public ?string $isbn = null;
 
     public ?string $title = null;

--- a/src/Entity/ComicSeries.php
+++ b/src/Entity/ComicSeries.php
@@ -269,6 +269,14 @@ class ComicSeries implements SoftDeletableInterface
         return $this->getMaxTomeNumber(static fn (Tome $t): bool => $t->isDownloaded());
     }
 
+    /**
+     * Retourne le dernier numéro de tome lu.
+     */
+    public function getLastRead(): ?int
+    {
+        return $this->getMaxTomeNumber(static fn (Tome $t): bool => $t->isRead());
+    }
+
     public function getLatestPublishedIssue(): ?int
     {
         return $this->latestPublishedIssue;
@@ -323,6 +331,14 @@ class ComicSeries implements SoftDeletableInterface
     public function getPublisher(): ?string
     {
         return $this->publisher;
+    }
+
+    /**
+     * Retourne le nombre de tomes lus.
+     */
+    public function getReadTomesCount(): int
+    {
+        return $this->tomes->filter(static fn (Tome $t): bool => $t->isRead())->count();
     }
 
     public function setPublisher(?string $publisher): static
@@ -408,11 +424,37 @@ class ComicSeries implements SoftDeletableInterface
     }
 
     /**
+     * Indique si la série est en cours de lecture (au moins 1 lu, pas tous).
+     */
+    public function isCurrentlyReading(): bool
+    {
+        if ($this->tomes->isEmpty()) {
+            return false;
+        }
+
+        $readCount = $this->getReadTomesCount();
+
+        return $readCount > 0 && $readCount < $this->tomes->count();
+    }
+
+    /**
      * Indique si le dernier tome possédé correspond au dernier tome paru.
      */
     public function isCurrentIssueComplete(): bool
     {
         return $this->isIssueComplete($this->getCurrentIssue());
+    }
+
+    /**
+     * Indique si tous les tomes sont lus.
+     */
+    public function isFullyRead(): bool
+    {
+        if ($this->tomes->isEmpty()) {
+            return false;
+        }
+
+        return $this->getReadTomesCount() === $this->tomes->count();
     }
 
     /**
@@ -429,6 +471,14 @@ class ComicSeries implements SoftDeletableInterface
     public function isLastDownloadedComplete(): bool
     {
         return $this->isIssueComplete($this->getLastDownloaded());
+    }
+
+    /**
+     * Indique si le dernier tome lu correspond au dernier tome paru.
+     */
+    public function isLastReadComplete(): bool
+    {
+        return $this->isIssueComplete($this->getLastRead());
     }
 
     public function isLatestPublishedIssueComplete(): bool

--- a/src/Entity/Tome.php
+++ b/src/Entity/Tome.php
@@ -65,6 +65,12 @@ class Tome
     private bool $onNas = false;
 
     /**
+     * Indique si le tome a été lu.
+     */
+    #[ORM\Column(name: '`read`')]
+    private bool $read = false;
+
+    /**
      * Titre spécifique du tome (optionnel).
      */
     #[ORM\Column(length: 255, nullable: true)]
@@ -170,6 +176,18 @@ class Tome
     public function setOnNas(bool $onNas): static
     {
         $this->onNas = $onNas;
+
+        return $this;
+    }
+
+    public function isRead(): bool
+    {
+        return $this->read;
+    }
+
+    public function setRead(bool $read): static
+    {
+        $this->read = $read;
 
         return $this;
     }

--- a/src/Form/TomeType.php
+++ b/src/Form/TomeType.php
@@ -44,6 +44,10 @@ class TomeType extends AbstractType
                 'label' => 'Sur NAS',
                 'required' => false,
             ])
+            ->add('read', CheckboxType::class, [
+                'label' => 'Lu',
+                'required' => false,
+            ])
             ->add('title', TextType::class, [
                 'attr' => ['placeholder' => 'Titre du tome (optionnel)'],
                 'label' => 'Titre',

--- a/src/Repository/ComicSeriesRepository.php
+++ b/src/Repository/ComicSeriesRepository.php
@@ -25,6 +25,7 @@ class ComicSeriesRepository extends ServiceEntityRepository
      * @param array{
      *     isWishlist?: bool,
      *     onNas?: bool|null,
+     *     reading?: string|null,
      *     search?: string|null,
      *     sort?: string,
      *     status?: ComicStatus|null,
@@ -71,6 +72,20 @@ class ComicSeriesRepository extends ServiceEntityRepository
                 // Séries sans aucun tome sur NAS
                 $qb->andWhere('NOT EXISTS (SELECT t2.id FROM App\Entity\Tome t2 WHERE t2.comicSeries = c AND t2.onNas = true)');
             }
+        }
+
+        // Reading filter
+        if (!empty($filters['reading'])) {
+            match ($filters['reading']) {
+                'reading' => $qb
+                    ->andWhere('EXISTS (SELECT r1.id FROM App\Entity\Tome r1 WHERE r1.comicSeries = c AND r1.read = true)')
+                    ->andWhere('EXISTS (SELECT r2.id FROM App\Entity\Tome r2 WHERE r2.comicSeries = c AND r2.read = false)'),
+                'read' => $qb
+                    ->andWhere('NOT EXISTS (SELECT r3.id FROM App\Entity\Tome r3 WHERE r3.comicSeries = c AND r3.read = false)'),
+                'unread' => $qb
+                    ->andWhere('NOT EXISTS (SELECT r4.id FROM App\Entity\Tome r4 WHERE r4.comicSeries = c AND r4.read = true)'),
+                default => null,
+            };
         }
 
         // Search filter (titre uniquement, ISBN est maintenant sur les tomes)
@@ -159,18 +174,23 @@ class ComicSeriesRepository extends ServiceEntityRepository
                 'description' => $comic->getDescription(),
                 'hasNasTome' => $hasNasTome,
                 'id' => $comic->getId(),
+                'isCurrentlyReading' => $comic->isCurrentlyReading(),
+                'isFullyRead' => $comic->isFullyRead(),
                 'isOneShot' => $comic->isOneShot(),
                 'isWishlist' => $comic->isWishlist(),
                 'lastBought' => $comic->getLastBought(),
                 'lastBoughtComplete' => $comic->isLastBoughtComplete(),
                 'lastDownloaded' => $comic->getLastDownloaded(),
                 'lastDownloadedComplete' => $comic->isLastDownloadedComplete(),
+                'lastRead' => $comic->getLastRead(),
+                'lastReadComplete' => $comic->isLastReadComplete(),
                 'latestPublishedIssue' => $comic->getLatestPublishedIssue(),
                 'latestPublishedIssueComplete' => $comic->isLatestPublishedIssueComplete(),
                 'missingTomesNumbers' => $comic->getMissingTomesNumbers(),
                 'ownedTomesNumbers' => $comic->getOwnedTomesNumbers(),
                 'publishedDate' => $comic->getPublishedDate(),
                 'publisher' => $comic->getPublisher(),
+                'readTomesCount' => $comic->getReadTomesCount(),
                 'status' => $comic->getStatus()->value,
                 'statusLabel' => $comic->getStatus()->getLabel(),
                 'title' => $comic->getTitle(),

--- a/templates/comic/show.html.twig
+++ b/templates/comic/show.html.twig
@@ -99,6 +99,15 @@
                     </div>
                 {% endif %}
 
+                {% set readCount = comic.readTomesCount %}
+                {% set totalCount = comic.tomes|length %}
+                {% if readCount > 0 or comic.fullyRead %}
+                    <div class="stat-item">
+                        <span class="stat-label">Lecture</span>
+                        <span class="stat-value">{% if comic.fullyRead %}Complet{% else %}{{ readCount }}/{{ totalCount }} lus{% endif %}</span>
+                    </div>
+                {% endif %}
+
                 {% set missingNumbers = comic.missingTomesNumbers %}
                 {% if missingNumbers|length > 0 %}
                     <div class="stat-item stat-item-full">
@@ -114,10 +123,11 @@
                     <div class="tomes-legend">
                         <span class="legend-item"><span class="legend-dot legend-dot--bought"></span> Acheté</span>
                         <span class="legend-item"><span class="legend-dot legend-dot--nas"></span> Sur NAS</span>
+                        <span class="legend-item"><span class="legend-dot legend-dot--read"></span> Lu</span>
                     </div>
                     <div class="tomes-grid">
                         {% for tome in comic.tomes %}
-                            <div class="tome-cell{% if tome.bought %} tome-cell--bought{% endif %}{% if tome.onNas %} tome-cell--nas{% endif %}">
+                            <div class="tome-cell{% if tome.bought %} tome-cell--bought{% endif %}{% if tome.onNas %} tome-cell--nas{% endif %}{% if tome.read %} tome-cell--read{% endif %}">
                                 <span class="tome-cell-number">{{ tome.number }}</span>
                                 <div class="tome-cell-icons">
                                     {% if tome.bought %}
@@ -131,6 +141,13 @@
                                         <span class="tome-icon tome-icon--nas" title="Sur NAS">
                                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14">
                                                 <path d="M2 20h20v-4H2v4zm2-3h2v2H4v-2zM2 4v4h20V4H2zm4 3H4V5h2v2zm-4 7h20v-4H2v4zm2-3h2v2H4v-2z"/>
+                                            </svg>
+                                        </span>
+                                    {% endif %}
+                                    {% if tome.read %}
+                                        <span class="tome-icon tome-icon--read" title="Lu">
+                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14">
+                                                <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
                                             </svg>
                                         </span>
                                     {% endif %}

--- a/templates/components/_filters.html.twig
+++ b/templates/components/_filters.html.twig
@@ -5,6 +5,7 @@
     - currentType: ComicType|null
     - currentStatus: ComicStatus|null (optional)
     - currentNas: string|null ('1', '0', or null)
+    - currentReading: string|null ('reading', 'read', 'unread', or null) (optional)
     - currentSort: string
     - currentSearch: string
     - types: ComicType[]
@@ -19,6 +20,7 @@
             {% if currentType %}<input type="hidden" name="type" value="{{ currentType.value }}">{% endif %}
             {% if currentStatus is defined and currentStatus %}<input type="hidden" name="status" value="{{ currentStatus.value }}">{% endif %}
             {% if currentNas is not null %}<input type="hidden" name="nas" value="{{ currentNas }}">{% endif %}
+            {% if currentReading is defined and currentReading %}<input type="hidden" name="reading" value="{{ currentReading }}">{% endif %}
             <input type="hidden" name="sort" value="{{ currentSort }}">
 
             <div class="search-input-wrapper">
@@ -38,6 +40,7 @@
                         type: currentType ? currentType.value : null,
                         status: (currentStatus is defined and currentStatus) ? currentStatus.value : null,
                         nas: currentNas,
+                        reading: (currentReading is defined and currentReading) ? currentReading : null,
                         sort: currentSort
                     }|filter(v => v is not null)) }}" class="search-clear">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
@@ -69,6 +72,7 @@
                 q: currentSearch ?: null,
                 status: (currentStatus is defined and currentStatus) ? currentStatus.value : null,
                 nas: currentNas,
+                reading: (currentReading is defined and currentReading) ? currentReading : null,
                 sort: currentSort
             }|filter(v => v is not null)) }}" class="chip {% if currentType is null %}active{% endif %}">Tous</a>
             {% for type in types %}
@@ -77,6 +81,7 @@
                     q: currentSearch ?: null,
                     status: (currentStatus is defined and currentStatus) ? currentStatus.value : null,
                     nas: currentNas,
+                    reading: (currentReading is defined and currentReading) ? currentReading : null,
                     sort: currentSort
                 }|filter(v => v is not null)) }}" class="chip {% if currentType == type %}active{% endif %}">{{ type.label }}</a>
             {% endfor %}
@@ -92,6 +97,7 @@
                     type: currentType ? currentType.value : null,
                     q: currentSearch ?: null,
                     nas: currentNas,
+                    reading: (currentReading is defined and currentReading) ? currentReading : null,
                     sort: currentSort
                 }|filter(v => v is not null)) }}" class="chip {% if currentStatus is null %}active{% endif %}">Tous</a>
                 {% for status in statuses %}
@@ -100,6 +106,7 @@
                         status: status.value,
                         q: currentSearch ?: null,
                         nas: currentNas,
+                        reading: (currentReading is defined and currentReading) ? currentReading : null,
                         sort: currentSort
                     }|filter(v => v is not null)) }}" class="chip {% if currentStatus == status %}active{% endif %}">{{ status.label }}</a>
                 {% endfor %}
@@ -115,6 +122,7 @@
                 type: currentType ? currentType.value : null,
                 status: (currentStatus is defined and currentStatus) ? currentStatus.value : null,
                 q: currentSearch ?: null,
+                reading: (currentReading is defined and currentReading) ? currentReading : null,
                 sort: currentSort
             }|filter(v => v is not null)) }}" class="chip {% if currentNas is null %}active{% endif %}">Tous</a>
             <a href="{{ path(route, {
@@ -122,6 +130,7 @@
                 status: (currentStatus is defined and currentStatus) ? currentStatus.value : null,
                 q: currentSearch ?: null,
                 nas: '1',
+                reading: (currentReading is defined and currentReading) ? currentReading : null,
                 sort: currentSort
             }|filter(v => v is not null)) }}" class="chip {% if currentNas == '1' %}active{% endif %}">Sur NAS</a>
             <a href="{{ path(route, {
@@ -129,10 +138,51 @@
                 status: (currentStatus is defined and currentStatus) ? currentStatus.value : null,
                 q: currentSearch ?: null,
                 nas: '0',
+                reading: (currentReading is defined and currentReading) ? currentReading : null,
                 sort: currentSort
             }|filter(v => v is not null)) }}" class="chip {% if currentNas == '0' %}active{% endif %}">Pas sur NAS</a>
         </div>
     </div>
+
+    {# Reading chips #}
+    {% if currentReading is defined %}
+        <div class="filter-section">
+            <span class="filter-label">Lecture</span>
+            <div class="chips-container">
+                <a href="{{ path(route, {
+                    type: currentType ? currentType.value : null,
+                    status: (currentStatus is defined and currentStatus) ? currentStatus.value : null,
+                    q: currentSearch ?: null,
+                    nas: currentNas,
+                    sort: currentSort
+                }|filter(v => v is not null)) }}" class="chip {% if currentReading is null %}active{% endif %}">Tous</a>
+                <a href="{{ path(route, {
+                    type: currentType ? currentType.value : null,
+                    status: (currentStatus is defined and currentStatus) ? currentStatus.value : null,
+                    q: currentSearch ?: null,
+                    nas: currentNas,
+                    reading: 'reading',
+                    sort: currentSort
+                }|filter(v => v is not null)) }}" class="chip {% if currentReading == 'reading' %}active{% endif %}">En cours</a>
+                <a href="{{ path(route, {
+                    type: currentType ? currentType.value : null,
+                    status: (currentStatus is defined and currentStatus) ? currentStatus.value : null,
+                    q: currentSearch ?: null,
+                    nas: currentNas,
+                    reading: 'read',
+                    sort: currentSort
+                }|filter(v => v is not null)) }}" class="chip {% if currentReading == 'read' %}active{% endif %}">Lus</a>
+                <a href="{{ path(route, {
+                    type: currentType ? currentType.value : null,
+                    status: (currentStatus is defined and currentStatus) ? currentStatus.value : null,
+                    q: currentSearch ?: null,
+                    nas: currentNas,
+                    reading: 'unread',
+                    sort: currentSort
+                }|filter(v => v is not null)) }}" class="chip {% if currentReading == 'unread' %}active{% endif %}">Non lus</a>
+            </div>
+        </div>
+    {% endif %}
 </div>
 
 <script>

--- a/tests/Dto/ComicFiltersTest.php
+++ b/tests/Dto/ComicFiltersTest.php
@@ -23,6 +23,7 @@ class ComicFiltersTest extends TestCase
 
         self::assertNull($filters->nas);
         self::assertNull($filters->q);
+        self::assertNull($filters->reading);
         self::assertSame('title_asc', $filters->sort);
         self::assertNull($filters->status);
         self::assertNull($filters->type);
@@ -89,6 +90,46 @@ class ComicFiltersTest extends TestCase
     }
 
     /**
+     * Teste getReading retourne la valeur du filtre lecture.
+     */
+    public function testGetReadingReturnsValue(): void
+    {
+        $filters = new ComicFilters(reading: 'reading');
+
+        self::assertSame('reading', $filters->getReading());
+    }
+
+    /**
+     * Teste getReading retourne null pour une valeur invalide.
+     */
+    public function testGetReadingReturnsNullForInvalidValue(): void
+    {
+        $filters = new ComicFilters(reading: 'invalid');
+
+        self::assertNull($filters->getReading());
+    }
+
+    /**
+     * Teste getReading retourne null quand non défini.
+     */
+    public function testGetReadingReturnsNullWhenNotSet(): void
+    {
+        $filters = new ComicFilters();
+
+        self::assertNull($filters->getReading());
+    }
+
+    /**
+     * Teste les trois valeurs valides de getReading.
+     */
+    public function testGetReadingValidValues(): void
+    {
+        self::assertSame('read', (new ComicFilters(reading: 'read'))->getReading());
+        self::assertSame('reading', (new ComicFilters(reading: 'reading'))->getReading());
+        self::assertSame('unread', (new ComicFilters(reading: 'unread'))->getReading());
+    }
+
+    /**
      * Teste la construction avec tous les paramètres.
      */
     public function testConstructWithAllParameters(): void
@@ -96,6 +137,7 @@ class ComicFiltersTest extends TestCase
         $filters = new ComicFilters(
             nas: '1',
             q: 'asterix',
+            reading: 'reading',
             sort: 'updated_desc',
             status: 'buying',
             type: 'bd',
@@ -103,10 +145,12 @@ class ComicFiltersTest extends TestCase
 
         self::assertSame('1', $filters->nas);
         self::assertSame('asterix', $filters->q);
+        self::assertSame('reading', $filters->reading);
         self::assertSame('updated_desc', $filters->sort);
         self::assertSame('buying', $filters->status);
         self::assertSame('bd', $filters->type);
         self::assertTrue($filters->getOnNas());
+        self::assertSame('reading', $filters->getReading());
         self::assertSame('asterix', $filters->getSearch());
         self::assertSame(ComicStatus::BUYING, $filters->getStatus());
         self::assertSame(ComicType::BD, $filters->getType());

--- a/tests/Dto/Input/TomeInputTest.php
+++ b/tests/Dto/Input/TomeInputTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Dto\Input;
+
+use App\Dto\Input\TomeInput;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires pour le DTO TomeInput.
+ */
+class TomeInputTest extends TestCase
+{
+    /**
+     * Teste les valeurs par défaut.
+     */
+    public function testDefaultValues(): void
+    {
+        $input = new TomeInput();
+
+        self::assertSame(0, $input->number);
+        self::assertFalse($input->bought);
+        self::assertFalse($input->downloaded);
+        self::assertNull($input->isbn);
+        self::assertFalse($input->onNas);
+        self::assertFalse($input->read);
+        self::assertNull($input->title);
+    }
+}

--- a/tests/Entity/ComicSeriesTest.php
+++ b/tests/Entity/ComicSeriesTest.php
@@ -241,6 +241,222 @@ class ComicSeriesTest extends TestCase
     }
 
     /**
+     * Teste getLastRead avec aucun tome lu.
+     */
+    public function testGetLastReadWithNoReadTomes(): void
+    {
+        $series = new ComicSeries();
+
+        $tome = new Tome();
+        $tome->setNumber(1);
+        $tome->setRead(false);
+        $series->addTome($tome);
+
+        self::assertNull($series->getLastRead());
+    }
+
+    /**
+     * Teste getLastRead retourne le numéro maximum des tomes lus.
+     */
+    public function testGetLastReadReturnsMaxReadNumber(): void
+    {
+        $series = new ComicSeries();
+
+        $tome1 = new Tome();
+        $tome1->setNumber(1);
+        $tome1->setRead(true);
+        $series->addTome($tome1);
+
+        $tome2 = new Tome();
+        $tome2->setNumber(4);
+        $tome2->setRead(true);
+        $series->addTome($tome2);
+
+        $tome3 = new Tome();
+        $tome3->setNumber(6);
+        $tome3->setRead(false);
+        $series->addTome($tome3);
+
+        self::assertSame(4, $series->getLastRead());
+    }
+
+    /**
+     * Teste isLastReadComplete quand complet.
+     */
+    public function testIsLastReadCompleteWhenComplete(): void
+    {
+        $series = new ComicSeries();
+        $series->setLatestPublishedIssue(3);
+
+        $tome = new Tome();
+        $tome->setNumber(3);
+        $tome->setRead(true);
+        $series->addTome($tome);
+
+        self::assertTrue($series->isLastReadComplete());
+    }
+
+    /**
+     * Teste isLastReadComplete quand incomplet.
+     */
+    public function testIsLastReadCompleteWhenIncomplete(): void
+    {
+        $series = new ComicSeries();
+        $series->setLatestPublishedIssue(5);
+
+        $tome = new Tome();
+        $tome->setNumber(3);
+        $tome->setRead(true);
+        $series->addTome($tome);
+
+        self::assertFalse($series->isLastReadComplete());
+    }
+
+    /**
+     * Teste getReadTomesCount retourne le nombre de tomes lus.
+     */
+    public function testGetReadTomesCount(): void
+    {
+        $series = new ComicSeries();
+
+        $tome1 = new Tome();
+        $tome1->setNumber(1);
+        $tome1->setRead(true);
+        $series->addTome($tome1);
+
+        $tome2 = new Tome();
+        $tome2->setNumber(2);
+        $tome2->setRead(false);
+        $series->addTome($tome2);
+
+        $tome3 = new Tome();
+        $tome3->setNumber(3);
+        $tome3->setRead(true);
+        $series->addTome($tome3);
+
+        self::assertSame(2, $series->getReadTomesCount());
+    }
+
+    /**
+     * Teste getReadTomesCount avec aucun tome lu.
+     */
+    public function testGetReadTomesCountWithNoReadTomes(): void
+    {
+        $series = new ComicSeries();
+
+        $tome = new Tome();
+        $tome->setNumber(1);
+        $series->addTome($tome);
+
+        self::assertSame(0, $series->getReadTomesCount());
+    }
+
+    /**
+     * Teste isCurrentlyReading quand en cours de lecture.
+     */
+    public function testIsCurrentlyReadingWhenReading(): void
+    {
+        $series = new ComicSeries();
+
+        $tome1 = new Tome();
+        $tome1->setNumber(1);
+        $tome1->setRead(true);
+        $series->addTome($tome1);
+
+        $tome2 = new Tome();
+        $tome2->setNumber(2);
+        $tome2->setRead(false);
+        $series->addTome($tome2);
+
+        self::assertTrue($series->isCurrentlyReading());
+    }
+
+    /**
+     * Teste isCurrentlyReading quand aucun tome lu.
+     */
+    public function testIsCurrentlyReadingWithNoReadTomes(): void
+    {
+        $series = new ComicSeries();
+
+        $tome = new Tome();
+        $tome->setNumber(1);
+        $tome->setRead(false);
+        $series->addTome($tome);
+
+        self::assertFalse($series->isCurrentlyReading());
+    }
+
+    /**
+     * Teste isCurrentlyReading quand tous les tomes sont lus.
+     */
+    public function testIsCurrentlyReadingWhenAllRead(): void
+    {
+        $series = new ComicSeries();
+
+        $tome1 = new Tome();
+        $tome1->setNumber(1);
+        $tome1->setRead(true);
+        $series->addTome($tome1);
+
+        $tome2 = new Tome();
+        $tome2->setNumber(2);
+        $tome2->setRead(true);
+        $series->addTome($tome2);
+
+        self::assertFalse($series->isCurrentlyReading());
+    }
+
+    /**
+     * Teste isFullyRead quand tous les tomes sont lus.
+     */
+    public function testIsFullyReadWhenAllRead(): void
+    {
+        $series = new ComicSeries();
+
+        $tome1 = new Tome();
+        $tome1->setNumber(1);
+        $tome1->setRead(true);
+        $series->addTome($tome1);
+
+        $tome2 = new Tome();
+        $tome2->setNumber(2);
+        $tome2->setRead(true);
+        $series->addTome($tome2);
+
+        self::assertTrue($series->isFullyRead());
+    }
+
+    /**
+     * Teste isFullyRead quand certains tomes ne sont pas lus.
+     */
+    public function testIsFullyReadWhenNotAllRead(): void
+    {
+        $series = new ComicSeries();
+
+        $tome1 = new Tome();
+        $tome1->setNumber(1);
+        $tome1->setRead(true);
+        $series->addTome($tome1);
+
+        $tome2 = new Tome();
+        $tome2->setNumber(2);
+        $tome2->setRead(false);
+        $series->addTome($tome2);
+
+        self::assertFalse($series->isFullyRead());
+    }
+
+    /**
+     * Teste isFullyRead avec une collection vide.
+     */
+    public function testIsFullyReadWithEmptyCollection(): void
+    {
+        $series = new ComicSeries();
+
+        self::assertFalse($series->isFullyRead());
+    }
+
+    /**
      * Teste getOwnedTomesNumbers retourne les numéros des tomes.
      */
     public function testGetOwnedTomesNumbers(): void

--- a/tests/Entity/TomeTest.php
+++ b/tests/Entity/TomeTest.php
@@ -49,6 +49,7 @@ class TomeTest extends TestCase
         self::assertFalse($tome->isBought());
         self::assertFalse($tome->isDownloaded());
         self::assertFalse($tome->isOnNas());
+        self::assertFalse($tome->isRead());
     }
 
     /**
@@ -93,6 +94,17 @@ class TomeTest extends TestCase
         $tome->setOnNas(true);
 
         self::assertTrue($tome->isOnNas());
+    }
+
+    /**
+     * Teste le getter et setter de read.
+     */
+    public function testReadGetterAndSetter(): void
+    {
+        $tome = new Tome();
+        $tome->setRead(true);
+
+        self::assertTrue($tome->isRead());
     }
 
     /**
@@ -243,6 +255,18 @@ class TomeTest extends TestCase
         $tome = new Tome();
 
         $result = $tome->setOnNas(true);
+
+        self::assertSame($tome, $result);
+    }
+
+    /**
+     * Teste que setRead retourne l'instance pour le chaînage.
+     */
+    public function testSetReadReturnsInstance(): void
+    {
+        $tome = new Tome();
+
+        $result = $tome->setRead(true);
 
         self::assertSame($tome, $result);
     }

--- a/tests/Form/TomeTypeTest.php
+++ b/tests/Form/TomeTypeTest.php
@@ -26,6 +26,7 @@ class TomeTypeTest extends TypeTestCase
             'isbn' => '978-2-505-00123-4',
             'number' => 5,
             'onNas' => true,
+            'read' => true,
             'title' => 'Le Retour du Héros',
         ];
 
@@ -40,6 +41,7 @@ class TomeTypeTest extends TypeTestCase
         self::assertTrue($input->bought);
         self::assertFalse($input->downloaded);
         self::assertTrue($input->onNas);
+        self::assertTrue($input->read);
         self::assertSame('978-2-505-00123-4', $input->isbn);
         self::assertSame('Le Retour du Héros', $input->title);
     }
@@ -55,6 +57,7 @@ class TomeTypeTest extends TypeTestCase
             'isbn' => '',
             'number' => 1,
             'onNas' => false,
+            'read' => false,
             'title' => '',
         ];
 
@@ -73,11 +76,12 @@ class TomeTypeTest extends TypeTestCase
     {
         $form = $this->factory->create(TomeType::class);
 
-        self::assertTrue($form->has('number'));
         self::assertTrue($form->has('bought'));
         self::assertTrue($form->has('downloaded'));
-        self::assertTrue($form->has('onNas'));
         self::assertTrue($form->has('isbn'));
+        self::assertTrue($form->has('number'));
+        self::assertTrue($form->has('onNas'));
+        self::assertTrue($form->has('read'));
         self::assertTrue($form->has('title'));
     }
 
@@ -91,6 +95,7 @@ class TomeTypeTest extends TypeTestCase
         $input->bought = true;
         $input->downloaded = true;
         $input->onNas = true;
+        $input->read = true;
         $input->isbn = '123-456';
         $input->title = 'Existing Title';
 
@@ -102,6 +107,7 @@ class TomeTypeTest extends TypeTestCase
         self::assertTrue($view->children['bought']->vars['checked']);
         self::assertTrue($view->children['downloaded']->vars['checked']);
         self::assertTrue($view->children['onNas']->vars['checked']);
+        self::assertTrue($view->children['read']->vars['checked']);
         self::assertSame('123-456', $view->children['isbn']->vars['value']);
         self::assertSame('Existing Title', $view->children['title']->vars['value']);
     }
@@ -136,6 +142,7 @@ class TomeTypeTest extends TypeTestCase
         self::assertFalse($form->get('bought')->isRequired());
         self::assertFalse($form->get('downloaded')->isRequired());
         self::assertFalse($form->get('onNas')->isRequired());
+        self::assertFalse($form->get('read')->isRequired());
     }
 
     /**
@@ -165,5 +172,6 @@ class TomeTypeTest extends TypeTestCase
         self::assertFalse($input->bought);
         self::assertFalse($input->downloaded);
         self::assertFalse($input->onNas);
+        self::assertFalse($input->read);
     }
 }

--- a/tests/Panther/OneShotFormTest.php
+++ b/tests/Panther/OneShotFormTest.php
@@ -231,7 +231,7 @@ final class OneShotFormTest extends TestCase
         $seriesId = (int) $matches[1];
 
         self::runSql(\sprintf(
-            "INSERT INTO tome (comic_series_id, number, bought, downloaded, on_nas, isbn, created_at, updated_at) VALUES (%d, 1, 1, 0, 0, '978-2-1234-0000-0', '%s', '%s')",
+            "INSERT INTO tome (comic_series_id, number, bought, downloaded, on_nas, `read`, isbn, created_at, updated_at) VALUES (%d, 1, 1, 0, 0, 0, '978-2-1234-0000-0', '%s', '%s')",
             $seriesId,
             $now,
             $now,

--- a/tests/Repository/ComicSeriesRepositoryTest.php
+++ b/tests/Repository/ComicSeriesRepositoryTest.php
@@ -192,6 +192,122 @@ class ComicSeriesRepositoryTest extends KernelTestCase
     }
 
     /**
+     * Teste findWithFilters avec filtre reading='reading' (en cours de lecture).
+     */
+    public function testFindWithFiltersReadingInProgress(): void
+    {
+        // Série en cours de lecture : 1 tome lu, 1 non lu
+        $reading = $this->createSeries('Reading In Progress Test', false);
+        $tomeRead = new Tome();
+        $tomeRead->setNumber(1);
+        $tomeRead->setRead(true);
+        $reading->addTome($tomeRead);
+        $tomeUnread = new Tome();
+        $tomeUnread->setNumber(2);
+        $tomeUnread->setRead(false);
+        $reading->addTome($tomeUnread);
+
+        // Série entièrement lue
+        $fullyRead = $this->createSeries('Fully Read Test', false);
+        $tomeAllRead = new Tome();
+        $tomeAllRead->setNumber(1);
+        $tomeAllRead->setRead(true);
+        $fullyRead->addTome($tomeAllRead);
+
+        // Série non lue
+        $unread = $this->createSeries('Unread Test', false);
+        $tomeNotRead = new Tome();
+        $tomeNotRead->setNumber(1);
+        $tomeNotRead->setRead(false);
+        $unread->addTome($tomeNotRead);
+
+        $this->em->flush();
+
+        $results = $this->repository->findWithFilters([
+            'isWishlist' => false,
+            'reading' => 'reading',
+        ]);
+
+        $titles = \array_map(static fn (ComicSeries $s): string => $s->getTitle(), $results);
+
+        self::assertContains('Reading In Progress Test', $titles);
+        self::assertNotContains('Fully Read Test', $titles);
+        self::assertNotContains('Unread Test', $titles);
+    }
+
+    /**
+     * Teste findWithFilters avec filtre reading='read' (entièrement lus).
+     */
+    public function testFindWithFiltersReadingRead(): void
+    {
+        // Série entièrement lue
+        $fullyRead = $this->createSeries('All Read Test', false);
+        $tome1 = new Tome();
+        $tome1->setNumber(1);
+        $tome1->setRead(true);
+        $fullyRead->addTome($tome1);
+        $tome2 = new Tome();
+        $tome2->setNumber(2);
+        $tome2->setRead(true);
+        $fullyRead->addTome($tome2);
+
+        // Série en cours
+        $reading = $this->createSeries('Partial Read Test', false);
+        $tomeRead = new Tome();
+        $tomeRead->setNumber(1);
+        $tomeRead->setRead(true);
+        $reading->addTome($tomeRead);
+        $tomeUnread = new Tome();
+        $tomeUnread->setNumber(2);
+        $tomeUnread->setRead(false);
+        $reading->addTome($tomeUnread);
+
+        $this->em->flush();
+
+        $results = $this->repository->findWithFilters([
+            'isWishlist' => false,
+            'reading' => 'read',
+        ]);
+
+        $titles = \array_map(static fn (ComicSeries $s): string => $s->getTitle(), $results);
+
+        self::assertContains('All Read Test', $titles);
+        self::assertNotContains('Partial Read Test', $titles);
+    }
+
+    /**
+     * Teste findWithFilters avec filtre reading='unread' (non lus).
+     */
+    public function testFindWithFiltersReadingUnread(): void
+    {
+        // Série non lue
+        $unread = $this->createSeries('Not Read Test', false);
+        $tome = new Tome();
+        $tome->setNumber(1);
+        $tome->setRead(false);
+        $unread->addTome($tome);
+
+        // Série avec au moins 1 tome lu
+        $partialRead = $this->createSeries('Some Read Test', false);
+        $tomeRead = new Tome();
+        $tomeRead->setNumber(1);
+        $tomeRead->setRead(true);
+        $partialRead->addTome($tomeRead);
+
+        $this->em->flush();
+
+        $results = $this->repository->findWithFilters([
+            'isWishlist' => false,
+            'reading' => 'unread',
+        ]);
+
+        $titles = \array_map(static fn (ComicSeries $s): string => $s->getTitle(), $results);
+
+        self::assertContains('Not Read Test', $titles);
+        self::assertNotContains('Some Read Test', $titles);
+    }
+
+    /**
      * Teste findWithFilters tri par titre ascendant.
      */
     public function testFindWithFiltersSortTitleAsc(): void
@@ -365,6 +481,11 @@ class ComicSeriesRepositoryTest extends KernelTestCase
         self::assertSame(5, $testResult['latestPublishedIssue']);
         self::assertIsArray($testResult['missingTomesNumbers']);
         self::assertIsArray($testResult['ownedTomesNumbers']);
+        self::assertArrayHasKey('isCurrentlyReading', $testResult);
+        self::assertArrayHasKey('isFullyRead', $testResult);
+        self::assertArrayHasKey('lastRead', $testResult);
+        self::assertArrayHasKey('lastReadComplete', $testResult);
+        self::assertArrayHasKey('readTomesCount', $testResult);
     }
 
     /**


### PR DESCRIPTION
## Summary

- **Champ `read`** sur `Tome` (booléen, défaut false) + checkbox "Lu" dans le formulaire
- **Méthodes calculées** sur `ComicSeries` : `getLastRead()`, `isLastReadComplete()`, `getReadTomesCount()`, `isCurrentlyReading()`, `isFullyRead()`
- **Filtre "Lecture"** sur la homepage (Tous / En cours / Lus / Non lus) via `ComicFilters.reading`
- **Statistique + indicateur visuel** : stat "Lecture X/Y lus" et bordure verte `.tome-cell--read` sur la fiche série
- **API PWA** : 5 nouveaux champs (`lastRead`, `lastReadComplete`, `readTomesCount`, `isCurrentlyReading`, `isFullyRead`)
- **Migration** : colonne `read` (backtickée — mot réservé SQL) sur la table `tome`

## Test plan

- [x] 514 tests PHP passent (dont 3 nouveaux tests repository pour le filtre reading)
- [x] 206 tests JS passent
- [x] PHP-CS-Fixer : 0 violation
- [x] PHPStan : 0 erreur
- [x] TDD respecté : tests écrits avant implémentation

Fixes #33