### PR TITLE
Skeleton loaders sur toutes les pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Skeleton loaders** : Remplacement du texte « Chargement… » par des skeleton placeholders animés sur toutes les pages — grille de cartes (Home/Wishlist), détail série, corbeille, formulaire d'édition (#85)
 - **Tri des séries** : Sélecteur de tri sur les pages Accueil et Liste de souhaits — titre (A→Z/Z→A), date d'ajout (récent/ancien), nombre de tomes (#84)
 - **Mode hors-ligne avec synchronisation différée** : CRUD complet (séries + tomes) en mode offline avec synchronisation automatique au retour en ligne (#3)
   - File d'attente IndexedDB (via `idb`) pour les opérations offline

--- a/frontend/src/__tests__/integration/components/ComicCardSkeleton.test.tsx
+++ b/frontend/src/__tests__/integration/components/ComicCardSkeleton.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import ComicCardSkeleton from "../../../components/ComicCardSkeleton";
+
+describe("ComicCardSkeleton", () => {
+  it("renders skeleton card with correct structure", () => {
+    render(<ComicCardSkeleton />);
+
+    expect(screen.getByTestId("comic-card-skeleton")).toBeInTheDocument();
+    // Contains multiple skeleton boxes (cover + text lines + actions)
+    expect(screen.getAllByTestId("skeleton-box").length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("has the same border styling as ComicCard", () => {
+    render(<ComicCardSkeleton />);
+
+    const card = screen.getByTestId("comic-card-skeleton");
+    expect(card).toHaveClass("rounded-xl");
+    expect(card).toHaveClass("border");
+    expect(card).toHaveClass("border-surface-border");
+  });
+});

--- a/frontend/src/__tests__/integration/components/SkeletonBox.test.tsx
+++ b/frontend/src/__tests__/integration/components/SkeletonBox.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import SkeletonBox from "../../../components/SkeletonBox";
+
+describe("SkeletonBox", () => {
+  it("renders with animate-pulse class", () => {
+    render(<SkeletonBox />);
+
+    const box = screen.getByTestId("skeleton-box");
+    expect(box).toHaveClass("animate-pulse");
+    expect(box).toHaveClass("bg-surface-tertiary");
+  });
+
+  it("applies custom className", () => {
+    render(<SkeletonBox className="h-4 w-3/4" />);
+
+    const box = screen.getByTestId("skeleton-box");
+    expect(box).toHaveClass("h-4");
+    expect(box).toHaveClass("w-3/4");
+  });
+});

--- a/frontend/src/__tests__/integration/pages/ComicDetail.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicDetail.test.tsx
@@ -41,7 +41,7 @@ describe("ComicDetail", () => {
     localStorage.setItem("jwt_token", "fake-jwt-token");
   });
 
-  it("shows loading state initially", () => {
+  it("shows skeleton loader initially", () => {
     // Use a handler that delays response
     server.use(
       http.get("/api/comic_series/:id", async () => {
@@ -52,7 +52,8 @@ describe("ComicDetail", () => {
 
     renderComicDetail();
 
-    expect(screen.getByText("Chargement…")).toBeInTheDocument();
+    expect(screen.getByTestId("comic-detail-skeleton")).toBeInTheDocument();
+    expect(screen.getAllByTestId("skeleton-box").length).toBeGreaterThanOrEqual(5);
   });
 
   it("renders comic title", async () => {

--- a/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
@@ -166,7 +166,7 @@ describe("ComicForm", () => {
   });
 
   describe("Edit mode", () => {
-    it("shows loading state while fetching comic", () => {
+    it("shows skeleton loader while fetching comic", () => {
       server.use(
         http.get("/api/comic_series/1", async () => {
           await new Promise((resolve) => setTimeout(resolve, 100));
@@ -176,7 +176,8 @@ describe("ComicForm", () => {
 
       renderEditForm();
 
-      expect(screen.getByText("Chargement…")).toBeInTheDocument();
+      expect(screen.getByTestId("comic-form-skeleton")).toBeInTheDocument();
+      expect(screen.getAllByTestId("skeleton-box").length).toBeGreaterThanOrEqual(5);
     });
 
     it("renders page title for edit", async () => {

--- a/frontend/src/__tests__/integration/pages/Home.test.tsx
+++ b/frontend/src/__tests__/integration/pages/Home.test.tsx
@@ -29,10 +29,11 @@ describe("Home", () => {
     localStorage.setItem("jwt_token", "fake-jwt-token");
   });
 
-  it("shows loading state initially", () => {
+  it("shows skeleton loaders initially", () => {
     renderWithProviders(<Home />);
 
-    expect(screen.getByText("Chargement…")).toBeInTheDocument();
+    const skeletons = screen.getAllByTestId("comic-card-skeleton");
+    expect(skeletons).toHaveLength(8);
   });
 
   it("renders comic series list", async () => {

--- a/frontend/src/__tests__/integration/pages/Trash.test.tsx
+++ b/frontend/src/__tests__/integration/pages/Trash.test.tsx
@@ -33,10 +33,11 @@ describe("Trash", () => {
     expect(screen.getByText("Corbeille")).toBeInTheDocument();
   });
 
-  it("shows loading state initially", () => {
+  it("shows skeleton loader initially", () => {
     renderWithProviders(<Trash />);
 
-    expect(screen.getByText("Chargement…")).toBeInTheDocument();
+    expect(screen.getByTestId("trash-skeleton")).toBeInTheDocument();
+    expect(screen.getAllByTestId("skeleton-box").length).toBeGreaterThanOrEqual(4);
   });
 
   it("shows empty state when no trashed comics", async () => {

--- a/frontend/src/__tests__/integration/pages/Wishlist.test.tsx
+++ b/frontend/src/__tests__/integration/pages/Wishlist.test.tsx
@@ -22,10 +22,11 @@ describe("Wishlist", () => {
     expect(screen.getByText("Liste de souhaits")).toBeInTheDocument();
   });
 
-  it("shows loading state initially", () => {
+  it("shows skeleton loaders initially", () => {
     renderWithProviders(<Wishlist />);
 
-    expect(screen.getByText("Chargement…")).toBeInTheDocument();
+    const skeletons = screen.getAllByTestId("comic-card-skeleton");
+    expect(skeletons).toHaveLength(8);
   });
 
   it("shows wishlist comics only", async () => {

--- a/frontend/src/components/ComicCardSkeleton.tsx
+++ b/frontend/src/components/ComicCardSkeleton.tsx
@@ -1,0 +1,25 @@
+import SkeletonBox from "./SkeletonBox";
+
+export default function ComicCardSkeleton() {
+  return (
+    <div
+      className="overflow-hidden rounded-xl border border-surface-border bg-surface-primary"
+      data-testid="comic-card-skeleton"
+    >
+      {/* Cover */}
+      <SkeletonBox className="aspect-[3/4] !rounded-none" />
+
+      {/* Info */}
+      <div className="space-y-2 p-2">
+        <SkeletonBox className="h-4 w-3/4" />
+        <SkeletonBox className="h-3 w-1/2" />
+
+        {/* Actions */}
+        <div className="flex gap-1 border-t border-surface-border pt-2">
+          <SkeletonBox className="h-8 flex-1" />
+          <SkeletonBox className="h-8 flex-1" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SkeletonBox.tsx
+++ b/frontend/src/components/SkeletonBox.tsx
@@ -1,0 +1,12 @@
+interface SkeletonBoxProps {
+  className?: string;
+}
+
+export default function SkeletonBox({ className = "" }: SkeletonBoxProps) {
+  return (
+    <div
+      className={`animate-pulse rounded-lg bg-surface-tertiary ${className}`}
+      data-testid="skeleton-box"
+    />
+  );
+}

--- a/frontend/src/pages/ComicDetail.tsx
+++ b/frontend/src/pages/ComicDetail.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import ConfirmModal from "../components/ConfirmModal";
+import SkeletonBox from "../components/SkeletonBox";
 import { useComic } from "../hooks/useComic";
 import { useDeleteComic } from "../hooks/useDeleteComic";
 import { ComicStatus, ComicStatusLabel, ComicTypeLabel } from "../types/enums";
@@ -15,7 +16,37 @@ export default function ComicDetail() {
   const [showDelete, setShowDelete] = useState(false);
 
   if (isLoading) {
-    return <div className="py-12 text-center text-text-muted">Chargement…</div>;
+    return (
+      <div className="mx-auto max-w-4xl space-y-6" data-testid="comic-detail-skeleton">
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <SkeletonBox className="h-5 w-5" />
+          <SkeletonBox className="h-6 w-48" />
+        </div>
+        {/* Content */}
+        <div className="flex flex-col gap-6 md:flex-row">
+          <SkeletonBox className="aspect-[3/4] w-full md:w-48" />
+          <div className="flex-1 space-y-3">
+            <div className="flex gap-2">
+              <SkeletonBox className="h-7 w-20 !rounded-full" />
+              <SkeletonBox className="h-7 w-24 !rounded-full" />
+            </div>
+            <SkeletonBox className="h-4 w-3/4" />
+            <SkeletonBox className="h-4 w-1/2" />
+            <SkeletonBox className="h-16 w-full" />
+          </div>
+        </div>
+        {/* Tomes table */}
+        <div>
+          <SkeletonBox className="mb-3 h-6 w-32" />
+          <div className="space-y-2">
+            {Array.from({ length: 5 }, (_, i) => (
+              <SkeletonBox className="h-10 w-full" key={i} />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
   }
 
   if (!comic) {

--- a/frontend/src/pages/ComicForm.tsx
+++ b/frontend/src/pages/ComicForm.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import BarcodeScanner from "../components/BarcodeScanner";
+import SkeletonBox from "../components/SkeletonBox";
 import { useAuthors } from "../hooks/useAuthors";
 import { useOnlineStatus } from "../hooks/useOnlineStatus";
 import { apiFetch } from "../services/api";
@@ -183,7 +184,46 @@ export default function ComicForm() {
   }, [comic, isEdit, initialized]);
 
   if (isEdit && !initialized) {
-    return <div className="py-12 text-center text-text-muted">Chargement…</div>;
+    return (
+      <div className="mx-auto max-w-3xl space-y-6" data-testid="comic-form-skeleton">
+        <div className="flex items-center gap-3">
+          <SkeletonBox className="h-5 w-5" />
+          <SkeletonBox className="h-6 w-40" />
+        </div>
+        <div className="space-y-5">
+          {/* Title field */}
+          <div>
+            <SkeletonBox className="mb-1 h-4 w-16" />
+            <SkeletonBox className="h-10 w-full" />
+          </div>
+          {/* Type + Status */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <SkeletonBox className="mb-1 h-4 w-12" />
+              <SkeletonBox className="h-10 w-full" />
+            </div>
+            <div>
+              <SkeletonBox className="mb-1 h-4 w-14" />
+              <SkeletonBox className="h-10 w-full" />
+            </div>
+          </div>
+          {/* Publisher + Cover */}
+          <div>
+            <SkeletonBox className="mb-1 h-4 w-16" />
+            <SkeletonBox className="h-10 w-full" />
+          </div>
+          <div>
+            <SkeletonBox className="mb-1 h-4 w-28" />
+            <SkeletonBox className="h-10 w-full" />
+          </div>
+          {/* Description */}
+          <div>
+            <SkeletonBox className="mb-1 h-4 w-24" />
+            <SkeletonBox className="h-20 w-full" />
+          </div>
+        </div>
+      </div>
+    );
   }
 
   const update = <K extends keyof FormData>(key: K, value: FormData[K]) => {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { Search } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import ComicCard from "../components/ComicCard";
+import ComicCardSkeleton from "../components/ComicCardSkeleton";
 import ConfirmModal from "../components/ConfirmModal";
 import Filters from "../components/Filters";
 import { useComics } from "../hooks/useComics";
@@ -62,7 +63,11 @@ export default function Home() {
       </div>
 
       {isLoading ? (
-        <div className="py-12 text-center text-text-muted">Chargement…</div>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+          {Array.from({ length: 8 }, (_, i) => (
+            <ComicCardSkeleton key={i} />
+          ))}
+        </div>
       ) : filtered.length === 0 ? (
         <div className="py-12 text-center text-text-muted">Aucune série trouvée</div>
       ) : (

--- a/frontend/src/pages/Trash.tsx
+++ b/frontend/src/pages/Trash.tsx
@@ -2,6 +2,7 @@ import { RotateCcw, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import ConfirmModal from "../components/ConfirmModal";
+import SkeletonBox from "../components/SkeletonBox";
 import { usePermanentDelete, useRestoreComic, useTrash } from "../hooks/useTrash";
 import type { ComicSeries } from "../types/api";
 
@@ -18,7 +19,16 @@ export default function Trash() {
       <h1 className="text-xl font-bold text-text-primary">Corbeille</h1>
 
       {isLoading ? (
-        <div className="py-12 text-center text-text-muted">Chargement…</div>
+        <div className="space-y-2" data-testid="trash-skeleton">
+          {Array.from({ length: 4 }, (_, i) => (
+            <div className="flex items-center gap-3 rounded-lg border border-surface-border bg-surface-primary p-3" key={i}>
+              <SkeletonBox className="h-12 w-9 !rounded" />
+              <SkeletonBox className="h-5 flex-1" />
+              <SkeletonBox className="h-8 w-8" />
+              <SkeletonBox className="h-8 w-8" />
+            </div>
+          ))}
+        </div>
       ) : comics.length === 0 ? (
         <div className="py-12 text-center text-text-muted">La corbeille est vide</div>
       ) : (

--- a/frontend/src/pages/Wishlist.tsx
+++ b/frontend/src/pages/Wishlist.tsx
@@ -1,6 +1,7 @@
 import { Search } from "lucide-react";
 import { useMemo, useState } from "react";
 import ComicCard from "../components/ComicCard";
+import ComicCardSkeleton from "../components/ComicCardSkeleton";
 import Filters from "../components/Filters";
 import { useComics } from "../hooks/useComics";
 import { ComicStatus } from "../types/enums";
@@ -59,7 +60,11 @@ export default function Wishlist() {
       </div>
 
       {isLoading ? (
-        <div className="py-12 text-center text-text-muted">Chargement…</div>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+          {Array.from({ length: 8 }, (_, i) => (
+            <ComicCardSkeleton key={i} />
+          ))}
+        </div>
       ) : filtered.length === 0 ? (
         <div className="py-12 text-center text-text-muted">Aucun souhait pour le moment</div>
       ) : (


### PR DESCRIPTION
## Summary
- Remplacement du texte « Chargement… » par des skeleton placeholders animés sur 5 pages
- Composants `SkeletonBox` (primitive animate-pulse) + `ComicCardSkeleton` (carte grille 3/4)
- Home/Wishlist : grille de 8 cartes skeleton
- ComicDetail : cover + métadonnées + table de tomes
- Trash : 4 items liste
- ComicForm (edit) : champs formulaire

## Test plan
- [x] 402 tests passent (dont 6 nouveaux pour les composants skeleton)
- [x] TypeScript clean
- [x] Tests mis à jour sur les 5 pages pour vérifier les skeletons au lieu de « Chargement… »

fixes #85