### PR TITLE
fix(navigation): boutons précédent/suivant inactifs vers la liste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Fixed
 
+- **Navigation** : Les boutons précédent/suivant du navigateur fonctionnent désormais correctement vers les pages de liste (bibliothèque, wishlist, recherche) — remplacement des `<turbo-frame>` inutilisés par des `<div>` pour ne pas interférer avec la restauration de page Turbo Drive
 - **Import Excel** : Les titres avec un article entre parenthèses (`(le)`, `(la)`, `(les)`, `(l')`) sont désormais normalisés lors de l'import (ex: `monde perdu (le)` → `le monde perdu`)
 
 ### Changed

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -20,7 +20,7 @@
         statuses: statuses
     } %}
 
-    <turbo-frame id="comics-list" {{ stimulus_target('library', 'results') }}>
+    <div {{ stimulus_target('library', 'results') }}>
         {% if comics|length > 0 %}
             <div class="cards-grid">
                 {% for comic in comics %}
@@ -32,6 +32,6 @@
                 <p>Aucune serie trouvee.</p>
             </div>
         {% endif %}
-    </turbo-frame>
+    </div>
 </div>
 {% endblock %}

--- a/templates/search/index.html.twig
+++ b/templates/search/index.html.twig
@@ -25,7 +25,7 @@
         </button>
     </form>
 
-    <turbo-frame id="search-results" {{ stimulus_target('search', 'results') }}>
+    <div {{ stimulus_target('search', 'results') }}>
         {% if query %}
             <p class="text-subtitle" style="margin-bottom: 16px;">{{ comics|length }} resultat(s) pour "{{ query }}"</p>
 
@@ -45,6 +45,6 @@
                 <p>Entrez un terme de recherche pour trouver des series.</p>
             </div>
         {% endif %}
-    </turbo-frame>
+    </div>
 </div>
 {% endblock %}

--- a/templates/wishlist/index.html.twig
+++ b/templates/wishlist/index.html.twig
@@ -18,7 +18,7 @@
         types: types
     } %}
 
-    <turbo-frame id="comics-list" {{ stimulus_target('library', 'results') }}>
+    <div {{ stimulus_target('library', 'results') }}>
         {% if comics|length > 0 %}
             <div class="cards-grid">
                 {% for comic in comics %}
@@ -30,6 +30,6 @@
                 <p>Aucune serie trouvee dans la liste de souhaits.</p>
             </div>
         {% endif %}
-    </turbo-frame>
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Remplacement des `<turbo-frame>` par des `<div>` sur les pages bibliothèque, wishlist et recherche
- Les frames interféraient avec la restauration de page de Turbo Drive (back/forward)
- Le filtrage est entièrement côté client via Stimulus — les frames n'étaient pas utilisés pour leur fonction native

## Test plan

- [ ] Naviguer vers une fiche série depuis la bibliothèque, puis appuyer sur le bouton Précédent → la liste se réaffiche correctement
- [ ] Même test depuis la wishlist
- [ ] Même test depuis la recherche
- [ ] Vérifier que le filtrage (chips, tri, recherche) fonctionne toujours normalement
- [ ] Vérifier la navigation forward (bouton Suivant) après un retour arrière

fixes #63