### PR TITLE
feat(ux): remplacer alert/confirm natifs par des modales custom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Modales de confirmation** : Les `confirm()` et `alert()` natifs du navigateur sont remplacés par des modales `<dialog>` custom Material Design via un nouveau Stimulus controller `confirm-modal` (suppression de séries dans les cartes, la page détail et la corbeille)
+- **Page hors ligne** : Le message d'erreur "Toujours hors ligne" s'affiche désormais en inline dans la page au lieu d'un `alert()` natif
+
 ### Fixed
 
 - **Couvertures Google Books** : Les couvertures provenant de Google Books sont désormais récupérées en meilleure résolution (`zoom=0`), suppression de l'effet de page cornée (`edge=curl`) et passage en HTTPS

--- a/assets/controllers/confirm_modal_controller.js
+++ b/assets/controllers/confirm_modal_controller.js
@@ -1,0 +1,95 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Contrôleur Stimulus pour remplacer les confirm() natifs par une modale <dialog>.
+ *
+ * Usage :
+ *   <form data-controller="confirm-modal"
+ *         data-confirm-modal-message-value="Supprimer ?"
+ *         data-confirm-modal-destructive-value="true"
+ *         data-action="submit->confirm-modal#intercept">
+ */
+export default class extends Controller {
+    static values = {
+        cancelLabel: { default: 'Annuler', type: String },
+        confirmLabel: { default: 'Confirmer', type: String },
+        destructive: { default: false, type: Boolean },
+        message: String,
+    };
+
+    #confirmed = false;
+    #dialog = null;
+
+    intercept(event) {
+        if (this.#confirmed) {
+            this.#confirmed = false;
+            return;
+        }
+
+        event.preventDefault();
+
+        if (this.#dialog) return;
+
+        this.#dialog = this.#createDialog();
+        document.body.appendChild(this.#dialog);
+        this.#dialog.showModal();
+    }
+
+    disconnect() {
+        this.#cleanup();
+    }
+
+    #createDialog() {
+        const dialog = document.createElement('dialog');
+        dialog.classList.add('confirm-modal');
+
+        const content = document.createElement('div');
+        content.classList.add('confirm-modal-content');
+
+        const message = document.createElement('p');
+        message.classList.add('confirm-modal-message');
+        message.textContent = this.messageValue;
+
+        const actions = document.createElement('div');
+        actions.classList.add('confirm-modal-actions');
+
+        const cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.classList.add('confirm-modal-cancel');
+        cancelBtn.textContent = this.cancelLabelValue;
+        cancelBtn.addEventListener('click', () => this.#cancel());
+
+        const confirmBtn = document.createElement('button');
+        confirmBtn.type = 'button';
+        confirmBtn.classList.add('confirm-modal-confirm');
+        if (this.destructiveValue) {
+            confirmBtn.classList.add('confirm-modal-confirm--destructive');
+        }
+        confirmBtn.textContent = this.confirmLabelValue;
+        confirmBtn.addEventListener('click', () => this.#confirm());
+
+        actions.append(cancelBtn, confirmBtn);
+        content.append(message, actions);
+        dialog.appendChild(content);
+        dialog.addEventListener('close', () => this.#cleanup());
+
+        return dialog;
+    }
+
+    #confirm() {
+        this.#confirmed = true;
+        this.#dialog.close();
+        this.element.requestSubmit();
+    }
+
+    #cancel() {
+        this.#dialog.close();
+    }
+
+    #cleanup() {
+        if (this.#dialog) {
+            this.#dialog.remove();
+            this.#dialog = null;
+        }
+    }
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -2495,3 +2495,88 @@ body[data-connection-status="OFFLINE"] .offline-indicator {
         right: var(--md-spacing-lg);
     }
 }
+
+/* ===== Confirm Modal ===== */
+.confirm-modal {
+    background: var(--md-surface);
+    border: none;
+    border-radius: var(--md-radius-lg);
+    box-shadow: var(--md-elevation-3);
+    margin: auto;
+    max-width: 360px;
+    padding: 0;
+    position: fixed;
+    width: calc(100% - 2 * var(--md-spacing-lg));
+}
+
+.confirm-modal::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+}
+
+.confirm-modal[open] {
+    animation: confirm-modal-fade-in 150ms ease-out;
+}
+
+.confirm-modal-content {
+    padding: var(--md-spacing-lg);
+}
+
+.confirm-modal-message {
+    color: var(--md-text-high);
+    font-size: 1rem;
+    line-height: 1.5;
+    margin-bottom: var(--md-spacing-lg);
+}
+
+.confirm-modal-actions {
+    display: flex;
+    gap: var(--md-spacing-sm);
+    justify-content: flex-end;
+}
+
+.confirm-modal-cancel {
+    background: transparent;
+    border: none;
+    border-radius: var(--md-radius-sm);
+    color: var(--md-text-medium);
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+    letter-spacing: 0.5px;
+    padding: var(--md-spacing-sm) var(--md-spacing-md);
+}
+
+.confirm-modal-cancel:hover {
+    background: rgba(0, 0, 0, 0.04);
+}
+
+.confirm-modal-confirm {
+    background: var(--md-primary);
+    border: none;
+    border-radius: var(--md-radius-sm);
+    color: var(--md-on-primary);
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+    letter-spacing: 0.5px;
+    padding: var(--md-spacing-sm) var(--md-spacing-md);
+}
+
+.confirm-modal-confirm:hover {
+    opacity: 0.9;
+}
+
+.confirm-modal-confirm--destructive {
+    background: var(--md-error);
+}
+
+@keyframes confirm-modal-fade-in {
+    from {
+        opacity: 0;
+        transform: scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}

--- a/assets/utils/card-renderer.js
+++ b/assets/utils/card-renderer.js
@@ -123,7 +123,11 @@ export function renderCard(comic, options = {}) {
     }
 
     actionsHtml += `
-            <form action="/comic/${comic.id}/delete" method="post" class="inline-form" data-turbo-frame="_top" onsubmit="return confirm('Supprimer cette serie ?');">
+            <form action="/comic/${comic.id}/delete" method="post" class="inline-form" data-turbo-frame="_top"
+                  data-controller="confirm-modal"
+                  data-confirm-modal-message-value="Supprimer cette série ?"
+                  data-confirm-modal-destructive-value="true"
+                  data-action="submit->confirm-modal#intercept">
                 <input type="hidden" name="_token" value="${escapeHtml(comic.deleteToken || '')}">
                 <button type="submit" class="btn btn-danger btn-full-width">Supprimer</button>
             </form>

--- a/templates/comic/_card.html.twig
+++ b/templates/comic/_card.html.twig
@@ -85,7 +85,11 @@
             </form>
         {% endif %}
 
-        <form action="{{ path('app_comic_delete', {id: comic.id}) }}" method="post" class="inline-form" data-turbo-frame="_top" onsubmit="return confirm('Supprimer cette serie ?');">
+        <form action="{{ path('app_comic_delete', {id: comic.id}) }}" method="post" class="inline-form" data-turbo-frame="_top"
+              data-controller="confirm-modal"
+              data-confirm-modal-message-value="Supprimer cette série ?"
+              data-confirm-modal-destructive-value="true"
+              data-action="submit->confirm-modal#intercept">
             <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ comic.id) }}">
             <button type="submit" class="btn btn-danger btn-full-width">Supprimer</button>
         </form>

--- a/templates/comic/show.html.twig
+++ b/templates/comic/show.html.twig
@@ -168,7 +168,11 @@
             Modifier
         </a>
 
-        <form action="{{ path('app_comic_delete', {id: comic.id}) }}" method="post" class="inline-form" onsubmit="return confirm('Déplacer cette série dans la corbeille ?');">
+        <form action="{{ path('app_comic_delete', {id: comic.id}) }}" method="post" class="inline-form"
+              data-controller="confirm-modal"
+              data-confirm-modal-message-value="Déplacer cette série dans la corbeille ?"
+              data-confirm-modal-destructive-value="true"
+              data-action="submit->confirm-modal#intercept">
             <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ comic.id) }}">
             <button type="submit" class="btn btn-danger">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">

--- a/templates/offline.html.twig
+++ b/templates/offline.html.twig
@@ -84,6 +84,20 @@
             .btn:hover {
                 opacity: 0.9;
             }
+
+            .offline-alert {
+                background-color: #fff3e0;
+                border-radius: 8px;
+                color: #e65100;
+                display: none;
+                font-size: 0.875rem;
+                margin-top: 1rem;
+                padding: 0.75rem 1rem;
+            }
+
+            .offline-alert--visible {
+                display: block;
+            }
         </style>
     </head>
     <body>
@@ -96,6 +110,7 @@
             <button class="btn btn-secondary" onclick="history.back()">Retour</button>
             <button class="btn btn-primary" id="retry-btn">Reessayer</button>
         </div>
+        <div class="offline-alert" id="offline-alert">Toujours hors ligne. Vérifiez votre connexion.</div>
 
         <script>
             const params = new URLSearchParams(window.location.search);
@@ -105,7 +120,7 @@
                 if (navigator.onLine) {
                     window.location.href = targetUrl;
                 } else {
-                    alert('Toujours hors ligne. Verifiez votre connexion.');
+                    document.getElementById('offline-alert').classList.add('offline-alert--visible');
                 }
             });
 

--- a/templates/trash/index.html.twig
+++ b/templates/trash/index.html.twig
@@ -30,7 +30,11 @@
                             Restaurer
                         </button>
                     </form>
-                    <form action="{{ path('app_trash_permanent_delete', {id: comic.id}) }}" method="post" class="inline-form" onsubmit="return confirm('Supprimer définitivement cette série ? Cette action est irréversible.');">
+                    <form action="{{ path('app_trash_permanent_delete', {id: comic.id}) }}" method="post" class="inline-form"
+                          data-controller="confirm-modal"
+                          data-confirm-modal-message-value="Supprimer définitivement cette série ? Cette action est irréversible."
+                          data-confirm-modal-destructive-value="true"
+                          data-action="submit->confirm-modal#intercept">
                         <input type="hidden" name="_token" value="{{ csrf_token('permanent-delete' ~ comic.id) }}">
                         <button type="submit" class="btn btn-danger btn-sm">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18">

--- a/tests/js/controllers/confirm_modal_controller.test.js
+++ b/tests/js/controllers/confirm_modal_controller.test.js
@@ -1,0 +1,230 @@
+import ConfirmModalController from '../../../assets/controllers/confirm_modal_controller.js';
+import { startStimulusController, stopStimulusController } from '../helpers/stimulus-helper.js';
+
+function buildHtml(attrs = {}) {
+    const message = attrs.message || 'Supprimer cette série ?';
+    const destructive = attrs.destructive !== undefined ? attrs.destructive : false;
+    const confirmLabel = attrs.confirmLabel || '';
+    const cancelLabel = attrs.cancelLabel || '';
+
+    let extra = '';
+    if (confirmLabel) extra += ` data-confirm-modal-confirm-label-value="${confirmLabel}"`;
+    if (cancelLabel) extra += ` data-confirm-modal-cancel-label-value="${cancelLabel}"`;
+
+    return `
+        <form data-controller="confirm-modal"
+              data-confirm-modal-message-value="${message}"
+              data-confirm-modal-destructive-value="${destructive}"
+              ${extra}
+              data-action="submit->confirm-modal#intercept"
+              action="/test" method="post">
+            <button type="submit">Supprimer</button>
+        </form>
+    `;
+}
+
+// Polyfill <dialog> pour jsdom (showModal, close, open)
+beforeAll(() => {
+    if (!HTMLDialogElement.prototype.showModal) {
+        HTMLDialogElement.prototype.showModal = function () {
+            this.setAttribute('open', '');
+        };
+    }
+    const originalClose = HTMLDialogElement.prototype.close;
+    HTMLDialogElement.prototype.close = function () {
+        this.removeAttribute('open');
+        if (originalClose) originalClose.call(this);
+        this.dispatchEvent(new Event('close'));
+    };
+});
+
+describe('confirm_modal_controller', () => {
+    let application;
+
+    afterEach(() => {
+        if (application) stopStimulusController(application);
+        // Nettoyer les dialogs restants
+        document.querySelectorAll('dialog').forEach((d) => d.remove());
+    });
+
+    async function setup(attrs = {}) {
+        ({ application } = await startStimulusController(
+            ConfirmModalController, 'confirm-modal', buildHtml(attrs),
+        ));
+    }
+
+    function getForm() {
+        return document.querySelector('[data-controller="confirm-modal"]');
+    }
+
+    function getDialog() {
+        return document.querySelector('dialog');
+    }
+
+    describe('intercept', () => {
+        it('empêche la soumission du formulaire et affiche un dialog', async () => {
+            await setup();
+            const form = getForm();
+            const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+            form.dispatchEvent(submitEvent);
+
+            expect(submitEvent.defaultPrevented).toBe(true);
+            const dialog = getDialog();
+            expect(dialog).not.toBeNull();
+            expect(dialog.open).toBe(true);
+        });
+
+        it('affiche le message configuré dans le dialog', async () => {
+            await setup({ message: 'Vraiment supprimer ?' });
+            const form = getForm();
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+            const dialog = getDialog();
+            expect(dialog.textContent).toContain('Vraiment supprimer ?');
+        });
+
+        it('utilise les labels par défaut pour les boutons', async () => {
+            await setup();
+            const form = getForm();
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+            const dialog = getDialog();
+            const buttons = dialog.querySelectorAll('button');
+            expect(buttons[0].textContent).toBe('Annuler');
+            expect(buttons[1].textContent).toBe('Confirmer');
+        });
+
+        it('utilise des labels personnalisés pour les boutons', async () => {
+            await setup({ confirmLabel: 'Oui', cancelLabel: 'Non' });
+            const form = getForm();
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+            const dialog = getDialog();
+            const buttons = dialog.querySelectorAll('button');
+            expect(buttons[0].textContent).toBe('Non');
+            expect(buttons[1].textContent).toBe('Oui');
+        });
+
+        it("n'ouvre pas un second dialog si déjà ouvert", async () => {
+            await setup();
+            const form = getForm();
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+            expect(document.querySelectorAll('dialog').length).toBe(1);
+        });
+    });
+
+    describe('confirmer', () => {
+        it('ferme le dialog et soumet le formulaire', async () => {
+            await setup();
+            const form = getForm();
+            const requestSubmit = vi.fn();
+            form.requestSubmit = requestSubmit;
+
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+            const dialog = getDialog();
+            const confirmBtn = dialog.querySelector('.confirm-modal-confirm');
+            confirmBtn.click();
+
+            expect(dialog.open).toBe(false);
+            expect(requestSubmit).toHaveBeenCalled();
+        });
+
+        it('bypass l\'interception lors du re-submit après confirmation', async () => {
+            await setup();
+            const form = getForm();
+            let submitCount = 0;
+            form.requestSubmit = () => {
+                // Simule le re-submit : le flag _confirmed doit empêcher l'interception
+                const event = new Event('submit', { bubbles: true, cancelable: true });
+                form.dispatchEvent(event);
+                if (!event.defaultPrevented) submitCount++;
+            };
+
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+            const confirmBtn = getDialog().querySelector('.confirm-modal-confirm');
+            confirmBtn.click();
+
+            expect(submitCount).toBe(1);
+        });
+    });
+
+    describe('annuler', () => {
+        it('ferme le dialog sans soumettre le formulaire', async () => {
+            await setup();
+            const form = getForm();
+            const requestSubmit = vi.fn();
+            form.requestSubmit = requestSubmit;
+
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+            const dialog = getDialog();
+            const cancelBtn = dialog.querySelector('.confirm-modal-cancel');
+            cancelBtn.click();
+
+            expect(dialog.open).toBe(false);
+            expect(requestSubmit).not.toHaveBeenCalled();
+        });
+
+        it('supprime le dialog du DOM après annulation', async () => {
+            await setup();
+            const form = getForm();
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+            const cancelBtn = getDialog().querySelector('.confirm-modal-cancel');
+            cancelBtn.click();
+
+            expect(getDialog()).toBeNull();
+        });
+    });
+
+    describe('mode destructif', () => {
+        it('ajoute la classe destructive au bouton confirmer', async () => {
+            await setup({ destructive: true });
+            const form = getForm();
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+            const confirmBtn = getDialog().querySelector('.confirm-modal-confirm');
+            expect(confirmBtn.classList.contains('confirm-modal-confirm--destructive')).toBe(true);
+        });
+
+        it("n'ajoute pas la classe destructive par défaut", async () => {
+            await setup({ destructive: false });
+            const form = getForm();
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+            const confirmBtn = getDialog().querySelector('.confirm-modal-confirm');
+            expect(confirmBtn.classList.contains('confirm-modal-confirm--destructive')).toBe(false);
+        });
+    });
+
+    describe('fermeture par Escape (natif dialog)', () => {
+        it('supprime le dialog du DOM quand il est fermé', async () => {
+            await setup();
+            const form = getForm();
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+            const dialog = getDialog();
+            // Simule la fermeture native (Escape) — le polyfill dispatche 'close'
+            dialog.close();
+
+            expect(getDialog()).toBeNull();
+        });
+    });
+
+    describe('disconnect', () => {
+        it('nettoie le dialog ouvert quand le contrôleur se déconnecte', async () => {
+            await setup();
+            const form = getForm();
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+            expect(getDialog()).not.toBeNull();
+            stopStimulusController(application);
+            application = null;
+
+            expect(getDialog()).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Nouveau Stimulus controller `confirm-modal` utilisant `<dialog>` natif (backdrop, focus trap, Escape, accessibilité)
- Styles Material Design : carte centrée, boutons texte/filled, mode destructif (rouge), animation fade-in
- Remplacement des `onsubmit="return confirm(...)"` dans `_card.html.twig`, `show.html.twig`, `trash/index.html.twig` et `card-renderer.js`
- Page offline : `alert()` remplacé par un message inline visible dans le DOM

## Test plan
- [x] 13 tests Vitest (controller)
- [x] 219 tests JS passent
- [x] 543 tests PHP passent
- [x] PHP-CS-Fixer clean
- [ ] Test manuel : cliquer "Supprimer" sur card, show, trash → modale custom
- [ ] Test manuel : bouton Annuler ne supprime pas, bouton Confirmer supprime
- [ ] Test manuel offline.html.twig : cliquer "Réessayer" hors ligne → message inline

Fixes #67