### PR TITLE
Recherche floue par titre, auteur et éditeur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Recherche par auteur et éditeur** : La barre de recherche (Accueil + Liste de souhaits) filtre désormais sur le titre, les auteurs et l'éditeur avec recherche floue tolérante aux fautes de frappe via Fuse.js (#89)
 - **Ajout de tomes en lot** : Inputs « Du tome X au tome Y » avec bouton « Générer » dans le formulaire de série — création en lot avec numéros pré-remplis, ignore les numéros déjà existants, tri automatique (#88)
 - **Toggle inline des tomes** : Checkboxes cliquables directement sur la page détail pour basculer acheté/téléchargé/lu/NAS sans passer par le formulaire d'édition — optimistic update, gestion d'erreur avec revert, support offline (#86)
 - **Skeleton loaders** : Remplacement du texte « Chargement… » par des skeleton placeholders animés sur toutes les pages — grille de cartes (Home/Wishlist), détail série, corbeille, formulaire d'édition (#85)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@react-oauth/google": "^0.13.4",
         "@tanstack/react-query": "^5.90",
         "@vitejs/plugin-react": "^5.1",
+        "fuse.js": "^7.1.0",
         "html5-qrcode": "^2.3",
         "idb": "^8.0.3",
         "lucide-react": "^0.575",
@@ -5070,6 +5071,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/generator-function": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@react-oauth/google": "^0.13.4",
     "@tanstack/react-query": "^5.90",
     "@vitejs/plugin-react": "^5.1",
+    "fuse.js": "^7.1.0",
     "html5-qrcode": "^2.3",
     "idb": "^8.0.3",
     "lucide-react": "^0.575",

--- a/frontend/src/__tests__/integration/pages/Home.test.tsx
+++ b/frontend/src/__tests__/integration/pages/Home.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from "msw";
 import { toast } from "sonner";
 import Home from "../../../pages/Home";
 import {
+  createMockAuthor,
   createMockComicSeries,
   createMockHydraCollection,
   createMockTome,
@@ -73,7 +74,7 @@ describe("Home", () => {
   it("renders search input", async () => {
     renderWithProviders(<Home />);
 
-    expect(screen.getByPlaceholderText("Rechercher une série…")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Rechercher par titre, auteur, éditeur…")).toBeInTheDocument();
   });
 
   it("filters comics by search text", async () => {
@@ -95,7 +96,7 @@ describe("Home", () => {
       expect(screen.getByText("Naruto")).toBeInTheDocument();
     });
 
-    await user.type(screen.getByPlaceholderText("Rechercher une série…"), "Naruto");
+    await user.type(screen.getByPlaceholderText("Rechercher par titre, auteur, éditeur…"), "Naruto");
 
     expect(screen.getByText("Naruto")).toBeInTheDocument();
     expect(screen.queryByText("One Piece")).not.toBeInTheDocument();
@@ -372,6 +373,93 @@ describe("Home", () => {
     expect(headings[2]).toHaveTextContent("None");
   });
 
+  it("filters comics by author name", async () => {
+    const user = userEvent.setup();
+    const comics = [
+      createMockComicSeries({
+        authors: [createMockAuthor({ name: "Naoki Urasawa" })],
+        id: 1,
+        title: "Monster",
+      }),
+      createMockComicSeries({
+        authors: [createMockAuthor({ name: "Eiichiro Oda" })],
+        id: 2,
+        title: "One Piece",
+      }),
+    ];
+
+    server.use(
+      http.get("/api/comic_series", () =>
+        HttpResponse.json(createMockHydraCollection(comics)),
+      ),
+    );
+
+    renderWithProviders(<Home />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Monster")).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText("Rechercher par titre, auteur, éditeur…"), "Urasawa");
+
+    expect(screen.getByText("Monster")).toBeInTheDocument();
+    expect(screen.queryByText("One Piece")).not.toBeInTheDocument();
+  });
+
+  it("filters comics by publisher", async () => {
+    const user = userEvent.setup();
+    const comics = [
+      createMockComicSeries({ id: 1, publisher: "Kana", title: "Monster" }),
+      createMockComicSeries({ id: 2, publisher: "Glénat", title: "One Piece" }),
+    ];
+
+    server.use(
+      http.get("/api/comic_series", () =>
+        HttpResponse.json(createMockHydraCollection(comics)),
+      ),
+    );
+
+    renderWithProviders(<Home />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Monster")).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText("Rechercher par titre, auteur, éditeur…"), "Kana");
+
+    expect(screen.getByText("Monster")).toBeInTheDocument();
+    expect(screen.queryByText("One Piece")).not.toBeInTheDocument();
+  });
+
+  it("filters comics with fuzzy search (typos)", async () => {
+    const user = userEvent.setup();
+    const comics = [
+      createMockComicSeries({
+        authors: [createMockAuthor({ name: "Naoki Urasawa" })],
+        id: 1,
+        title: "Monster",
+      }),
+      createMockComicSeries({ id: 2, title: "One Piece" }),
+    ];
+
+    server.use(
+      http.get("/api/comic_series", () =>
+        HttpResponse.json(createMockHydraCollection(comics)),
+      ),
+    );
+
+    renderWithProviders(<Home />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Monster")).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText("Rechercher par titre, auteur, éditeur…"), "Uraswa");
+
+    expect(screen.getByText("Monster")).toBeInTheDocument();
+    expect(screen.queryByText("One Piece")).not.toBeInTheDocument();
+  });
+
   it("handles case-insensitive search with surrounding whitespace", async () => {
     const user = userEvent.setup();
     const comics = [
@@ -391,7 +479,7 @@ describe("Home", () => {
       expect(screen.getByText("Naruto")).toBeInTheDocument();
     });
 
-    await user.type(screen.getByPlaceholderText("Rechercher une série…"), "  naruto  ");
+    await user.type(screen.getByPlaceholderText("Rechercher par titre, auteur, éditeur…"), "  naruto  ");
 
     expect(screen.getByText("Naruto")).toBeInTheDocument();
     expect(screen.queryByText("One Piece")).not.toBeInTheDocument();

--- a/frontend/src/__tests__/integration/pages/Wishlist.test.tsx
+++ b/frontend/src/__tests__/integration/pages/Wishlist.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import Wishlist from "../../../pages/Wishlist";
 import {
+  createMockAuthor,
   createMockComicSeries,
   createMockHydraCollection,
 } from "../../helpers/factories";
@@ -103,7 +104,7 @@ describe("Wishlist", () => {
   it("renders search input", () => {
     renderWithProviders(<Wishlist />);
 
-    expect(screen.getByPlaceholderText("Rechercher…")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Rechercher par titre, auteur, éditeur…")).toBeInTheDocument();
   });
 
   it("hides status filter", () => {
@@ -132,9 +133,69 @@ describe("Wishlist", () => {
       expect(screen.getByText("Dragon Ball")).toBeInTheDocument();
     });
 
-    await user.type(screen.getByPlaceholderText("Rechercher…"), "Dragon");
+    await user.type(screen.getByPlaceholderText("Rechercher par titre, auteur, éditeur…"), "Dragon");
 
     expect(screen.getByText("Dragon Ball")).toBeInTheDocument();
+    expect(screen.queryByText("One Piece")).not.toBeInTheDocument();
+  });
+
+  it("filters wishlist comics by author name", async () => {
+    const user = userEvent.setup();
+    const comics = [
+      createMockComicSeries({
+        authors: [createMockAuthor({ name: "Naoki Urasawa" })],
+        id: 1,
+        status: ComicStatus.WISHLIST,
+        title: "Monster",
+      }),
+      createMockComicSeries({
+        authors: [createMockAuthor({ name: "Eiichiro Oda" })],
+        id: 2,
+        status: ComicStatus.WISHLIST,
+        title: "One Piece",
+      }),
+    ];
+
+    server.use(
+      http.get("/api/comic_series", () =>
+        HttpResponse.json(createMockHydraCollection(comics)),
+      ),
+    );
+
+    renderWithProviders(<Wishlist />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Monster")).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText("Rechercher par titre, auteur, éditeur…"), "Urasawa");
+
+    expect(screen.getByText("Monster")).toBeInTheDocument();
+    expect(screen.queryByText("One Piece")).not.toBeInTheDocument();
+  });
+
+  it("filters wishlist comics by publisher", async () => {
+    const user = userEvent.setup();
+    const comics = [
+      createMockComicSeries({ id: 1, publisher: "Kana", status: ComicStatus.WISHLIST, title: "Monster" }),
+      createMockComicSeries({ id: 2, publisher: "Glénat", status: ComicStatus.WISHLIST, title: "One Piece" }),
+    ];
+
+    server.use(
+      http.get("/api/comic_series", () =>
+        HttpResponse.json(createMockHydraCollection(comics)),
+      ),
+    );
+
+    renderWithProviders(<Wishlist />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Monster")).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText("Rechercher par titre, auteur, éditeur…"), "Kana");
+
+    expect(screen.getByText("Monster")).toBeInTheDocument();
     expect(screen.queryByText("One Piece")).not.toBeInTheDocument();
   });
 
@@ -189,7 +250,7 @@ describe("Wishlist", () => {
     await user.click(screen.getByText("Manga"));
 
     // Then search within the filtered results
-    await user.type(screen.getByPlaceholderText("Rechercher…"), "Naruto");
+    await user.type(screen.getByPlaceholderText("Rechercher par titre, auteur, éditeur…"), "Naruto");
 
     expect(screen.getByText("Naruto")).toBeInTheDocument();
     expect(screen.queryByText("Dragon Ball")).not.toBeInTheDocument();

--- a/frontend/src/__tests__/unit/utils/searchComics.test.ts
+++ b/frontend/src/__tests__/unit/utils/searchComics.test.ts
@@ -1,0 +1,91 @@
+import { createMockAuthor, createMockComicSeries } from "../../helpers/factories";
+import { searchComics } from "../../../utils/searchComics";
+
+describe("searchComics", () => {
+  const comics = [
+    createMockComicSeries({
+      authors: [createMockAuthor({ name: "Naoki Urasawa" })],
+      id: 1,
+      publisher: "Kana",
+      title: "Monster",
+    }),
+    createMockComicSeries({
+      authors: [createMockAuthor({ name: "Eiichiro Oda" })],
+      id: 2,
+      publisher: "Glénat",
+      title: "One Piece",
+    }),
+    createMockComicSeries({
+      authors: [
+        createMockAuthor({ name: "Tsugumi Ohba" }),
+        createMockAuthor({ name: "Takeshi Obata" }),
+      ],
+      id: 3,
+      publisher: "Kana",
+      title: "Death Note",
+    }),
+  ];
+
+  it("returns all comics when query is empty", () => {
+    expect(searchComics(comics, "")).toHaveLength(3);
+    expect(searchComics(comics, "  ")).toHaveLength(3);
+  });
+
+  it("matches on title", () => {
+    const results = searchComics(comics, "Monster");
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("Monster");
+  });
+
+  it("matches on author name", () => {
+    const results = searchComics(comics, "Urasawa");
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("Monster");
+  });
+
+  it("matches on publisher", () => {
+    const results = searchComics(comics, "Kana");
+    expect(results).toHaveLength(2);
+    const titles = results.map((c) => c.title).sort();
+    expect(titles).toEqual(["Death Note", "Monster"]);
+  });
+
+  it("is case insensitive", () => {
+    const results = searchComics(comics, "urasawa");
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("Monster");
+  });
+
+  it("trims whitespace", () => {
+    const results = searchComics(comics, "  Monster  ");
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("Monster");
+  });
+
+  it("matches with typos (fuzzy)", () => {
+    const results = searchComics(comics, "Uraswa");
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].title).toBe("Monster");
+  });
+
+  it("matches partial author name with typo", () => {
+    const results = searchComics(comics, "Eiichro");
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].title).toBe("One Piece");
+  });
+
+  it("matches when comic has multiple authors", () => {
+    const results = searchComics(comics, "Obata");
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("Death Note");
+  });
+
+  it("returns empty array when nothing matches", () => {
+    const results = searchComics(comics, "zzzzzzzzz");
+    expect(results).toHaveLength(0);
+  });
+
+  it("handles empty comics array", () => {
+    expect(searchComics([], "test")).toHaveLength(0);
+  });
+});

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -8,6 +8,7 @@ import Filters from "../components/Filters";
 import { useComics } from "../hooks/useComics";
 import { useDeleteComic } from "../hooks/useDeleteComic";
 import type { ComicSeries } from "../types/api";
+import { searchComics } from "../utils/searchComics";
 import { sortComics } from "../utils/sortComics";
 import type { SortOption } from "../utils/sortComics";
 
@@ -23,14 +24,12 @@ export default function Home() {
   const allComics = data?.member ?? [];
 
   const filtered = useMemo(() => {
-    const q = search.toLowerCase().trim();
-    const result = allComics.filter((c) => {
+    const preFiltered = allComics.filter((c) => {
       if (type && c.type !== type) return false;
       if (status && c.status !== status) return false;
-      if (q && !c.title.toLowerCase().includes(q)) return false;
       return true;
     });
-    return sortComics(result, sort);
+    return sortComics(searchComics(preFiltered, search), sort);
   }, [allComics, search, sort, status, type]);
 
   return (
@@ -41,7 +40,7 @@ export default function Home() {
         <input
           className="w-full rounded-lg border border-surface-border bg-surface-primary py-2 pl-10 pr-4 text-sm text-text-primary placeholder:text-text-muted focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
           onChange={(e) => setSearch(e.target.value)}
-          placeholder="Rechercher une série…"
+          placeholder="Rechercher par titre, auteur, éditeur…"
           type="search"
           value={search}
         />

--- a/frontend/src/pages/Wishlist.tsx
+++ b/frontend/src/pages/Wishlist.tsx
@@ -5,6 +5,7 @@ import ComicCardSkeleton from "../components/ComicCardSkeleton";
 import Filters from "../components/Filters";
 import { useComics } from "../hooks/useComics";
 import { ComicStatus } from "../types/enums";
+import { searchComics } from "../utils/searchComics";
 import { sortComics } from "../utils/sortComics";
 import type { SortOption } from "../utils/sortComics";
 
@@ -20,13 +21,11 @@ export default function Wishlist() {
   );
 
   const filtered = useMemo(() => {
-    const q = search.toLowerCase().trim();
-    const result = allWishlist.filter((c) => {
+    const preFiltered = allWishlist.filter((c) => {
       if (type && c.type !== type) return false;
-      if (q && !c.title.toLowerCase().includes(q)) return false;
       return true;
     });
-    return sortComics(result, sort);
+    return sortComics(searchComics(preFiltered, search), sort);
   }, [allWishlist, search, sort, type]);
 
   return (
@@ -38,7 +37,7 @@ export default function Wishlist() {
         <input
           className="w-full rounded-lg border border-surface-border bg-surface-primary py-2 pl-10 pr-4 text-sm text-text-primary placeholder:text-text-muted focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
           onChange={(e) => setSearch(e.target.value)}
-          placeholder="Rechercher…"
+          placeholder="Rechercher par titre, auteur, éditeur…"
           type="search"
           value={search}
         />

--- a/frontend/src/utils/searchComics.ts
+++ b/frontend/src/utils/searchComics.ts
@@ -1,0 +1,27 @@
+import Fuse, { type IFuseOptions } from "fuse.js";
+import type { ComicSeries } from "../types/api";
+
+const fuseOptions: IFuseOptions<ComicSeries> = {
+  ignoreLocation: true,
+  keys: [
+    { name: "title", weight: 2 },
+    { name: "authors.name", weight: 1.5 },
+    { name: "publisher", weight: 1 },
+  ],
+  threshold: 0.35,
+};
+
+/**
+ * Recherche floue multi-champs (titre, auteurs, éditeur) via Fuse.js.
+ * Retourne tous les comics si la query est vide.
+ */
+export function searchComics(
+  comics: ComicSeries[],
+  query: string,
+): ComicSeries[] {
+  const q = query.trim();
+  if (!q) return comics;
+
+  const fuse = new Fuse(comics, fuseOptions);
+  return fuse.search(q).map((result) => result.item);
+}


### PR DESCRIPTION
## Summary

- Remplace le filtre `includes()` sur titre seul par une recherche fuzzy multi-champs via **Fuse.js** (titre, auteurs, éditeur) sur Home et Wishlist
- Tolère les fautes de frappe (threshold 0.35)
- Extrait la logique de recherche dans `searchComics()` pour éviter la duplication
- Placeholder mis à jour : « Rechercher par titre, auteur, éditeur… »

## Test plan

- [x] 11 tests unitaires `searchComics` (exact, fuzzy, multi-auteurs, vide, case)
- [x] 3 tests intégration Home (auteur, éditeur, fuzzy typo)
- [x] 2 tests intégration Wishlist (auteur, éditeur)
- [x] 441/441 tests passent, lint clean

fixes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)