### PR TITLE
Masquer les actions des cartes derrière un menu contextuel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
+- **Menu contextuel des cartes** : Les actions Modifier/Supprimer sont masquées derrière un bouton `⋮` — barre d'actions fixe en bas sur mobile, dropdown Headless UI sur desktop. Suppression de la barre d'actions permanente et du skeleton correspondant (#95)
 - **Unification Wishlist dans Home** : Suppression de la page Wishlist séparée, les filtres (statut, type, tri, recherche) sont désormais synchronisés avec les paramètres URL sur la page d'accueil. Le lien Wishlist dans la navigation mène vers `/?status=wishlist` (#92)
 - **Layout carte des tomes sur mobile** : Remplacement du tableau à 8 colonnes par des cartes empilées dans le formulaire de série sur mobile (< `sm`) — numéro + titre, ISBN avec lookup, checkboxes en grille 2×2, bouton supprimer. Tableau conservé sur desktop (#87)
 

--- a/frontend/src/__tests__/integration/components/CardActionBar.test.tsx
+++ b/frontend/src/__tests__/integration/components/CardActionBar.test.tsx
@@ -1,0 +1,71 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CardActionBar from "../../../components/CardActionBar";
+import { createMockComicSeries } from "../../helpers/factories";
+import { renderWithProviders } from "../../helpers/test-utils";
+
+describe("CardActionBar", () => {
+  const comic = createMockComicSeries({ id: 1, title: "Naruto" });
+  const defaultProps = {
+    comic,
+    onClose: vi.fn(),
+    onDelete: vi.fn(),
+    onEdit: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when comic is null", () => {
+    const { container } = renderWithProviders(
+      <CardActionBar {...defaultProps} comic={null} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders comic title", () => {
+    renderWithProviders(<CardActionBar {...defaultProps} />);
+
+    expect(screen.getByText("Naruto")).toBeInTheDocument();
+  });
+
+  it("renders edit and delete buttons", () => {
+    renderWithProviders(<CardActionBar {...defaultProps} />);
+
+    expect(screen.getByRole("button", { name: /modifier/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /supprimer/i })).toBeInTheDocument();
+  });
+
+  it("calls onEdit with comic when edit button is clicked", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<CardActionBar {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: /modifier/i }));
+
+    expect(defaultProps.onEdit).toHaveBeenCalledWith(comic);
+  });
+
+  it("calls onDelete with comic when delete button is clicked", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<CardActionBar {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: /supprimer/i }));
+
+    expect(defaultProps.onDelete).toHaveBeenCalledWith(comic);
+  });
+
+  it("calls onClose when overlay is clicked", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<CardActionBar {...defaultProps} />);
+
+    const overlay = screen.getByTestId("card-action-overlay");
+    await user.click(overlay);
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/integration/components/ComicCard.test.tsx
+++ b/frontend/src/__tests__/integration/components/ComicCard.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import ComicCard from "../../../components/ComicCard";
 import { createMockComicSeries, createMockTome } from "../../helpers/factories";
 import { renderWithProviders } from "../../helpers/test-utils";
-import { ComicStatus, ComicType } from "../../../types/enums";
+import { ComicType } from "../../../types/enums";
 
 describe("ComicCard", () => {
   beforeEach(() => {
@@ -93,31 +93,66 @@ describe("ComicCard", () => {
     expect(screen.queryByText(/t\./)).not.toBeInTheDocument();
   });
 
-  it("shows delete button when onDelete is provided", () => {
+  it("shows the ⋮ menu button", () => {
     const comic = createMockComicSeries({ title: "Test" });
-    const onDelete = vi.fn();
 
-    renderWithProviders(<ComicCard comic={comic} onDelete={onDelete} />);
+    renderWithProviders(<ComicCard comic={comic} onDelete={vi.fn()} />);
 
-    expect(screen.getByTitle("Supprimer")).toBeInTheDocument();
+    const buttons = screen.getAllByTitle("Actions");
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("does not show delete button when onDelete is not provided", () => {
+  it("does not show ⋮ button when no action callbacks are provided", () => {
     const comic = createMockComicSeries({ title: "Test" });
 
     renderWithProviders(<ComicCard comic={comic} />);
 
-    expect(screen.queryByTitle("Supprimer")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("Actions")).not.toBeInTheDocument();
   });
 
-  it("calls onDelete when delete button is clicked", async () => {
+  it("calls onMenuOpen when mobile ⋮ button is clicked", async () => {
     const user = userEvent.setup();
     const comic = createMockComicSeries({ title: "Test" });
+    const onMenuOpen = vi.fn();
+
+    renderWithProviders(
+      <ComicCard comic={comic} onDelete={vi.fn()} onMenuOpen={onMenuOpen} />,
+    );
+
+    // Click the mobile button (lg:hidden)
+    const buttons = screen.getAllByTitle("Actions");
+    // The first one is the mobile button
+    await user.click(buttons[0]);
+
+    expect(onMenuOpen).toHaveBeenCalledWith(comic);
+  });
+
+  it("shows desktop dropdown with edit and delete options", async () => {
+    const user = userEvent.setup();
+    const comic = createMockComicSeries({ id: 5, title: "Test" });
     const onDelete = vi.fn();
 
     renderWithProviders(<ComicCard comic={comic} onDelete={onDelete} />);
 
-    await user.click(screen.getByTitle("Supprimer"));
+    // Click the desktop menu button (hidden lg:block)
+    const buttons = screen.getAllByTitle("Actions");
+    // The last one is the desktop Headless UI MenuButton
+    await user.click(buttons[buttons.length - 1]);
+
+    expect(screen.getByText("Modifier")).toBeInTheDocument();
+    expect(screen.getByText("Supprimer")).toBeInTheDocument();
+  });
+
+  it("calls onDelete from desktop dropdown", async () => {
+    const user = userEvent.setup();
+    const comic = createMockComicSeries({ id: 5, title: "Test" });
+    const onDelete = vi.fn();
+
+    renderWithProviders(<ComicCard comic={comic} onDelete={onDelete} />);
+
+    const buttons = screen.getAllByTitle("Actions");
+    await user.click(buttons[buttons.length - 1]);
+    await user.click(screen.getByText("Supprimer"));
 
     expect(onDelete).toHaveBeenCalledWith(comic);
   });
@@ -198,26 +233,5 @@ describe("ComicCard", () => {
     renderWithProviders(<ComicCard comic={comic} />);
 
     expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
-  });
-
-  it("has an edit button that navigates to edit page", async () => {
-    const user = userEvent.setup();
-    const comic = createMockComicSeries({ id: 5, title: "Test" });
-
-    const { Route, Routes } = await import("react-router-dom");
-
-    renderWithProviders(
-      <Routes>
-        <Route element={<ComicCard comic={comic} />} path="/" />
-        <Route element={<div>Edit Page</div>} path="/comic/5/edit" />
-      </Routes>,
-    );
-
-    const editButton = screen.getByTitle("Modifier");
-    expect(editButton).toBeInTheDocument();
-
-    await user.click(editButton);
-
-    expect(screen.getByText("Edit Page")).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/integration/components/ComicCardSkeleton.test.tsx
+++ b/frontend/src/__tests__/integration/components/ComicCardSkeleton.test.tsx
@@ -6,8 +6,8 @@ describe("ComicCardSkeleton", () => {
     render(<ComicCardSkeleton />);
 
     expect(screen.getByTestId("comic-card-skeleton")).toBeInTheDocument();
-    // Contains multiple skeleton boxes (cover + text lines + actions)
-    expect(screen.getAllByTestId("skeleton-box").length).toBeGreaterThanOrEqual(4);
+    // Contains skeleton boxes (cover + text lines)
+    expect(screen.getAllByTestId("skeleton-box").length).toBeGreaterThanOrEqual(3);
   });
 
   it("has the same border styling as ComicCard", () => {

--- a/frontend/src/__tests__/integration/pages/Home.test.tsx
+++ b/frontend/src/__tests__/integration/pages/Home.test.tsx
@@ -243,8 +243,12 @@ describe("Home", () => {
       expect(screen.getByText("Delete Me")).toBeInTheDocument();
     });
 
-    // Click delete button on the card
-    await user.click(screen.getByTitle("Supprimer"));
+    // Open the ⋮ dropdown menu on desktop
+    const menuButtons = screen.getAllByTitle("Actions");
+    await user.click(menuButtons[menuButtons.length - 1]);
+
+    // Click "Supprimer" in the dropdown
+    await user.click(screen.getByText("Supprimer"));
 
     // Confirm modal should appear
     expect(screen.getByText(/Supprimer Delete Me/)).toBeInTheDocument();
@@ -306,7 +310,14 @@ describe("Home", () => {
       expect(screen.getByText("Toast Delete")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByTitle("Supprimer"));
+    // Open the ⋮ dropdown menu on desktop
+    const menuButtons = screen.getAllByTitle("Actions");
+    await user.click(menuButtons[menuButtons.length - 1]);
+
+    // Click "Supprimer" in the dropdown
+    await user.click(screen.getByText("Supprimer"));
+
+    // Click the confirm button in the modal
     const confirmButton = screen.getByRole("button", { name: "Supprimer" });
     await user.click(confirmButton);
 

--- a/frontend/src/components/CardActionBar.tsx
+++ b/frontend/src/components/CardActionBar.tsx
@@ -1,0 +1,47 @@
+import { Edit, Trash2 } from "lucide-react";
+import type { ComicSeries } from "../types/api";
+
+interface CardActionBarProps {
+  comic: ComicSeries | null;
+  onClose: () => void;
+  onDelete: (comic: ComicSeries) => void;
+  onEdit: (comic: ComicSeries) => void;
+}
+
+export default function CardActionBar({ comic, onClose, onDelete, onEdit }: CardActionBarProps) {
+  if (!comic) return null;
+
+  return (
+    <>
+      {/* Overlay */}
+      <div
+        className="fixed inset-0 z-[60] bg-black/30"
+        data-testid="card-action-overlay"
+        onClick={onClose}
+      />
+
+      {/* Barre d'actions */}
+      <div className="fixed inset-x-0 bottom-0 z-[60] border-t border-surface-border bg-surface-primary px-4 py-3 pb-safe">
+        <p className="mb-2 truncate text-sm font-semibold text-text-primary">{comic.title}</p>
+        <div className="flex gap-2">
+          <button
+            className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-primary-50 py-3 text-sm font-medium text-primary-600 dark:bg-primary-950/30"
+            onClick={() => onEdit(comic)}
+            type="button"
+          >
+            <Edit className="h-4 w-4" />
+            Modifier
+          </button>
+          <button
+            className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-red-50 py-3 text-sm font-medium text-red-600 dark:bg-red-950/30"
+            onClick={() => onDelete(comic)}
+            type="button"
+          >
+            <Trash2 className="h-4 w-4" />
+            Supprimer
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/ComicCard.tsx
+++ b/frontend/src/components/ComicCard.tsx
@@ -1,4 +1,5 @@
-import { Edit, Trash2 } from "lucide-react";
+import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
+import { Edit, EllipsisVertical, Trash2 } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import type { ComicSeries } from "../types/api";
 import { ComicTypeLabel } from "../types/enums";
@@ -7,15 +8,17 @@ import ProgressBar from "./ProgressBar";
 interface ComicCardProps {
   comic: ComicSeries;
   onDelete?: (comic: ComicSeries) => void;
+  onMenuOpen?: (comic: ComicSeries) => void;
 }
 
-export default function ComicCard({ comic, onDelete }: ComicCardProps) {
+export default function ComicCard({ comic, onDelete, onMenuOpen }: ComicCardProps) {
   const navigate = useNavigate();
   const coverSrc = comic.coverUrl ?? (comic.coverImage ? `/uploads/covers/${comic.coverImage}` : null);
   const tomeCount = comic.tomes?.length ?? 0;
   const boughtCount = comic.tomes?.filter((t) => t.bought).length ?? 0;
   const total = comic.latestPublishedIssue ?? tomeCount;
   const showProgress = !comic.isOneShot && tomeCount > 0;
+  const hasActions = !!onDelete;
 
   return (
     <Link
@@ -34,45 +37,83 @@ export default function ComicCard({ comic, onDelete }: ComicCardProps) {
 
       {/* Info */}
       <div className="p-2">
-        <h3 className="truncate text-sm font-semibold text-text-primary">{comic.title}</h3>
-        <p className="truncate text-xs text-text-muted">
-          {ComicTypeLabel[comic.type]}
-          {!comic.isOneShot && ` · ${tomeCount} t.`}
-        </p>
+        <div className="flex items-start gap-1">
+          <div className="min-w-0 flex-1">
+            <h3 className="truncate text-sm font-semibold text-text-primary">{comic.title}</h3>
+            <p className="truncate text-xs text-text-muted">
+              {ComicTypeLabel[comic.type]}
+              {!comic.isOneShot && ` · ${tomeCount} t.`}
+            </p>
+          </div>
+
+          {hasActions && (
+            <>
+              {/* Mobile: simple button → CardActionBar */}
+              <button
+                className="shrink-0 rounded-lg p-1 text-text-muted hover:bg-surface-tertiary lg:hidden"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onMenuOpen?.(comic);
+                }}
+                title="Actions"
+                type="button"
+              >
+                <EllipsisVertical className="h-4 w-4" />
+              </button>
+
+              {/* Desktop: Headless UI dropdown */}
+              <Menu as="div" className="relative hidden shrink-0 lg:block">
+                <MenuButton
+                  className="rounded-lg p-1 text-text-muted hover:bg-surface-tertiary"
+                  onClick={(e: React.MouseEvent) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                  title="Actions"
+                >
+                  <EllipsisVertical className="h-4 w-4" />
+                </MenuButton>
+                <MenuItems anchor="bottom end" className="z-50 w-36 rounded-lg border border-surface-border bg-surface-primary py-1 shadow-lg">
+                  <MenuItem>
+                    <button
+                      className="flex w-full items-center gap-2 px-3 py-2 text-sm text-text-primary data-[focus]:bg-surface-tertiary"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        navigate(`/comic/${comic.id}/edit`);
+                      }}
+                      type="button"
+                    >
+                      <Edit className="h-4 w-4" />
+                      Modifier
+                    </button>
+                  </MenuItem>
+                  <MenuItem>
+                    <button
+                      className="flex w-full items-center gap-2 px-3 py-2 text-sm text-red-500 data-[focus]:bg-surface-tertiary"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        onDelete?.(comic);
+                      }}
+                      type="button"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      Supprimer
+                    </button>
+                  </MenuItem>
+                </MenuItems>
+              </Menu>
+            </>
+          )}
+        </div>
 
         {showProgress && (
           <div className="mt-1.5">
             <ProgressBar compact current={boughtCount} label="Progression d'achat" total={total} />
           </div>
         )}
-
-        {/* Actions */}
-        <div className="mt-2 flex gap-1 border-t border-surface-border pt-2">
-          <button
-            className="flex flex-1 items-center justify-center rounded-lg py-1.5 text-primary-600 hover:bg-primary-50 dark:hover:bg-primary-950/30"
-            onClick={(e) => {
-              e.preventDefault();
-              navigate(`/comic/${comic.id}/edit`);
-            }}
-            title="Modifier"
-            type="button"
-          >
-            <Edit className="h-4 w-4" />
-          </button>
-          {onDelete && (
-            <button
-              className="flex flex-1 items-center justify-center rounded-lg py-1.5 text-red-500 hover:bg-red-50 dark:hover:bg-red-950/30"
-              onClick={(e) => {
-                e.preventDefault();
-                onDelete(comic);
-              }}
-              title="Supprimer"
-              type="button"
-            >
-              <Trash2 className="h-4 w-4" />
-            </button>
-          )}
-        </div>
       </div>
     </Link>
   );

--- a/frontend/src/components/ComicCardSkeleton.tsx
+++ b/frontend/src/components/ComicCardSkeleton.tsx
@@ -13,12 +13,6 @@ export default function ComicCardSkeleton() {
       <div className="space-y-2 p-2">
         <SkeletonBox className="h-4 w-3/4" />
         <SkeletonBox className="h-3 w-1/2" />
-
-        {/* Actions */}
-        <div className="flex gap-1 border-t border-surface-border pt-2">
-          <SkeletonBox className="h-8 flex-1" />
-          <SkeletonBox className="h-8 flex-1" />
-        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,7 +1,8 @@
 import { BookOpen, Filter, Heart, Search } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
+import CardActionBar from "../components/CardActionBar";
 import ComicCard from "../components/ComicCard";
 import ComicCardSkeleton from "../components/ComicCardSkeleton";
 import ConfirmModal from "../components/ConfirmModal";
@@ -31,8 +32,10 @@ export default function Home() {
   const sort: SortOption = VALID_SORTS.has(sortParam) ? (sortParam as SortOption) : "title-asc";
   const searchParam = searchParams.get("search") ?? "";
 
+  const navigate = useNavigate();
   const [search, setSearch] = useState(searchParam);
   const [deleteTarget, setDeleteTarget] = useState<ComicSeries | null>(null);
+  const [menuComic, setMenuComic] = useState<ComicSeries | null>(null);
 
   useEffect(() => {
     setSearch(searchParam);
@@ -149,10 +152,23 @@ export default function Home() {
       ) : (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
           {filtered.map((comic) => (
-            <ComicCard comic={comic} key={comic.id} onDelete={setDeleteTarget} />
+            <ComicCard comic={comic} key={comic.id} onDelete={setDeleteTarget} onMenuOpen={setMenuComic} />
           ))}
         </div>
       )}
+
+      <CardActionBar
+        comic={menuComic}
+        onClose={() => setMenuComic(null)}
+        onDelete={(c) => {
+          setMenuComic(null);
+          setDeleteTarget(c);
+        }}
+        onEdit={(c) => {
+          setMenuComic(null);
+          navigate(`/comic/${c.id}/edit`);
+        }}
+      />
 
       <ConfirmModal
         confirmLabel="Supprimer"


### PR DESCRIPTION
## Summary
- Suppression de la barre d'actions permanente (Modifier/Supprimer) sous chaque carte
- Ajout d'un bouton `⋮` dans la zone info avec comportement responsive :
  - **Mobile (< lg)** : ouvre une barre d'actions fixe en bas de l'écran avec overlay sombre
  - **Desktop (lg+)** : dropdown Headless UI positionné via `anchor`
- Nouveau composant `CardActionBar` pour la barre mobile
- Skeleton simplifié (suppression de la zone actions)

## Test plan
- [x] 461 tests frontend passent
- [x] TypeScript (`tsc --noEmit`) sans erreur
- [ ] Test manuel mobile : bouton ⋮ → barre en bas → Modifier navigue, Supprimer ouvre modale
- [ ] Test manuel desktop : bouton ⋮ → dropdown → mêmes actions

fixes #95