### PR TITLE
fix(lookup): optimiser les URL de couverture Google Books

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Fixed
 
+- **Couvertures Google Books** : Les couvertures provenant de Google Books sont désormais récupérées en meilleure résolution (`zoom=0`), suppression de l'effet de page cornée (`edge=curl`) et passage en HTTPS
 - **Navigation** : Les boutons précédent/suivant du navigateur fonctionnent désormais correctement vers les pages de liste (bibliothèque, wishlist, recherche) — remplacement des `<turbo-frame>` inutilisés par des `<div>` pour ne pas interférer avec la restauration de page Turbo Drive
 - **Import Excel** : Les titres avec un article entre parenthèses (`(le)`, `(la)`, `(les)`, `(l')`) sont désormais normalisés lors de l'import (ex: `monde perdu (le)` → `le monde perdu`)
 

--- a/src/Service/Lookup/GoogleBooksLookup.php
+++ b/src/Service/Lookup/GoogleBooksLookup.php
@@ -177,9 +177,13 @@ class GoogleBooksLookup implements LookupProviderInterface
             }
 
             if (null === $thumbnail) {
-                $thumbnail = $volumeInfo['imageLinks']['thumbnail']
+                $rawThumbnail = $volumeInfo['imageLinks']['thumbnail']
                     ?? $volumeInfo['imageLinks']['smallThumbnail']
                     ?? null;
+
+                if (\is_string($rawThumbnail)) {
+                    $thumbnail = $this->optimizeThumbnailUrl($rawThumbnail);
+                }
             }
 
             if (null === $title && !empty($volumeInfo['title'])) {
@@ -210,6 +214,26 @@ class GoogleBooksLookup implements LookupProviderInterface
             thumbnail: $thumbnail,
             title: $title,
         );
+    }
+
+    /**
+     * Optimise l'URL d'une couverture Google Books pour obtenir une meilleure résolution.
+     *
+     * - Remplace zoom=1 par zoom=0 (plus grande image disponible)
+     * - Supprime edge=curl (effet de page cornée)
+     * - Force HTTPS
+     */
+    private function optimizeThumbnailUrl(string $url): string
+    {
+        if (!\str_contains($url, 'books.google.com/')) {
+            return $url;
+        }
+
+        $url = (string) \preg_replace('#^http://#', 'https://', $url);
+        $url = \str_replace('zoom=1', 'zoom=0', $url);
+        $url = (string) \preg_replace('/&?edge=curl&?/', '&', $url);
+
+        return \rtrim($url, '&');
     }
 
     private function recordApiMessage(ApiLookupStatus $status, string $message): void

--- a/tests/Service/Lookup/GoogleBooksLookupTest.php
+++ b/tests/Service/Lookup/GoogleBooksLookupTest.php
@@ -148,6 +148,93 @@ class GoogleBooksLookupTest extends TestCase
         self::assertSame('https://example.com/small.jpg', $result->thumbnail);
     }
 
+    public function testThumbnailUrlIsOptimizedForLargerResolution(): void
+    {
+        $response = new MockResponse(\json_encode([
+            'items' => [
+                [
+                    'volumeInfo' => [
+                        'imageLinks' => [
+                            'thumbnail' => 'http://books.google.com/books/content?id=ABC123&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api',
+                        ],
+                        'title' => 'Book with Google Books URL',
+                    ],
+                ],
+            ],
+        ]));
+
+        $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
+
+        self::assertSame(
+            'https://books.google.com/books/content?id=ABC123&printsec=frontcover&img=1&zoom=0&source=gbs_api',
+            $result->thumbnail,
+        );
+    }
+
+    public function testThumbnailUrlReplacesHttpWithHttps(): void
+    {
+        $response = new MockResponse(\json_encode([
+            'items' => [
+                [
+                    'volumeInfo' => [
+                        'imageLinks' => [
+                            'thumbnail' => 'http://books.google.com/books/content?id=XYZ&img=1&zoom=1&source=gbs_api',
+                        ],
+                        'title' => 'HTTP URL book',
+                    ],
+                ],
+            ],
+        ]));
+
+        $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
+
+        self::assertStringStartsWith('https://', $result->thumbnail);
+    }
+
+    public function testThumbnailUrlRemovesEdgeCurl(): void
+    {
+        $response = new MockResponse(\json_encode([
+            'items' => [
+                [
+                    'volumeInfo' => [
+                        'imageLinks' => [
+                            'thumbnail' => 'https://books.google.com/books/content?id=ABC&img=1&zoom=1&edge=curl&source=gbs_api',
+                        ],
+                        'title' => 'Book with edge curl',
+                    ],
+                ],
+            ],
+        ]));
+
+        $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
+
+        self::assertStringNotContainsString('edge=curl', $result->thumbnail);
+    }
+
+    public function testThumbnailUrlLeavesNonGoogleUrlsUntouched(): void
+    {
+        $response = new MockResponse(\json_encode([
+            'items' => [
+                [
+                    'volumeInfo' => [
+                        'imageLinks' => [
+                            'thumbnail' => 'https://example.com/cover.jpg',
+                        ],
+                        'title' => 'Book with external URL',
+                    ],
+                ],
+            ],
+        ]));
+
+        $provider = new GoogleBooksLookup(new MockHttpClient([$response]), new NullLogger());
+        $result = $this->doLookup($provider, '1234567890', null, 'isbn');
+
+        self::assertSame('https://example.com/cover.jpg', $result->thumbnail);
+    }
+
     public function testLookupByIsbnExtractsIsbn13(): void
     {
         $response = new MockResponse(\json_encode([


### PR DESCRIPTION
## Summary

- Optimise les URL de couverture Google Books dans `GoogleBooksLookup` pour récupérer des images en meilleure résolution
- Remplace `zoom=1` par `zoom=0` (plus grande taille disponible)
- Supprime l'effet de page cornée (`edge=curl`)
- Force HTTPS sur les URL de couverture
- Les URL non-Google Books restent inchangées

## Test plan

- [x] Tests unitaires ajoutés pour la transformation d'URL (zoom, edge=curl, HTTPS, URL non-Google)
- [x] 22/22 tests GoogleBooksLookupTest passent
- [x] PHP CS Fixer : 0 erreur
- [x] PHPStan : aucune nouvelle erreur

fixes #66