### PR TITLE
Cache findAllForApi() avec invalidation automatique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Cache sur findAllForApi()** : Cache applicatif Symfony (15 min, filesystem) sur la requête principale de l'API PWA avec invalidation automatique via listener Doctrine lors de modifications sur ComicSeries, Tome ou Author (#23)
 - **Placeholder de couverture stylisé** : Les séries sans couverture affichent une illustration spécifique au type (BD, Manga, Comics, Livre) au lieu du placeholder générique (#100)
 
 ### Changed

--- a/backend/config/packages/cache.yaml
+++ b/backend/config/packages/cache.yaml
@@ -16,6 +16,9 @@ framework:
 
         # Namespaced pools use the above "app" backend by default
         pools:
+            comic_series_api.cache:
+                adapter: cache.adapter.filesystem
+                default_lifetime: 900 # 15 minutes
             gemini.cache:
                 adapter: cache.adapter.filesystem
                 default_lifetime: 2592000 # 30 jours

--- a/backend/phpstan-baseline.neon
+++ b/backend/phpstan-baseline.neon
@@ -51,56 +51,50 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$kernel of class Symfony\\Bundle\\FrameworkBundle\\Console\\Application constructor expects Symfony\\Component\\HttpKernel\\KernelInterface, Symfony\\Component\\HttpKernel\\KernelInterface\|null given\.$#'
 			identifier: argument.type
-			count: 6
-			path: tests/Command/CreateUserCommandTest.php
-
-		-
-			message: '#^Parameter \#1 \$kernel of class Symfony\\Bundle\\FrameworkBundle\\Console\\Application constructor expects Symfony\\Component\\HttpKernel\\KernelInterface, Symfony\\Component\\HttpKernel\\KernelInterface\|null given\.$#'
-			identifier: argument.type
 			count: 15
-			path: tests/Command/ImportExcelCommandTest.php
+			path: tests/Integration/Command/ImportExcelCommandTest.php
 
 		-
 			message: '#^Parameter \#1 \$kernel of class Symfony\\Bundle\\FrameworkBundle\\Console\\Application constructor expects Symfony\\Component\\HttpKernel\\KernelInterface, Symfony\\Component\\HttpKernel\\KernelInterface\|null given\.$#'
 			identifier: argument.type
 			count: 3
-			path: tests/Command/InvalidateTokensCommandTest.php
+			path: tests/Integration/Command/InvalidateTokensCommandTest.php
 
 		-
 			message: '#^Parameter \#1 \$kernel of class Symfony\\Bundle\\FrameworkBundle\\Console\\Application constructor expects Symfony\\Component\\HttpKernel\\KernelInterface, Symfony\\Component\\HttpKernel\\KernelInterface\|null given\.$#'
 			identifier: argument.type
 			count: 4
-			path: tests/Command/PurgeDeletedCommandTest.php
+			path: tests/Integration/Command/PurgeDeletedCommandTest.php
 
 		-
 			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true will always evaluate to true\.$#'
 			identifier: staticMethod.alreadyNarrowedType
 			count: 1
-			path: tests/Entity/UserTest.php
+			path: tests/Unit/Entity/UserTest.php
 
 		-
 			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertNull\(\) with null will always evaluate to true\.$#'
 			identifier: staticMethod.alreadyNarrowedType
 			count: 2
-			path: tests/Enum/ComicStatusTest.php
+			path: tests/Unit/Enum/ComicStatusTest.php
 
 		-
 			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertNull\(\) with null will always evaluate to true\.$#'
 			identifier: staticMethod.alreadyNarrowedType
 			count: 3
-			path: tests/Enum/ComicTypeTest.php
+			path: tests/Unit/Enum/ComicTypeTest.php
 
 		-
-			message: '#^Property App\\Tests\\Repository\\AuthorRepositoryTest\:\:\$repository \(App\\Repository\\AuthorRepository\) does not accept Doctrine\\ORM\\EntityRepository\<App\\Entity\\Author\>\.$#'
+			message: '#^Property App\\Tests\\Integration\\Repository\\AuthorRepositoryTest\:\:\$repository \(App\\Repository\\AuthorRepository\) does not accept Doctrine\\ORM\\EntityRepository\<App\\Entity\\Author\>\.$#'
 			identifier: assign.propertyType
 			count: 1
-			path: tests/Repository/AuthorRepositoryTest.php
+			path: tests/Integration/Repository/AuthorRepositoryTest.php
 
 		-
-			message: '#^Property App\\Tests\\Repository\\ComicSeriesRepositoryTest\:\:\$repository \(App\\Repository\\ComicSeriesRepository\) does not accept Doctrine\\ORM\\EntityRepository\<App\\Entity\\ComicSeries\>\.$#'
+			message: '#^Property App\\Tests\\Integration\\Repository\\ComicSeriesRepositoryTest\:\:\$repository \(App\\Repository\\ComicSeriesRepository\) does not accept Doctrine\\ORM\\EntityRepository\<App\\Entity\\ComicSeries\>\.$#'
 			identifier: assign.propertyType
 			count: 1
-			path: tests/Repository/ComicSeriesRepositoryTest.php
+			path: tests/Integration/Repository/ComicSeriesRepositoryTest.php
 
 		-
 			message: '#^Call to function method_exists\(\) with ''Symfony\\\\Component\\\\Dotenv\\\\Dotenv'' and ''bootEnv'' will always evaluate to true\.$#'

--- a/backend/src/EventListener/ComicSeriesCacheInvalidator.php
+++ b/backend/src/EventListener/ComicSeriesCacheInvalidator.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+use App\Entity\Author;
+use App\Entity\ComicSeries;
+use App\Entity\Tome;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\ORM\Events;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\Cache\CacheInterface;
+
+/**
+ * Invalide le cache de findAllForApi() lors de modifications sur les entités liées.
+ *
+ * Écoute les événements Doctrine postPersist, postUpdate et postRemove
+ * sur ComicSeries, Tome et Author pour supprimer le cache.
+ */
+#[AsDoctrineListener(event: Events::postPersist)]
+#[AsDoctrineListener(event: Events::postRemove)]
+#[AsDoctrineListener(event: Events::postUpdate)]
+class ComicSeriesCacheInvalidator
+{
+    private const array WATCHED_ENTITIES = [
+        Author::class,
+        ComicSeries::class,
+        Tome::class,
+    ];
+
+    public function __construct(
+        #[Autowire(service: 'comic_series_api.cache')]
+        private readonly CacheInterface $cache,
+    ) {
+    }
+
+    public function postPersist(PostPersistEventArgs $event): void
+    {
+        $this->invalidateIfRelevant($event->getObject());
+    }
+
+    public function postRemove(PostRemoveEventArgs $event): void
+    {
+        $this->invalidateIfRelevant($event->getObject());
+    }
+
+    public function postUpdate(PostUpdateEventArgs $event): void
+    {
+        $this->invalidateIfRelevant($event->getObject());
+    }
+
+    private function invalidateIfRelevant(object $entity): void
+    {
+        foreach (self::WATCHED_ENTITIES as $watchedClass) {
+            if ($entity instanceof $watchedClass) {
+                $this->cache->delete('comic_series_api_all');
+
+                return;
+            }
+        }
+    }
+}

--- a/backend/src/Repository/ComicSeriesRepository.php
+++ b/backend/src/Repository/ComicSeriesRepository.php
@@ -10,14 +10,20 @@ use App\Enum\ComicStatus;
 use App\Enum\ComicType;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 
 /**
  * @extends ServiceEntityRepository<ComicSeries>
  */
 class ComicSeriesRepository extends ServiceEntityRepository
 {
-    public function __construct(ManagerRegistry $registry)
-    {
+    public function __construct(
+        #[Autowire(service: 'comic_series_api.cache')]
+        private readonly CacheInterface $cache,
+        ManagerRegistry $registry,
+    ) {
         parent::__construct($registry, ComicSeries::class);
     }
 
@@ -114,12 +120,27 @@ class ComicSeriesRepository extends ServiceEntityRepository
     /**
      * Retourne toutes les séries avec leurs relations pour l'API PWA.
      *
-     * Utilise un eager loading avec leftJoin + addSelect pour éviter
-     * le problème N+1 (une requête par série pour chaque relation).
+     * Utilise un cache applicatif (15 min) pour éviter de requêter la base
+     * à chaque chargement. Le cache est invalidé par ComicSeriesCacheInvalidator.
      *
      * @return list<array<string, mixed>>
      */
     public function findAllForApi(): array
+    {
+        /* @var list<array<string, mixed>> */
+        return $this->cache->get('comic_series_api_all', function (ItemInterface $item): array {
+            $item->expiresAfter(900);
+
+            return $this->doFindAllForApi();
+        });
+    }
+
+    /**
+     * Exécute la requête complète avec eager loading pour éviter le N+1.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function doFindAllForApi(): array
     {
         /** @var ComicSeries[] $comics */
         $comics = $this->createQueryBuilder('c')

--- a/backend/tests/Integration/Repository/ComicSeriesRepositoryTest.php
+++ b/backend/tests/Integration/Repository/ComicSeriesRepositoryTest.php
@@ -11,12 +11,14 @@ use App\Repository\ComicSeriesRepository;
 use App\Tests\Factory\EntityFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Contracts\Cache\CacheInterface;
 
 /**
  * Tests d'integration pour ComicSeriesRepository.
  */
 final class ComicSeriesRepositoryTest extends KernelTestCase
 {
+    private CacheInterface $cache;
     private ComicSeriesRepository $repository;
     private EntityManagerInterface $em;
 
@@ -24,8 +26,12 @@ final class ComicSeriesRepositoryTest extends KernelTestCase
     {
         self::bootKernel();
 
+        $this->cache = static::getContainer()->get('comic_series_api.cache');
         $this->em = static::getContainer()->get(EntityManagerInterface::class);
         $this->repository = static::getContainer()->get(ComicSeriesRepository::class);
+
+        // Vider le cache avant chaque test pour garantir l'isolation
+        $this->cache->delete('comic_series_api_all');
     }
 
     // ---------------------------------------------------------------
@@ -538,5 +544,81 @@ final class ComicSeriesRepositoryTest extends KernelTestCase
         self::assertSame(0, $result[0]['tomesCount']);
         self::assertSame(0, $result[0]['readTomesCount']);
         self::assertFalse($result[0]['hasNasTome']);
+    }
+
+    // ---------------------------------------------------------------
+    // findAllForApi — cache
+    // ---------------------------------------------------------------
+
+    public function testFindAllForApiReturnsSameResultOnConsecutiveCalls(): void
+    {
+        $series = EntityFactory::createComicSeries('Alpha');
+        $this->em->persist($series);
+        $this->em->flush();
+
+        // Deux appels consécutifs doivent retourner le même résultat (cache)
+        $firstResult = $this->repository->findAllForApi();
+        $secondResult = $this->repository->findAllForApi();
+
+        self::assertSame($firstResult, $secondResult);
+    }
+
+    public function testFindAllForApiCacheInvalidatedAfterNewSeries(): void
+    {
+        $series = EntityFactory::createComicSeries('Alpha');
+        $this->em->persist($series);
+        $this->em->flush();
+
+        // Premier appel → remplit le cache
+        $firstResult = $this->repository->findAllForApi();
+        self::assertCount(1, $firstResult);
+
+        // Ajouter une nouvelle série via Doctrine (déclenche le listener)
+        $newSeries = EntityFactory::createComicSeries('Bravo');
+        $this->em->persist($newSeries);
+        $this->em->flush();
+
+        // Le cache doit être invalidé, nouveau résultat avec 2 séries
+        $secondResult = $this->repository->findAllForApi();
+        self::assertCount(2, $secondResult);
+    }
+
+    public function testFindAllForApiCacheInvalidatedAfterSeriesUpdate(): void
+    {
+        $series = EntityFactory::createComicSeries('Alpha');
+        $this->em->persist($series);
+        $this->em->flush();
+
+        // Premier appel → remplit le cache
+        $firstResult = $this->repository->findAllForApi();
+        self::assertSame('Alpha', $firstResult[0]['title']);
+
+        // Modifier la série
+        $series->setTitle('Alpha Modifié');
+        $this->em->flush();
+
+        // Le cache doit être invalidé, titre mis à jour
+        $secondResult = $this->repository->findAllForApi();
+        self::assertSame('Alpha Modifié', $secondResult[0]['title']);
+    }
+
+    public function testFindAllForApiCacheInvalidatedAfterTomePersist(): void
+    {
+        $series = EntityFactory::createComicSeries('Alpha');
+        $this->em->persist($series);
+        $this->em->flush();
+
+        // Premier appel → 0 tomes
+        $firstResult = $this->repository->findAllForApi();
+        self::assertSame(0, $firstResult[0]['tomesCount']);
+
+        // Ajouter un tome
+        $tome = EntityFactory::createTome(1);
+        $series->addTome($tome);
+        $this->em->flush();
+
+        // Le cache doit être invalidé, 1 tome maintenant
+        $secondResult = $this->repository->findAllForApi();
+        self::assertSame(1, $secondResult[0]['tomesCount']);
     }
 }

--- a/backend/tests/Unit/EventListener/ComicSeriesCacheInvalidatorTest.php
+++ b/backend/tests/Unit/EventListener/ComicSeriesCacheInvalidatorTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\EventListener;
+
+use App\Entity\Author;
+use App\Entity\ComicSeries;
+use App\Entity\Tome;
+use App\Entity\User;
+use App\EventListener\ComicSeriesCacheInvalidator;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Cache\CacheInterface;
+
+/**
+ * Tests unitaires pour ComicSeriesCacheInvalidator.
+ */
+final class ComicSeriesCacheInvalidatorTest extends TestCase
+{
+    private CacheInterface&MockObject $cache;
+    private EntityManagerInterface&Stub $entityManager;
+    private ComicSeriesCacheInvalidator $listener;
+
+    protected function setUp(): void
+    {
+        $this->cache = $this->createMock(CacheInterface::class);
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
+
+        $this->listener = new ComicSeriesCacheInvalidator($this->cache);
+    }
+
+    public function testPostPersistWithComicSeriesInvalidatesCache(): void
+    {
+        $entity = new ComicSeries();
+        $event = new PostPersistEventArgs($entity, $this->entityManager);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('delete')
+            ->with('comic_series_api_all');
+
+        $this->listener->postPersist($event);
+    }
+
+    public function testPostPersistWithTomeInvalidatesCache(): void
+    {
+        $entity = new Tome();
+        $event = new PostPersistEventArgs($entity, $this->entityManager);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('delete')
+            ->with('comic_series_api_all');
+
+        $this->listener->postPersist($event);
+    }
+
+    public function testPostPersistWithAuthorInvalidatesCache(): void
+    {
+        $entity = new Author();
+        $event = new PostPersistEventArgs($entity, $this->entityManager);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('delete')
+            ->with('comic_series_api_all');
+
+        $this->listener->postPersist($event);
+    }
+
+    public function testPostPersistWithUnrelatedEntityDoesNotInvalidateCache(): void
+    {
+        $entity = new User();
+        $event = new PostPersistEventArgs($entity, $this->entityManager);
+
+        $this->cache
+            ->expects(self::never())
+            ->method('delete');
+
+        $this->listener->postPersist($event);
+    }
+
+    public function testPostUpdateWithComicSeriesInvalidatesCache(): void
+    {
+        $entity = new ComicSeries();
+        $event = new PostUpdateEventArgs($entity, $this->entityManager);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('delete')
+            ->with('comic_series_api_all');
+
+        $this->listener->postUpdate($event);
+    }
+
+    public function testPostUpdateWithTomeInvalidatesCache(): void
+    {
+        $entity = new Tome();
+        $event = new PostUpdateEventArgs($entity, $this->entityManager);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('delete')
+            ->with('comic_series_api_all');
+
+        $this->listener->postUpdate($event);
+    }
+
+    public function testPostUpdateWithAuthorInvalidatesCache(): void
+    {
+        $entity = new Author();
+        $event = new PostUpdateEventArgs($entity, $this->entityManager);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('delete')
+            ->with('comic_series_api_all');
+
+        $this->listener->postUpdate($event);
+    }
+
+    public function testPostUpdateWithUnrelatedEntityDoesNotInvalidateCache(): void
+    {
+        $entity = new User();
+        $event = new PostUpdateEventArgs($entity, $this->entityManager);
+
+        $this->cache
+            ->expects(self::never())
+            ->method('delete');
+
+        $this->listener->postUpdate($event);
+    }
+
+    public function testPostRemoveWithComicSeriesInvalidatesCache(): void
+    {
+        $entity = new ComicSeries();
+        $event = new PostRemoveEventArgs($entity, $this->entityManager);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('delete')
+            ->with('comic_series_api_all');
+
+        $this->listener->postRemove($event);
+    }
+
+    public function testPostRemoveWithTomeInvalidatesCache(): void
+    {
+        $entity = new Tome();
+        $event = new PostRemoveEventArgs($entity, $this->entityManager);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('delete')
+            ->with('comic_series_api_all');
+
+        $this->listener->postRemove($event);
+    }
+
+    public function testPostRemoveWithAuthorInvalidatesCache(): void
+    {
+        $entity = new Author();
+        $event = new PostRemoveEventArgs($entity, $this->entityManager);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('delete')
+            ->with('comic_series_api_all');
+
+        $this->listener->postRemove($event);
+    }
+
+    public function testPostRemoveWithUnrelatedEntityDoesNotInvalidateCache(): void
+    {
+        $entity = new User();
+        $event = new PostRemoveEventArgs($entity, $this->entityManager);
+
+        $this->cache
+            ->expects(self::never())
+            ->method('delete');
+
+        $this->listener->postRemove($event);
+    }
+}


### PR DESCRIPTION
## Summary

- **Cache applicatif Symfony** (15 min, filesystem) sur `ComicSeriesRepository::findAllForApi()` pour éviter de requêter la base à chaque chargement PWA
- **Invalidation automatique** via `ComicSeriesCacheInvalidator` (listener Doctrine `postPersist`/`postUpdate`/`postRemove`) lors de modifications sur ComicSeries, Tome ou Author
- **Correction** des chemins obsolètes dans `phpstan-baseline.neon` (tests déplacés vers `Unit/`/`Integration/`)

## Fichiers modifiés

| Fichier | Description |
|---------|-------------|
| `backend/config/packages/cache.yaml` | Nouveau pool `comic_series_api.cache` |
| `backend/src/Repository/ComicSeriesRepository.php` | Injection du cache, `findAllForApi()` délègue à `doFindAllForApi()` via cache contracts |
| `backend/src/EventListener/ComicSeriesCacheInvalidator.php` | Listener Doctrine qui invalide le cache |
| `backend/tests/Unit/EventListener/ComicSeriesCacheInvalidatorTest.php` | 12 tests unitaires (3 entités × 3 events + 3 non-related) |
| `backend/tests/Integration/Repository/ComicSeriesRepositoryTest.php` | 4 tests d'intégration cache (consistance, invalidation persist/update/tome) |
| `backend/phpstan-baseline.neon` | Correction chemins tests |

## Test plan

- [x] 12 tests unitaires `ComicSeriesCacheInvalidatorTest` — tous passent
- [x] 27 tests intégration `ComicSeriesRepositoryTest` — tous passent (dont 4 nouveaux cache)
- [x] Suite complète (567 tests) — aucune régression
- [x] PHP-CS-Fixer — aucune erreur
- [x] PHPStan level 9 — aucune erreur

fixes #23