### PR TITLE
Commande app:lookup-missing pour métadonnées manquantes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Lookup automatique des métadonnées manquantes** : Commande `app:lookup-missing` pour rechercher automatiquement description, couverture, éditeur, auteurs et date de publication des séries incomplètes. Gestion du rate-limiting avec backoff exponentiel, options `--dry-run`, `--limit`, `--type`, `--series`, `--force`. Champ `lookupCompletedAt` pour éviter les re-lookups. Service `LookupApplier` réutilisable pour appliquer un `LookupResult` sur une série (#112)
 - **Transitions animées entre les pages** : Fade subtil entre les pages via la View Transition API native (CSS `::view-transition`) intégrée avec React Router (`viewTransition` sur les Links et `navigate()`). Respect de `prefers-reduced-motion`. Aucune dépendance ajoutée (#96)
 - **Tomes multi-numéros (intégrales)** : Champ optionnel `tomeEnd` sur l'entité Tome pour représenter une plage de numéros (ex : tome 4-6). Affiché dans la page détail et éditable dans le formulaire. Enrichissement Gemini : détection automatique des intégrales lors du lookup ISBN avec pré-remplissage de `tomeEnd` (#111)
 - **Cache sur findAllForApi()** : Cache applicatif Symfony (15 min, filesystem) sur la requête principale de l'API PWA avec invalidation automatique via listener Doctrine lors de modifications sur ComicSeries, Tome ou Author (#23)

--- a/backend/migrations/Version20260303201205.php
+++ b/backend/migrations/Version20260303201205.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260303201205 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajout du champ lookupCompletedAt sur ComicSeries';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE comic_series ADD lookup_completed_at DATETIME DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE comic_series DROP lookup_completed_at');
+    }
+}

--- a/backend/src/Command/ImportExcelCommand.php
+++ b/backend/src/Command/ImportExcelCommand.php
@@ -165,6 +165,10 @@ class ImportExcelCommand extends Command
             $totalTomes
         ));
 
+        if ($totalImported > 0 && !$dryRun) {
+            $io->info('Pour compléter les données des séries importées, exécutez : bin/console app:lookup-missing');
+        }
+
         return Command::SUCCESS;
     }
 

--- a/backend/src/Command/LookupMissingCommand.php
+++ b/backend/src/Command/LookupMissingCommand.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\ComicSeries;
+use App\Enum\ApiLookupStatus;
+use App\Enum\ComicType;
+use App\Repository\ComicSeriesRepository;
+use App\Service\Lookup\LookupApplier;
+use App\Service\Lookup\LookupOrchestrator;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Commande de lookup automatique pour les séries avec données manquantes.
+ */
+#[AsCommand(
+    name: 'app:lookup-missing',
+    description: 'Recherche les métadonnées manquantes pour les séries sans données',
+)]
+class LookupMissingCommand extends Command
+{
+    private const int BATCH_SIZE = 10;
+    private const int MAX_DELAY = 60;
+
+    public function __construct(
+        private readonly ComicSeriesRepository $comicSeriesRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LookupApplier $lookupApplier,
+        private readonly LookupOrchestrator $lookupOrchestrator,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('delay', 'd', InputOption::VALUE_REQUIRED, 'Délai en secondes entre chaque lookup', '2')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Simuler sans persister')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Ignorer lookupCompletedAt (re-lookup)')
+            ->addOption('limit', 'l', InputOption::VALUE_REQUIRED, 'Nombre maximum de lookups (0 = illimité)', '0')
+            ->addOption('series', 's', InputOption::VALUE_REQUIRED, 'ID d\'une série spécifique')
+            ->addOption('type', 't', InputOption::VALUE_REQUIRED, 'Filtrer par type (bd, manga, comics, livre)')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        /** @var string $delayOption */
+        $delayOption = $input->getOption('delay');
+        $delay = (int) $delayOption;
+        /** @var bool $dryRun */
+        $dryRun = $input->getOption('dry-run');
+        /** @var bool $force */
+        $force = $input->getOption('force');
+        /** @var string $limitOption */
+        $limitOption = $input->getOption('limit');
+        $limit = (int) $limitOption;
+        /** @var int|string|null $seriesId */
+        $seriesId = $input->getOption('series');
+        /** @var string|null $typeValue */
+        $typeValue = $input->getOption('type');
+
+        $type = \is_string($typeValue) ? ComicType::tryFrom($typeValue) : null;
+
+        $io->title('Lookup des métadonnées manquantes');
+
+        if ($dryRun) {
+            $io->warning('Mode dry-run activé. Aucune donnée ne sera persistée.');
+        }
+
+        // Mode série spécifique
+        if (null !== $seriesId) {
+            return $this->processSpecificSeries($io, (int) $seriesId, $delay, $dryRun);
+        }
+
+        $seriesToProcess = $this->comicSeriesRepository->findWithMissingLookupData(
+            force: $force,
+            limit: $limit > 0 ? $limit : null,
+            type: $type,
+        );
+
+        if ([] === $seriesToProcess) {
+            $io->success('Aucune série avec des données manquantes.');
+
+            return Command::SUCCESS;
+        }
+
+        $io->info(\sprintf('%d série(s) à traiter.', \count($seriesToProcess)));
+
+        return $this->processSeriesList($io, $seriesToProcess, $delay, $dryRun);
+    }
+
+    private function processSpecificSeries(SymfonyStyle $io, int $seriesId, int $delay, bool $dryRun): int
+    {
+        $series = $this->comicSeriesRepository->find($seriesId);
+
+        if (!$series instanceof ComicSeries) {
+            $io->error(\sprintf('Série #%d introuvable.', $seriesId));
+
+            return Command::FAILURE;
+        }
+
+        return $this->processSeriesList($io, [$series], $delay, $dryRun);
+    }
+
+    /**
+     * @param ComicSeries[] $seriesList
+     */
+    private function processSeriesList(SymfonyStyle $io, array $seriesList, int $initialDelay, bool $dryRun): int
+    {
+        $currentDelay = $initialDelay;
+        $failed = 0;
+        $processed = 0;
+        $skipped = 0;
+        $updated = 0;
+
+        foreach ($seriesList as $index => $series) {
+            $title = $series->getTitle();
+            $type = $series->getType();
+
+            $io->text(\sprintf('[%d/%d] %s (%s)', $index + 1, \count($seriesList), $title, $type->getLabel()));
+
+            $result = $this->lookupOrchestrator->lookupByTitle($title, $type);
+
+            // Vérifier le rate limiting
+            if ($this->hasRateLimitError()) {
+                $io->warning(\sprintf('  Rate limit détecté, attente %ds...', \min($currentDelay * 2, self::MAX_DELAY)));
+                $currentDelay = \min($currentDelay * 2, self::MAX_DELAY);
+                \sleep($currentDelay);
+
+                // Retry
+                $result = $this->lookupOrchestrator->lookupByTitle($title, $type);
+
+                if ($this->hasRateLimitError()) { // @phpstan-ignore if.alwaysTrue (état dépend de l'appel API)
+                    $io->error(\sprintf('  Rate limit persistant pour « %s », passage à la suivante.', $title));
+                    ++$failed;
+                    ++$processed;
+
+                    continue;
+                }
+            }
+
+            if (null === $result) {
+                $io->text('  Aucun résultat trouvé.');
+                ++$skipped;
+
+                if (!$dryRun) {
+                    $series->setLookupCompletedAt(new \DateTimeImmutable());
+                }
+            } else {
+                $updatedFields = $this->lookupApplier->apply($series, $result);
+
+                if ([] !== $updatedFields) {
+                    $io->text(\sprintf('  Champs mis à jour : %s', \implode(', ', $updatedFields)));
+                    ++$updated;
+                } else {
+                    $io->text('  Résultat trouvé mais aucun champ vide à remplir.');
+                    ++$skipped;
+                }
+
+                if (!$dryRun) {
+                    $series->setLookupCompletedAt(new \DateTimeImmutable());
+                }
+
+                // Reset delay après un succès
+                $currentDelay = $initialDelay;
+            }
+
+            ++$processed;
+
+            // Flush par batch
+            if (!$dryRun && 0 === $processed % self::BATCH_SIZE) {
+                $this->entityManager->flush();
+            }
+
+            // Délai entre les lookups (sauf dernier)
+            if ($index < \count($seriesList) - 1 && $currentDelay > 0) {
+                \sleep($currentDelay);
+            }
+        }
+
+        // Flush final
+        if (!$dryRun) {
+            $this->entityManager->flush();
+        }
+
+        $io->newLine();
+        $io->success(\sprintf(
+            '%d série(s) traitée(s) : %d mise(s) à jour, %d ignorée(s), %d en erreur.',
+            $processed,
+            $updated,
+            $skipped,
+            $failed,
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Vérifie si un des messages API indique un rate limit.
+     */
+    private function hasRateLimitError(): bool
+    {
+        foreach ($this->lookupOrchestrator->getLastApiMessages() as $message) {
+            if (ApiLookupStatus::RATE_LIMITED->value === $message['status']) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/src/Entity/ComicSeries.php
+++ b/backend/src/Entity/ComicSeries.php
@@ -166,6 +166,12 @@ class ComicSeries implements SoftDeletableInterface
     private ?string $description = null;
 
     /**
+     * Date du dernier lookup automatique effectué.
+     */
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $lookupCompletedAt = null;
+
+    /**
      * Date de publication.
      */
     #[Groups(['comic:read', 'comic:write'])]
@@ -351,6 +357,18 @@ class ComicSeries implements SoftDeletableInterface
     public function getLatestPublishedIssue(): ?int
     {
         return $this->latestPublishedIssue;
+    }
+
+    public function getLookupCompletedAt(): ?\DateTimeImmutable
+    {
+        return $this->lookupCompletedAt;
+    }
+
+    public function setLookupCompletedAt(?\DateTimeImmutable $lookupCompletedAt): static
+    {
+        $this->lookupCompletedAt = $lookupCompletedAt;
+
+        return $this;
     }
 
     public function setLatestPublishedIssue(?int $latestPublishedIssue): static

--- a/backend/src/Repository/ComicSeriesRepository.php
+++ b/backend/src/Repository/ComicSeriesRepository.php
@@ -118,6 +118,43 @@ class ComicSeriesRepository extends ServiceEntityRepository
     }
 
     /**
+     * Retourne les séries dont au moins un champ remplissable par lookup est vide.
+     *
+     * @return ComicSeries[]
+     */
+    public function findWithMissingLookupData(?ComicType $type = null, ?int $limit = null, bool $force = false): array
+    {
+        $qb = $this->createQueryBuilder('c')
+            ->leftJoin('c.authors', 'a')
+            ->groupBy('c.id')
+            ->having(
+                'c.description IS NULL'
+                .' OR c.publisher IS NULL'
+                .' OR c.publishedDate IS NULL'
+                .' OR (c.coverUrl IS NULL AND c.coverImage IS NULL)'
+                .' OR c.latestPublishedIssue IS NULL'
+                .' OR COUNT(a.id) = 0'
+            )
+            ->orderBy('c.title', 'ASC');
+
+        if (!$force) {
+            $qb->andWhere('c.lookupCompletedAt IS NULL');
+        }
+
+        if (null !== $type) {
+            $qb->andWhere('c.type = :type')
+                ->setParameter('type', $type);
+        }
+
+        if (null !== $limit && $limit > 0) {
+            $qb->setMaxResults($limit);
+        }
+
+        /** @var ComicSeries[] */
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
      * Retourne toutes les séries avec leurs relations pour l'API PWA.
      *
      * Utilise un cache applicatif (15 min) pour éviter de requêter la base

--- a/backend/src/Service/Lookup/LookupApplier.php
+++ b/backend/src/Service/Lookup/LookupApplier.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Lookup;
+
+use App\Entity\ComicSeries;
+use App\Repository\AuthorRepository;
+
+/**
+ * Applique un LookupResult sur une ComicSeries (uniquement les champs null).
+ */
+class LookupApplier
+{
+    public function __construct(
+        private readonly AuthorRepository $authorRepository,
+    ) {
+    }
+
+    /**
+     * Applique les données du résultat sur la série (champs null uniquement).
+     *
+     * @return list<string> Liste des champs mis à jour
+     */
+    public function apply(ComicSeries $series, LookupResult $result): array
+    {
+        $updatedFields = [];
+
+        if (null === $series->getDescription() && null !== $result->description) {
+            $series->setDescription($result->description);
+            $updatedFields[] = 'description';
+        }
+
+        if (null === $series->getCoverUrl() && null !== $result->thumbnail) {
+            $series->setCoverUrl($result->thumbnail);
+            $updatedFields[] = 'coverUrl';
+        }
+
+        if (!$series->isOneShot() && true === $result->isOneShot) {
+            $series->setIsOneShot(true);
+            $updatedFields[] = 'isOneShot';
+        }
+
+        if (null === $series->getLatestPublishedIssue() && null !== $result->latestPublishedIssue) {
+            $series->setLatestPublishedIssue($result->latestPublishedIssue);
+            $updatedFields[] = 'latestPublishedIssue';
+        }
+
+        if (null === $series->getPublishedDate() && null !== $result->publishedDate) {
+            $series->setPublishedDate($result->publishedDate);
+            $updatedFields[] = 'publishedDate';
+        }
+
+        if (null === $series->getPublisher() && null !== $result->publisher) {
+            $series->setPublisher($result->publisher);
+            $updatedFields[] = 'publisher';
+        }
+
+        if ($series->getAuthors()->isEmpty() && null !== $result->authors) {
+            $names = \array_map('trim', \explode(',', $result->authors));
+            $authors = $this->authorRepository->findOrCreateMultiple($names);
+
+            foreach ($authors as $author) {
+                $series->addAuthor($author);
+            }
+
+            if ([] !== $authors) {
+                $updatedFields[] = 'authors';
+            }
+        }
+
+        return $updatedFields;
+    }
+}

--- a/backend/tests/Integration/Command/LookupMissingCommandTest.php
+++ b/backend/tests/Integration/Command/LookupMissingCommandTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Command;
+
+use App\Entity\ComicSeries;
+use App\Enum\ComicType;
+use App\Tests\Factory\EntityFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Tests d'intégration pour la commande app:lookup-missing.
+ */
+final class LookupMissingCommandTest extends KernelTestCase
+{
+    private CommandTester $commandTester;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+
+        $application = new Application(self::$kernel);
+        $command = $application->find('app:lookup-missing');
+        $this->commandTester = new CommandTester($command);
+    }
+
+    public function testDryRunDoesNotModifyDatabase(): void
+    {
+        $series = EntityFactory::createComicSeries('Test Series');
+        $this->em->persist($series);
+        $this->em->flush();
+
+        $this->commandTester->execute(['--dry-run' => true, '--delay' => 0]);
+
+        self::assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        self::assertStringContainsString('dry-run', $this->commandTester->getDisplay());
+
+        // Vérifier que lookupCompletedAt n'a pas été mis à jour
+        $this->em->clear();
+        $refreshed = $this->em->getRepository(ComicSeries::class)->findOneBy(['title' => 'Test Series']);
+        self::assertNull($refreshed->getLookupCompletedAt());
+    }
+
+    public function testLimitRestrictsNumberOfLookups(): void
+    {
+        $this->em->persist(EntityFactory::createComicSeries('Alpha'));
+        $this->em->persist(EntityFactory::createComicSeries('Bravo'));
+        $this->em->persist(EntityFactory::createComicSeries('Charlie'));
+        $this->em->flush();
+
+        $this->commandTester->execute(['--limit' => 1, '--delay' => 0]);
+
+        self::assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $display = $this->commandTester->getDisplay();
+        self::assertStringContainsString('1 série(s) traitée(s)', $display);
+    }
+
+    public function testTypeFilterRestrictsToSpecificType(): void
+    {
+        $manga = EntityFactory::createComicSeries('Naruto', type: ComicType::MANGA);
+        $bd = EntityFactory::createComicSeries('Asterix', type: ComicType::BD);
+
+        $this->em->persist($bd);
+        $this->em->persist($manga);
+        $this->em->flush();
+
+        $this->commandTester->execute(['--type' => 'manga', '--delay' => 0]);
+
+        self::assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $display = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Naruto', $display);
+        self::assertStringNotContainsString('Asterix', $display);
+    }
+
+    public function testSkipsSeriesWithLookupCompletedAt(): void
+    {
+        $already = EntityFactory::createComicSeries('Already Done');
+        $already->setLookupCompletedAt(new \DateTimeImmutable());
+        $pending = EntityFactory::createComicSeries('Pending');
+
+        $this->em->persist($already);
+        $this->em->persist($pending);
+        $this->em->flush();
+
+        $this->commandTester->execute(['--delay' => 0]);
+
+        self::assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $display = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Pending', $display);
+        self::assertStringNotContainsString('Already Done', $display);
+    }
+
+    public function testForceIgnoresLookupCompletedAt(): void
+    {
+        $already = EntityFactory::createComicSeries('Already Done');
+        $already->setLookupCompletedAt(new \DateTimeImmutable());
+
+        $this->em->persist($already);
+        $this->em->flush();
+
+        $this->commandTester->execute(['--force' => true, '--delay' => 0]);
+
+        self::assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $display = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Already Done', $display);
+    }
+
+    public function testNoSeriesFoundDisplaysMessage(): void
+    {
+        $this->commandTester->execute(['--delay' => 0]);
+
+        self::assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $display = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Aucune série', $display);
+    }
+
+    public function testSeriesIdOptionTargetsSpecificSeries(): void
+    {
+        $alpha = EntityFactory::createComicSeries('Alpha');
+        $bravo = EntityFactory::createComicSeries('Bravo');
+
+        $this->em->persist($alpha);
+        $this->em->persist($bravo);
+        $this->em->flush();
+
+        $this->commandTester->execute(['--series' => $alpha->getId(), '--delay' => 0]);
+
+        self::assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        $display = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Alpha', $display);
+        self::assertStringNotContainsString('Bravo', $display);
+    }
+
+    public function testInvalidSeriesIdReturnsFailure(): void
+    {
+        $this->commandTester->execute(['--series' => 99999, '--delay' => 0]);
+
+        self::assertSame(Command::FAILURE, $this->commandTester->getStatusCode());
+        $display = $this->commandTester->getDisplay();
+        self::assertStringContainsString('introuvable', $display);
+    }
+}

--- a/backend/tests/Integration/Repository/ComicSeriesRepositoryTest.php
+++ b/backend/tests/Integration/Repository/ComicSeriesRepositoryTest.php
@@ -621,4 +621,129 @@ final class ComicSeriesRepositoryTest extends KernelTestCase
         $secondResult = $this->repository->findAllForApi();
         self::assertSame(1, $secondResult[0]['tomesCount']);
     }
+
+    // ---------------------------------------------------------------
+    // findWithMissingLookupData
+    // ---------------------------------------------------------------
+
+    public function testFindWithMissingLookupDataReturnsSeriesWithoutDescription(): void
+    {
+        $missing = EntityFactory::createComicSeries('Missing');
+        $complete = EntityFactory::createComicSeries('Complete');
+        $complete->setDescription('Une description');
+        $complete->setPublisher('Editeur');
+        $complete->setPublishedDate('2024');
+        $complete->setCoverUrl('https://example.com/cover.jpg');
+        $complete->setLatestPublishedIssue(5);
+        $author = EntityFactory::createAuthor('Auteur');
+        $this->em->persist($author);
+        $complete->addAuthor($author);
+
+        $this->em->persist($complete);
+        $this->em->persist($missing);
+        $this->em->flush();
+
+        $result = $this->repository->findWithMissingLookupData();
+
+        self::assertCount(1, $result);
+        self::assertSame('Missing', $result[0]->getTitle());
+    }
+
+    public function testFindWithMissingLookupDataSkipsLookupCompleted(): void
+    {
+        $alreadyLooked = EntityFactory::createComicSeries('Already Looked');
+        $alreadyLooked->setLookupCompletedAt(new \DateTimeImmutable());
+
+        $notLooked = EntityFactory::createComicSeries('Not Looked');
+
+        $this->em->persist($alreadyLooked);
+        $this->em->persist($notLooked);
+        $this->em->flush();
+
+        $result = $this->repository->findWithMissingLookupData();
+
+        self::assertCount(1, $result);
+        self::assertSame('Not Looked', $result[0]->getTitle());
+    }
+
+    public function testFindWithMissingLookupDataWithTypeFilter(): void
+    {
+        $manga = EntityFactory::createComicSeries('Naruto', ComicStatus::BUYING, ComicType::MANGA);
+        $bd = EntityFactory::createComicSeries('Asterix', ComicStatus::BUYING, ComicType::BD);
+
+        $this->em->persist($bd);
+        $this->em->persist($manga);
+        $this->em->flush();
+
+        $result = $this->repository->findWithMissingLookupData(type: ComicType::MANGA);
+
+        self::assertCount(1, $result);
+        self::assertSame('Naruto', $result[0]->getTitle());
+    }
+
+    public function testFindWithMissingLookupDataWithLimit(): void
+    {
+        $this->em->persist(EntityFactory::createComicSeries('Alpha'));
+        $this->em->persist(EntityFactory::createComicSeries('Bravo'));
+        $this->em->persist(EntityFactory::createComicSeries('Charlie'));
+        $this->em->flush();
+
+        $result = $this->repository->findWithMissingLookupData(limit: 2);
+
+        self::assertCount(2, $result);
+    }
+
+    public function testFindWithMissingLookupDataReturnsMissingCover(): void
+    {
+        $noCover = EntityFactory::createComicSeries('No Cover');
+        $noCover->setDescription('Has description');
+        $noCover->setPublisher('Editeur');
+        $noCover->setPublishedDate('2024');
+        $noCover->setLatestPublishedIssue(5);
+        $author = EntityFactory::createAuthor('Auteur');
+        $this->em->persist($author);
+        $noCover->addAuthor($author);
+        // Pas de coverUrl ni coverImage → doit être retourné
+
+        $this->em->persist($noCover);
+        $this->em->flush();
+
+        $result = $this->repository->findWithMissingLookupData();
+
+        self::assertCount(1, $result);
+        self::assertSame('No Cover', $result[0]->getTitle());
+    }
+
+    public function testFindWithMissingLookupDataReturnsMissingAuthors(): void
+    {
+        $noAuthors = EntityFactory::createComicSeries('No Authors');
+        $noAuthors->setDescription('Has description');
+        $noAuthors->setPublisher('Editeur');
+        $noAuthors->setPublishedDate('2024');
+        $noAuthors->setCoverUrl('https://example.com/cover.jpg');
+        $noAuthors->setLatestPublishedIssue(5);
+        // Pas d'auteurs → doit être retourné
+
+        $this->em->persist($noAuthors);
+        $this->em->flush();
+
+        $result = $this->repository->findWithMissingLookupData();
+
+        self::assertCount(1, $result);
+        self::assertSame('No Authors', $result[0]->getTitle());
+    }
+
+    public function testFindWithMissingLookupDataForceIgnoresLookupCompletedAt(): void
+    {
+        $alreadyLooked = EntityFactory::createComicSeries('Already Looked');
+        $alreadyLooked->setLookupCompletedAt(new \DateTimeImmutable());
+
+        $this->em->persist($alreadyLooked);
+        $this->em->flush();
+
+        $result = $this->repository->findWithMissingLookupData(force: true);
+
+        self::assertCount(1, $result);
+        self::assertSame('Already Looked', $result[0]->getTitle());
+    }
 }

--- a/backend/tests/Unit/Service/Lookup/LookupApplierTest.php
+++ b/backend/tests/Unit/Service/Lookup/LookupApplierTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Lookup;
+
+use App\Entity\Author;
+use App\Entity\ComicSeries;
+use App\Repository\AuthorRepository;
+use App\Service\Lookup\LookupApplier;
+use App\Service\Lookup\LookupResult;
+use App\Tests\Factory\EntityFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires pour LookupApplier.
+ */
+final class LookupApplierTest extends TestCase
+{
+    private AuthorRepository $authorRepository;
+    private LookupApplier $applier;
+
+    protected function setUp(): void
+    {
+        $this->authorRepository = $this->createMock(AuthorRepository::class);
+        $this->applier = new LookupApplier($this->authorRepository);
+    }
+
+    public function testApplyFillsAllNullFields(): void
+    {
+        $series = EntityFactory::createComicSeries('Test');
+        $result = new LookupResult(
+            authors: 'Author A, Author B',
+            description: 'Une description',
+            isOneShot: true,
+            latestPublishedIssue: 10,
+            publishedDate: '2024',
+            publisher: 'Editeur',
+            source: 'test',
+            thumbnail: 'https://example.com/cover.jpg',
+        );
+
+        $authorA = EntityFactory::createAuthor('Author A');
+        $authorB = EntityFactory::createAuthor('Author B');
+        $this->authorRepository->method('findOrCreateMultiple')
+            ->with(['Author A', 'Author B'])
+            ->willReturn([$authorA, $authorB]);
+
+        $updatedFields = $this->applier->apply($series, $result);
+
+        self::assertSame('Une description', $series->getDescription());
+        self::assertSame('Editeur', $series->getPublisher());
+        self::assertSame('2024', $series->getPublishedDate());
+        self::assertSame('https://example.com/cover.jpg', $series->getCoverUrl());
+        self::assertTrue($series->isOneShot());
+        self::assertSame(10, $series->getLatestPublishedIssue());
+        self::assertCount(2, $series->getAuthors());
+        self::assertContains('authors', $updatedFields);
+        self::assertContains('coverUrl', $updatedFields);
+        self::assertContains('description', $updatedFields);
+        self::assertContains('isOneShot', $updatedFields);
+        self::assertContains('latestPublishedIssue', $updatedFields);
+        self::assertContains('publishedDate', $updatedFields);
+        self::assertContains('publisher', $updatedFields);
+    }
+
+    public function testApplySkipsNonNullFields(): void
+    {
+        $series = EntityFactory::createComicSeries('Test');
+        $series->setDescription('Existing description');
+        $series->setPublisher('Existing publisher');
+
+        $result = new LookupResult(
+            description: 'New description',
+            publisher: 'New publisher',
+            source: 'test',
+            thumbnail: 'https://example.com/cover.jpg',
+        );
+
+        $updatedFields = $this->applier->apply($series, $result);
+
+        // Les champs existants ne sont pas écrasés
+        self::assertSame('Existing description', $series->getDescription());
+        self::assertSame('Existing publisher', $series->getPublisher());
+        // Le champ vide est rempli
+        self::assertSame('https://example.com/cover.jpg', $series->getCoverUrl());
+        self::assertNotContains('description', $updatedFields);
+        self::assertNotContains('publisher', $updatedFields);
+        self::assertContains('coverUrl', $updatedFields);
+    }
+
+    public function testApplySkipsNullResultFields(): void
+    {
+        $series = EntityFactory::createComicSeries('Test');
+        $result = new LookupResult(source: 'test');
+
+        $updatedFields = $this->applier->apply($series, $result);
+
+        self::assertSame([], $updatedFields);
+        self::assertNull($series->getDescription());
+        self::assertNull($series->getPublisher());
+    }
+
+    public function testApplyAddsAuthorsOnlyWhenEmpty(): void
+    {
+        $series = EntityFactory::createComicSeries('Test');
+
+        $result = new LookupResult(
+            authors: 'Author A, Author B',
+            source: 'test',
+        );
+
+        $authorA = EntityFactory::createAuthor('Author A');
+        $authorB = EntityFactory::createAuthor('Author B');
+        $this->authorRepository->method('findOrCreateMultiple')
+            ->with(['Author A', 'Author B'])
+            ->willReturn([$authorA, $authorB]);
+
+        $updatedFields = $this->applier->apply($series, $result);
+
+        self::assertCount(2, $series->getAuthors());
+        self::assertContains('authors', $updatedFields);
+    }
+
+    public function testApplySkipsAuthorsWhenSeriesAlreadyHasAuthors(): void
+    {
+        $series = EntityFactory::createComicSeries('Test');
+        $series->addAuthor(EntityFactory::createAuthor('Existing'));
+
+        $result = new LookupResult(
+            authors: 'New Author',
+            source: 'test',
+        );
+
+        $updatedFields = $this->applier->apply($series, $result);
+
+        // La série a déjà des auteurs → on ne les remplace pas
+        self::assertCount(1, $series->getAuthors());
+        self::assertNotContains('authors', $updatedFields);
+    }
+
+    public function testApplySkipsLatestPublishedIssueWhenAlreadySet(): void
+    {
+        $series = EntityFactory::createComicSeries('Test');
+        $series->setLatestPublishedIssue(5);
+
+        $result = new LookupResult(
+            latestPublishedIssue: 10,
+            source: 'test',
+        );
+
+        $updatedFields = $this->applier->apply($series, $result);
+
+        self::assertSame(5, $series->getLatestPublishedIssue());
+        self::assertNotContains('latestPublishedIssue', $updatedFields);
+    }
+
+    public function testApplySkipsIsOneShotWhenAlreadyTrue(): void
+    {
+        $series = EntityFactory::createComicSeries('Test');
+        $series->setIsOneShot(true);
+
+        $result = new LookupResult(
+            isOneShot: false,
+            source: 'test',
+        );
+
+        $updatedFields = $this->applier->apply($series, $result);
+
+        // isOneShot est déjà true → on ne le change pas
+        self::assertTrue($series->isOneShot());
+        self::assertNotContains('isOneShot', $updatedFields);
+    }
+}


### PR DESCRIPTION
## Summary

- **`app:lookup-missing`** : nouvelle commande pour rechercher automatiquement les métadonnées (description, couverture, éditeur, auteurs, date de publication) des séries incomplètes
- **`LookupApplier`** : service réutilisable qui applique un `LookupResult` sur une `ComicSeries` (uniquement les champs null)
- **`lookupCompletedAt`** : champ datetime sur `ComicSeries` pour éviter les re-lookups inutiles
- **Options** : `--delay` (backoff rate-limit), `--limit`, `--type`, `--series` (ID spécifique), `--force` (ignorer lookupCompletedAt), `--dry-run`
- Message d'info dans `ImportExcelCommand` après import suggérant `app:lookup-missing`

## Test plan

- [x] 7 tests unitaires LookupApplier (champs null, skip non-null, auteurs, isOneShot)
- [x] 8 tests intégration LookupMissingCommand (dry-run, limit, type, force, series ID, no results)
- [x] 7 tests intégration findWithMissingLookupData (missing fields, lookupCompletedAt, type filter, limit, force)
- [x] PHPStan clean
- [x] CS Fixer clean
- [x] 609 tests backend passent

Fixes #112