### PR TITLE
Afficher la date de publication sur la page détail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Toutes les modifications notables de ce projet sont documentées dans ce fichier
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/),
 et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/).
 
+## [Unreleased]
+
+### Added
+
+- **Date de publication sur la page détail** : Affichage de la date de publication (champ `publishedDate`) dans les métadonnées de la page détail d'une série, formatée en français (#98)
+
 ## [v2.0.0] - 2026-03-03
 
 ### Added

--- a/frontend/src/__tests__/integration/pages/ComicDetail.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicDetail.test.tsx
@@ -428,6 +428,41 @@ describe("ComicDetail", () => {
     expect(screen.queryByText("Auteurs :")).not.toBeInTheDocument();
   });
 
+  it("renders published date when available", async () => {
+    server.use(
+      http.get("/api/comic_series/1", () =>
+        HttpResponse.json(
+          createMockComicSeries({ id: 1, publishedDate: "2020-03-15", title: "With Date" }),
+        ),
+      ),
+    );
+
+    renderComicDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("With Date")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Parution :")).toBeInTheDocument();
+    expect(screen.getByText("15 mars 2020")).toBeInTheDocument();
+  });
+
+  it("does not render published date when null", async () => {
+    server.use(
+      http.get("/api/comic_series/1", () =>
+        HttpResponse.json(
+          createMockComicSeries({ id: 1, publishedDate: null, title: "No Date" }),
+        ),
+      ),
+    );
+
+    renderComicDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("No Date")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Parution :")).not.toBeInTheDocument();
+  });
+
   it("does not render publisher section when publisher is null", async () => {
     server.use(
       http.get("/api/comic_series/1", () =>

--- a/frontend/src/pages/ComicDetail.tsx
+++ b/frontend/src/pages/ComicDetail.tsx
@@ -150,6 +150,12 @@ export default function ComicDetail() {
               <span className="font-medium">Éditeur :</span> {comic.publisher}
             </p>
           )}
+          {comic.publishedDate && (
+            <p className="text-sm text-text-secondary">
+              <span className="font-medium">Parution :</span>{" "}
+              {new Date(comic.publishedDate).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}
+            </p>
+          )}
           {comic.description && (
             <p className="text-sm leading-relaxed text-text-secondary">{comic.description}</p>
           )}


### PR DESCRIPTION
## Summary

- Affiche le champ `publishedDate` dans les métadonnées de la page détail, formaté en français (ex : « 15 mars 2020 »)
- Le champ n'apparaît pas si la date est absente

Fixes #98

## Test plan

- [x] Test : la date s'affiche quand `publishedDate` est renseigné
- [x] Test : rien ne s'affiche quand `publishedDate` est null
- [x] 471/471 tests frontend passent
- [x] TypeScript clean (`tsc --noEmit`)