### PR TITLE
Système d'événements domaine pour ComicSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 ### Added
 
 - **Cache sur findAllForApi()** : Cache applicatif Symfony (15 min, filesystem) sur la requête principale de l'API PWA avec invalidation automatique via listener Doctrine lors de modifications sur ComicSeries, Tome ou Author (#23)
+- **Événements domaine ComicSeries** : Système d'événements Symfony dispatché via un listener Doctrine — `ComicSeriesCreatedEvent`, `ComicSeriesUpdatedEvent`, `ComicSeriesDeletedEvent` (soft-delete, hard-delete et suppression permanente DBAL) (#36)
 - **Placeholder de couverture stylisé** : Les séries sans couverture affichent une illustration spécifique au type (BD, Manga, Comics, Livre) au lieu du placeholder générique (#100)
 
 ### Changed

--- a/backend/src/Event/ComicSeriesCreatedEvent.php
+++ b/backend/src/Event/ComicSeriesCreatedEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event;
+
+use App\Entity\ComicSeries;
+
+/**
+ * Événement dispatché lorsqu'une série est créée.
+ */
+final readonly class ComicSeriesCreatedEvent
+{
+    public function __construct(
+        private ComicSeries $comicSeries,
+    ) {
+    }
+
+    public function getComicSeries(): ComicSeries
+    {
+        return $this->comicSeries;
+    }
+}

--- a/backend/src/Event/ComicSeriesDeletedEvent.php
+++ b/backend/src/Event/ComicSeriesDeletedEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event;
+
+/**
+ * Événement dispatché lorsqu'une série est supprimée.
+ *
+ * Contient l'identifiant et le titre car l'entité peut ne plus exister.
+ */
+final readonly class ComicSeriesDeletedEvent
+{
+    public function __construct(
+        private int $id,
+        private string $title,
+    ) {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+}

--- a/backend/src/Event/ComicSeriesUpdatedEvent.php
+++ b/backend/src/Event/ComicSeriesUpdatedEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event;
+
+use App\Entity\ComicSeries;
+
+/**
+ * Événement dispatché lorsqu'une série est mise à jour.
+ */
+final readonly class ComicSeriesUpdatedEvent
+{
+    public function __construct(
+        private ComicSeries $comicSeries,
+    ) {
+    }
+
+    public function getComicSeries(): ComicSeries
+    {
+        return $this->comicSeries;
+    }
+}

--- a/backend/src/EventListener/ComicSeriesEventListener.php
+++ b/backend/src/EventListener/ComicSeriesEventListener.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+use App\Entity\ComicSeries;
+use App\Event\ComicSeriesCreatedEvent;
+use App\Event\ComicSeriesDeletedEvent;
+use App\Event\ComicSeriesUpdatedEvent;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\ORM\Events;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Listener Doctrine qui dispatche des événements domaine pour ComicSeries.
+ *
+ * - postPersist → ComicSeriesCreatedEvent
+ * - postUpdate → ComicSeriesUpdatedEvent (ou ComicSeriesDeletedEvent si soft-delete)
+ * - postRemove → ComicSeriesDeletedEvent
+ */
+#[AsDoctrineListener(event: Events::postPersist)]
+#[AsDoctrineListener(event: Events::postRemove)]
+#[AsDoctrineListener(event: Events::postUpdate)]
+class ComicSeriesEventListener
+{
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function postPersist(PostPersistEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if (!$entity instanceof ComicSeries) {
+            return;
+        }
+
+        $this->eventDispatcher->dispatch(new ComicSeriesCreatedEvent($entity));
+    }
+
+    public function postRemove(PostRemoveEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if (!$entity instanceof ComicSeries) {
+            return;
+        }
+
+        $this->eventDispatcher->dispatch(new ComicSeriesDeletedEvent(
+            (int) $entity->getId(),
+            $entity->getTitle(),
+        ));
+    }
+
+    public function postUpdate(PostUpdateEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if (!$entity instanceof ComicSeries) {
+            return;
+        }
+
+        // Un soft-delete positionne deletedAt : on dispatche un événement de suppression
+        if ($entity->isDeleted()) {
+            $this->eventDispatcher->dispatch(new ComicSeriesDeletedEvent(
+                (int) $entity->getId(),
+                $entity->getTitle(),
+            ));
+
+            return;
+        }
+
+        $this->eventDispatcher->dispatch(new ComicSeriesUpdatedEvent($entity));
+    }
+}

--- a/backend/src/Service/ComicSeriesService.php
+++ b/backend/src/Service/ComicSeriesService.php
@@ -6,8 +6,10 @@ namespace App\Service;
 
 use App\Entity\ComicSeries;
 use App\Enum\ComicStatus;
+use App\Event\ComicSeriesDeletedEvent;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Service de gestion du cycle de vie des séries.
@@ -18,6 +20,7 @@ class ComicSeriesService
         private readonly Connection $connection,
         private readonly CoverRemoverInterface $coverRemover,
         private readonly EntityManagerInterface $entityManager,
+        private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -35,11 +38,14 @@ class ComicSeriesService
      */
     public function permanentDelete(int $id, ComicSeries $comic): void
     {
+        $title = $comic->getTitle();
         $this->coverRemover->remove($comic);
 
         $this->connection->delete('comic_series_author', ['comic_series_id' => $id]);
         $this->connection->delete('tome', ['comic_series_id' => $id]);
         $this->connection->delete('comic_series', ['id' => $id]);
+
+        $this->eventDispatcher->dispatch(new ComicSeriesDeletedEvent($id, $title));
     }
 
     /**

--- a/backend/tests/Unit/Event/ComicSeriesCreatedEventTest.php
+++ b/backend/tests/Unit/Event/ComicSeriesCreatedEventTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Event;
+
+use App\Entity\ComicSeries;
+use App\Event\ComicSeriesCreatedEvent;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires pour ComicSeriesCreatedEvent.
+ */
+final class ComicSeriesCreatedEventTest extends TestCase
+{
+    /**
+     * Teste que l'événement retourne la série passée au constructeur.
+     */
+    public function testGetComicSeriesReturnsEntity(): void
+    {
+        $comicSeries = new ComicSeries();
+        $comicSeries->setTitle('Naruto');
+
+        $event = new ComicSeriesCreatedEvent($comicSeries);
+
+        self::assertSame($comicSeries, $event->getComicSeries());
+    }
+}

--- a/backend/tests/Unit/Event/ComicSeriesDeletedEventTest.php
+++ b/backend/tests/Unit/Event/ComicSeriesDeletedEventTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Event;
+
+use App\Event\ComicSeriesDeletedEvent;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires pour ComicSeriesDeletedEvent.
+ */
+final class ComicSeriesDeletedEventTest extends TestCase
+{
+    /**
+     * Teste que l'événement retourne l'identifiant passé au constructeur.
+     */
+    public function testGetIdReturnsId(): void
+    {
+        $event = new ComicSeriesDeletedEvent(42, 'Naruto');
+
+        self::assertSame(42, $event->getId());
+    }
+
+    /**
+     * Teste que l'événement retourne le titre passé au constructeur.
+     */
+    public function testGetTitleReturnsTitle(): void
+    {
+        $event = new ComicSeriesDeletedEvent(42, 'Naruto');
+
+        self::assertSame('Naruto', $event->getTitle());
+    }
+}

--- a/backend/tests/Unit/Event/ComicSeriesUpdatedEventTest.php
+++ b/backend/tests/Unit/Event/ComicSeriesUpdatedEventTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Event;
+
+use App\Entity\ComicSeries;
+use App\Event\ComicSeriesUpdatedEvent;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires pour ComicSeriesUpdatedEvent.
+ */
+final class ComicSeriesUpdatedEventTest extends TestCase
+{
+    /**
+     * Teste que l'événement retourne la série passée au constructeur.
+     */
+    public function testGetComicSeriesReturnsEntity(): void
+    {
+        $comicSeries = new ComicSeries();
+        $comicSeries->setTitle('One Piece');
+
+        $event = new ComicSeriesUpdatedEvent($comicSeries);
+
+        self::assertSame($comicSeries, $event->getComicSeries());
+    }
+}

--- a/backend/tests/Unit/EventListener/ComicSeriesEventListenerTest.php
+++ b/backend/tests/Unit/EventListener/ComicSeriesEventListenerTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\EventListener;
+
+use App\Entity\ComicSeries;
+use App\Event\ComicSeriesCreatedEvent;
+use App\Event\ComicSeriesDeletedEvent;
+use App\Event\ComicSeriesUpdatedEvent;
+use App\EventListener\ComicSeriesEventListener;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Tests unitaires pour ComicSeriesEventListener.
+ */
+final class ComicSeriesEventListenerTest extends TestCase
+{
+    private EntityManagerInterface&MockObject $entityManager;
+    private EventDispatcherInterface&MockObject $eventDispatcher;
+    private ComicSeriesEventListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $this->listener = new ComicSeriesEventListener($this->eventDispatcher);
+    }
+
+    /**
+     * Teste que postPersist dispatche un ComicSeriesCreatedEvent.
+     */
+    public function testPostPersistDispatchesCreatedEvent(): void
+    {
+        $comic = new ComicSeries();
+        $comic->setTitle('Naruto');
+
+        $args = new PostPersistEventArgs($comic, $this->entityManager);
+
+        $this->eventDispatcher
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with(self::callback(static function (object $event) use ($comic): bool {
+                return $event instanceof ComicSeriesCreatedEvent
+                    && $event->getComicSeries() === $comic;
+            }));
+
+        $this->listener->postPersist($args);
+    }
+
+    /**
+     * Teste que postPersist ne fait rien pour une entité non-ComicSeries.
+     */
+    public function testPostPersistIgnoresNonComicSeriesEntity(): void
+    {
+        $entity = new \stdClass();
+        $args = new PostPersistEventArgs($entity, $this->entityManager);
+
+        $this->eventDispatcher
+            ->expects(self::never())
+            ->method('dispatch');
+
+        $this->listener->postPersist($args);
+    }
+
+    /**
+     * Teste que postUpdate dispatche un ComicSeriesUpdatedEvent pour une mise à jour normale.
+     */
+    public function testPostUpdateDispatchesUpdatedEvent(): void
+    {
+        $comic = new ComicSeries();
+        $comic->setTitle('One Piece');
+
+        $args = new PostUpdateEventArgs($comic, $this->entityManager);
+
+        $this->eventDispatcher
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with(self::callback(static function (object $event) use ($comic): bool {
+                return $event instanceof ComicSeriesUpdatedEvent
+                    && $event->getComicSeries() === $comic;
+            }));
+
+        $this->listener->postUpdate($args);
+    }
+
+    /**
+     * Teste que postUpdate dispatche un ComicSeriesDeletedEvent pour un soft-delete.
+     */
+    public function testPostUpdateDispatchesDeletedEventOnSoftDelete(): void
+    {
+        $comic = new ComicSeries();
+        $comic->setTitle('Bleach');
+        // Simuler un soft-delete
+        $comic->delete();
+
+        // On a besoin d'un ID pour le DeletedEvent — utiliser Reflection
+        $reflection = new \ReflectionProperty(ComicSeries::class, 'id');
+        $reflection->setValue($comic, 7);
+
+        $args = new PostUpdateEventArgs($comic, $this->entityManager);
+
+        $this->eventDispatcher
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with(self::callback(static function (object $event): bool {
+                return $event instanceof ComicSeriesDeletedEvent
+                    && 7 === $event->getId()
+                    && 'Bleach' === $event->getTitle();
+            }));
+
+        $this->listener->postUpdate($args);
+    }
+
+    /**
+     * Teste que postUpdate ne fait rien pour une entité non-ComicSeries.
+     */
+    public function testPostUpdateIgnoresNonComicSeriesEntity(): void
+    {
+        $entity = new \stdClass();
+        $args = new PostUpdateEventArgs($entity, $this->entityManager);
+
+        $this->eventDispatcher
+            ->expects(self::never())
+            ->method('dispatch');
+
+        $this->listener->postUpdate($args);
+    }
+
+    /**
+     * Teste que postRemove dispatche un ComicSeriesDeletedEvent.
+     */
+    public function testPostRemoveDispatchesDeletedEvent(): void
+    {
+        $comic = new ComicSeries();
+        $comic->setTitle('Dragon Ball');
+
+        $reflection = new \ReflectionProperty(ComicSeries::class, 'id');
+        $reflection->setValue($comic, 42);
+
+        $args = new PostRemoveEventArgs($comic, $this->entityManager);
+
+        $this->eventDispatcher
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with(self::callback(static function (object $event): bool {
+                return $event instanceof ComicSeriesDeletedEvent
+                    && 42 === $event->getId()
+                    && 'Dragon Ball' === $event->getTitle();
+            }));
+
+        $this->listener->postRemove($args);
+    }
+
+    /**
+     * Teste que postRemove ne fait rien pour une entité non-ComicSeries.
+     */
+    public function testPostRemoveIgnoresNonComicSeriesEntity(): void
+    {
+        $entity = new \stdClass();
+        $args = new PostRemoveEventArgs($entity, $this->entityManager);
+
+        $this->eventDispatcher
+            ->expects(self::never())
+            ->method('dispatch');
+
+        $this->listener->postRemove($args);
+    }
+}

--- a/backend/tests/Unit/Service/ComicSeriesServiceTest.php
+++ b/backend/tests/Unit/Service/ComicSeriesServiceTest.php
@@ -6,12 +6,14 @@ namespace App\Tests\Unit\Service;
 
 use App\Entity\ComicSeries;
 use App\Enum\ComicStatus;
+use App\Event\ComicSeriesDeletedEvent;
 use App\Service\ComicSeriesService;
 use App\Service\CoverRemoverInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Tests unitaires pour ComicSeriesService.
@@ -21,6 +23,7 @@ final class ComicSeriesServiceTest extends TestCase
     private Connection&MockObject $connection;
     private CoverRemoverInterface&MockObject $coverRemover;
     private EntityManagerInterface&MockObject $entityManager;
+    private EventDispatcherInterface&MockObject $eventDispatcher;
     private ComicSeriesService $service;
 
     protected function setUp(): void
@@ -28,11 +31,13 @@ final class ComicSeriesServiceTest extends TestCase
         $this->connection = $this->createMock(Connection::class);
         $this->coverRemover = $this->createMock(CoverRemoverInterface::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $this->service = new ComicSeriesService(
             $this->connection,
             $this->coverRemover,
             $this->entityManager,
+            $this->eventDispatcher,
         );
     }
 
@@ -140,5 +145,26 @@ final class ComicSeriesServiceTest extends TestCase
             ['comic_series_author', 'tome', 'comic_series'],
             $deleteCallOrder,
         );
+    }
+
+    /**
+     * Teste que permanentDelete dispatche un ComicSeriesDeletedEvent.
+     */
+    public function testPermanentDeleteDispatchesDeletedEvent(): void
+    {
+        $comic = new ComicSeries();
+        $comic->setTitle('Bleach');
+        $id = 7;
+
+        $this->eventDispatcher
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with(self::callback(static function (object $event): bool {
+                return $event instanceof ComicSeriesDeletedEvent
+                    && 7 === $event->getId()
+                    && 'Bleach' === $event->getTitle();
+            }));
+
+        $this->service->permanentDelete($id, $comic);
     }
 }


### PR DESCRIPTION
## Summary

- Ajout de 3 événements domaine : `ComicSeriesCreatedEvent`, `ComicSeriesUpdatedEvent`, `ComicSeriesDeletedEvent`
- Listener Doctrine (`ComicSeriesEventListener`) qui dispatche automatiquement ces événements sur `postPersist`, `postUpdate` et `postRemove`
- Le soft-delete (détecté via `isDeleted()` dans `postUpdate`) dispatche `ComicSeriesDeletedEvent` au lieu de `ComicSeriesUpdatedEvent`
- Dispatch direct depuis `ComicSeriesService::permanentDelete()` car le DBAL contourne les événements Doctrine
- 11 tests unitaires couvrent tous les cas (création, mise à jour, soft-delete, hard-delete, entités non-ComicSeries ignorées)

## Test plan

- [x] Tests unitaires Event DTOs (constructeur + getters)
- [x] Tests unitaires ComicSeriesEventListener (postPersist, postUpdate, postUpdate soft-delete, postRemove, entités ignorées)
- [x] Test unitaire ComicSeriesService::permanentDelete dispatche l'événement
- [x] Suite complète PHPUnit (575 tests, 0 failure)
- [x] PHP-CS-Fixer (0 issue)

fixes #36