### PR TITLE
fix(lookup): corriger le parsing des auteurs BnF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Lookup BnF** : Correction du parsing des noms d'auteurs contenant un suffixe de rôle BnF (ex: `. Auteur du texte`, `. Illustrateur`) (#133)
+
 ### Added
 
 - **Lookup Bedetheque via Gemini Google Search** : Nouveau provider de recherche ciblant bedetheque.com via Gemini avec Google Search grounding. Priorité élevée pour les BD (150), modérée pour manga/comics (110). Recherche par ISBN et titre (#119)

--- a/backend/src/Service/Lookup/BnfLookup.php
+++ b/backend/src/Service/Lookup/BnfLookup.php
@@ -96,8 +96,12 @@ class BnfLookup extends AbstractLookupProvider
      */
     private function cleanAuthorName(string $raw): string
     {
-        // Supprimer les dates entre parenthèses : "(1926-1977)" ou "(1975-....)"
-        $cleaned = \trim((string) \preg_replace('/\s*\([^)]*\)\s*$/', '', $raw));
+        // Supprimer le suffixe de rôle BnF après les dates : "(1975-....). Auteur du texte"
+        // Format : parenthèses de dates suivies d'un point et du rôle
+        $cleaned = \trim((string) \preg_replace('/\([^)]*\)\.\s+.*$/', '', $raw));
+
+        // Supprimer les dates entre parenthèses restantes : "(1926-1977)" ou "(1975-....)"
+        $cleaned = \trim((string) \preg_replace('/\s*\([^)]*\)/', '', $cleaned));
 
         // Si format "Nom, Prénom" → "Prénom Nom"
         if (\str_contains($cleaned, ',')) {

--- a/backend/tests/Unit/Service/Lookup/BnfLookupTest.php
+++ b/backend/tests/Unit/Service/Lookup/BnfLookupTest.php
@@ -371,6 +371,62 @@ final class BnfLookupTest extends TestCase
     }
 
     /**
+     * Teste que cleanAuthorName supprime le suffixe de rôle BnF (". Auteur du texte").
+     */
+    public function testResolveLookupStripsRoleSuffix(): void
+    {
+        $xml = $this->buildXml(
+            creator: 'Oda, Eiichirō (1975-....). Auteur du texte',
+            title: 'One Piece',
+        );
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getContent')->willReturn($xml);
+
+        $result = $this->provider->resolveLookup($response);
+
+        self::assertNotNull($result);
+        self::assertSame('Eiichirō Oda', $result->authors);
+    }
+
+    /**
+     * Teste que cleanAuthorName supprime un rôle différent (". Illustrateur").
+     */
+    public function testResolveLookupStripsVariousRoleSuffixes(): void
+    {
+        $xml = $this->buildXml(
+            creator: 'Uderzo, Albert (1927-2020). Illustrateur',
+            title: 'Astérix',
+        );
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getContent')->willReturn($xml);
+
+        $result = $this->provider->resolveLookup($response);
+
+        self::assertNotNull($result);
+        self::assertSame('Albert Uderzo', $result->authors);
+    }
+
+    /**
+     * Teste que cleanTitle supprime les mentions de traducteur après " ; ".
+     */
+    public function testResolveLookupStripsTranslatorFromTitle(): void
+    {
+        $xml = $this->buildXml(
+            title: 'One Piece. 56 / Eiichiro Oda ; traduction Sylvain Chollet',
+        );
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getContent')->willReturn($xml);
+
+        $result = $this->provider->resolveLookup($response);
+
+        self::assertNotNull($result);
+        self::assertSame('One Piece. 56', $result->title);
+    }
+
+    /**
      * Teste cleanAuthorName avec un auteur sans virgule (nom seul).
      */
     public function testResolveLookupSingleNameAuthor(): void


### PR DESCRIPTION
## Summary

- Corrige le parsing des noms d'auteurs BnF qui incluent un suffixe de rôle (`. Auteur du texte`, `. Illustrateur`, etc.) après les dates entre parenthèses
- La regex nettoie d'abord le pattern `(dates). Rôle`, puis les parenthèses restantes

## Exemple

**Avant** : `Oda, Eiichirō (1975-....). Auteur du texte` → `Eiichirō (1975-....). Auteur du texte Oda`
**Après** : `Oda, Eiichirō (1975-....). Auteur du texte` → `Eiichirō Oda`

## Test plan

- [x] 3 nouveaux tests unitaires (suffixe rôle, rôles variés, titre avec traducteur)
- [x] 21 tests BnfLookup passent
- [x] 633 tests backend passent
- [x] PHP CS Fixer clean

fixes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)