### PR TITLE
feat(purge): outil de purge interactif depuis le frontend

### DIFF
--- a/backend/src/Command/PurgeDeletedCommand.php
+++ b/backend/src/Command/PurgeDeletedCommand.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace App\Command;
 
-use App\Entity\ComicSeries;
-use App\Service\ComicSeriesService;
-use Doctrine\ORM\EntityManagerInterface;
+use App\Service\PurgeService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,8 +19,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class PurgeDeletedCommand extends Command
 {
     public function __construct(
-        private readonly ComicSeriesService $comicSeriesService,
-        private readonly EntityManagerInterface $entityManager,
+        private readonly PurgeService $purgeService,
     ) {
         parent::__construct();
     }
@@ -49,45 +46,26 @@ class PurgeDeletedCommand extends Command
         }
 
         $dryRun = (bool) $input->getOption('dry-run');
-        $cutoffDate = new \DateTime(\sprintf('-%d days', $days));
+        $purgeable = $this->purgeService->findPurgeable($days);
 
-        // Désactiver le filtre pour accéder aux séries soft-deleted
-        $this->entityManager->getFilters()->disable('soft_delete');
-
-        /** @var ComicSeries[] $seriesToPurge */
-        $seriesToPurge = $this->entityManager->getRepository(ComicSeries::class)
-            ->createQueryBuilder('c')
-            ->where('c.deletedAt IS NOT NULL')
-            ->andWhere('c.deletedAt <= :cutoff')
-            ->setParameter('cutoff', $cutoffDate)
-            ->getQuery()
-            ->getResult();
-
-        $this->entityManager->getFilters()->enable('soft_delete');
-
-        if ([] === $seriesToPurge) {
+        if ([] === $purgeable) {
             $io->success('Aucune série à purger.');
 
             return Command::SUCCESS;
         }
 
-        $io->section(\sprintf('%d série(s) éligible(s) à la purge (supprimées depuis plus de %d jours)', \count($seriesToPurge), $days));
+        $io->section(\sprintf('%d série(s) éligible(s) à la purge (supprimées depuis plus de %d jours)', \count($purgeable), $days));
 
-        foreach ($seriesToPurge as $series) {
-            $deletedAt = $series->getDeletedAt();
-            $io->writeln(\sprintf('  - %s (supprimée le %s)', $series->getTitle(), $deletedAt instanceof \DateTimeInterface ? $deletedAt->format('d/m/Y') : '?'));
-
-            if (!$dryRun) {
-                /** @var int $seriesId already persisted entity, getId() cannot be null */
-                $seriesId = $series->getId();
-                $this->comicSeriesService->permanentDelete($seriesId, $series);
-            }
+        foreach ($purgeable as $series) {
+            $io->writeln(\sprintf('  - %s (supprimée le %s)', $series->title, $series->deletedAt->format('d/m/Y')));
         }
 
         if ($dryRun) {
             $io->note('Mode dry-run : aucune suppression effectuée.');
         } else {
-            $io->success(\sprintf('%d série(s) purgée(s).', \count($seriesToPurge)));
+            $ids = \array_map(static fn ($s) => $s->id, $purgeable);
+            $count = $this->purgeService->executePurge($ids);
+            $io->success(\sprintf('%d série(s) purgée(s).', $count));
         }
 
         return Command::SUCCESS;

--- a/backend/src/Controller/PurgeController.php
+++ b/backend/src/Controller/PurgeController.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\PurgeService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Endpoints pour la purge des séries soft-deleted.
+ */
+#[IsGranted('ROLE_USER')]
+#[Route('/api/tools/purge')]
+class PurgeController
+{
+    public function __construct(
+        private readonly PurgeService $purgeService,
+    ) {
+    }
+
+    /**
+     * Exécute la purge des séries identifiées.
+     */
+    #[Route('/execute', name: 'api_tools_purge_execute', methods: ['POST'])]
+    public function execute(Request $request): JsonResponse
+    {
+        /** @var array<string, mixed> $data */
+        $data = \json_decode($request->getContent(), true) ?? [];
+
+        $seriesIds = $data['seriesIds'] ?? null;
+
+        if (!\is_array($seriesIds) || [] === $seriesIds) {
+            return new JsonResponse(
+                ['error' => 'Le champ "seriesIds" est requis et ne peut pas être vide.'],
+                Response::HTTP_BAD_REQUEST,
+            );
+        }
+
+        /** @var int[] $ids */
+        $ids = \array_map('\intval', $seriesIds);
+        $count = $this->purgeService->executePurge($ids);
+
+        return new JsonResponse(['purged' => $count]);
+    }
+
+    /**
+     * Prévisualise les séries éligibles à la purge.
+     */
+    #[Route('/preview', name: 'api_tools_purge_preview', methods: ['GET'])]
+    public function preview(Request $request): JsonResponse
+    {
+        $days = (int) $request->query->get('days', '30');
+
+        if ($days <= 0) {
+            return new JsonResponse(
+                ['error' => 'Le paramètre "days" doit être supérieur à 0.'],
+                Response::HTTP_BAD_REQUEST,
+            );
+        }
+
+        $purgeable = $this->purgeService->findPurgeable($days);
+
+        return new JsonResponse($purgeable);
+    }
+}

--- a/backend/src/DTO/PurgeableSeries.php
+++ b/backend/src/DTO/PurgeableSeries.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+/**
+ * Série éligible à la purge.
+ */
+final readonly class PurgeableSeries implements \JsonSerializable
+{
+    public function __construct(
+        public \DateTimeImmutable $deletedAt,
+        public int $id,
+        public string $title,
+    ) {
+    }
+
+    /**
+     * @return array{deletedAt: string, id: int, title: string}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'deletedAt' => $this->deletedAt->format(\DateTimeInterface::ATOM),
+            'id' => $this->id,
+            'title' => $this->title,
+        ];
+    }
+}

--- a/backend/src/Service/PurgeService.php
+++ b/backend/src/Service/PurgeService.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\DTO\PurgeableSeries;
+use App\Entity\ComicSeries;
+use App\Repository\ComicSeriesRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Service de purge des séries soft-deleted.
+ */
+class PurgeService
+{
+    public function __construct(
+        private readonly ComicSeriesRepository $comicSeriesRepository,
+        private readonly ComicSeriesService $comicSeriesService,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * Exécute la purge définitive des séries identifiées par leurs IDs.
+     *
+     * @param int[] $seriesIds
+     *
+     * @return int nombre de séries purgées
+     */
+    public function executePurge(array $seriesIds): int
+    {
+        if ([] === $seriesIds) {
+            return 0;
+        }
+
+        $this->entityManager->getFilters()->disable('soft_delete');
+
+        $count = 0;
+
+        foreach ($seriesIds as $id) {
+            $series = $this->comicSeriesRepository->find($id);
+
+            if ($series instanceof ComicSeries) {
+                $this->comicSeriesService->permanentDelete($id, $series);
+                ++$count;
+            }
+        }
+
+        $this->entityManager->getFilters()->enable('soft_delete');
+
+        return $count;
+    }
+
+    /**
+     * Recherche les séries éligibles à la purge (soft-deleted depuis plus de N jours).
+     *
+     * @return PurgeableSeries[]
+     */
+    public function findPurgeable(int $days): array
+    {
+        $cutoffDate = new \DateTime(\sprintf('-%d days', $days));
+
+        $this->entityManager->getFilters()->disable('soft_delete');
+
+        /** @var ComicSeries[] $series */
+        $series = $this->comicSeriesRepository->createQueryBuilder('c')
+            ->where('c.deletedAt IS NOT NULL')
+            ->andWhere('c.deletedAt <= :cutoff')
+            ->setParameter('cutoff', $cutoffDate)
+            ->getQuery()
+            ->getResult();
+
+        $this->entityManager->getFilters()->enable('soft_delete');
+
+        return \array_map(
+            static function (ComicSeries $s): PurgeableSeries {
+                /** @var \DateTimeInterface $deletedAt query filtre deletedAt IS NOT NULL */
+                $deletedAt = $s->getDeletedAt();
+                /** @var int $id entité persistée */
+                $id = $s->getId();
+
+                return new PurgeableSeries(
+                    deletedAt: \DateTimeImmutable::createFromInterface($deletedAt),
+                    id: $id,
+                    title: $s->getTitle(),
+                );
+            },
+            $series,
+        );
+    }
+}

--- a/backend/tests/Functional/Controller/PurgeControllerTest.php
+++ b/backend/tests/Functional/Controller/PurgeControllerTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Repository\UserRepository;
+use App\Tests\Factory\EntityFactory;
+use App\Tests\Trait\AuthenticatedTestTrait;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Tests fonctionnels pour PurgeController.
+ */
+final class PurgeControllerTest extends ApiTestCase
+{
+    use AuthenticatedTestTrait;
+
+    protected static ?bool $alwaysBootKernel = true;
+
+    protected function setUp(): void
+    {
+        $container = static::getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+
+        /** @var UserRepository $userRepo */
+        $userRepo = $container->get(UserRepository::class);
+
+        if (null === $userRepo->findOneBy(['email' => 'test@example.com'])) {
+            $user = EntityFactory::createUser();
+            $em->persist($user);
+            $em->flush();
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Authentification
+    // ---------------------------------------------------------------
+
+    public function testPreviewRequiresAuthentication(): void
+    {
+        $client = $this->createUnauthenticatedClient();
+
+        $client->request('GET', '/api/tools/purge/preview?days=30');
+
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testExecuteRequiresAuthentication(): void
+    {
+        $client = $this->createUnauthenticatedClient();
+
+        $client->request('POST', '/api/tools/purge/execute', [
+            'json' => ['seriesIds' => [1]],
+        ]);
+
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    // ---------------------------------------------------------------
+    // GET /api/tools/purge/preview
+    // ---------------------------------------------------------------
+
+    public function testPreviewReturnsEmptyListWhenNoPurgeable(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/tools/purge/preview?days=30');
+
+        self::assertResponseIsSuccessful();
+        $data = $client->getResponse()->toArray();
+        self::assertSame([], $data);
+    }
+
+    public function testPreviewReturnsPurgeableSeries(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+        $series = EntityFactory::createComicSeries('Old Deleted');
+        $em->persist($series);
+        $em->flush();
+
+        $series->delete();
+        $em->flush();
+
+        // Simuler une suppression ancienne
+        $em->getConnection()->executeStatement(
+            'UPDATE comic_series SET deleted_at = :date WHERE id = :id',
+            [
+                'date' => (new \DateTime('-60 days'))->format('Y-m-d H:i:s'),
+                'id' => $series->getId(),
+            ]
+        );
+
+        $client->request('GET', '/api/tools/purge/preview?days=30');
+
+        self::assertResponseIsSuccessful();
+        $data = $client->getResponse()->toArray();
+        self::assertNotEmpty($data);
+        self::assertSame('Old Deleted', $data[0]['title']);
+        self::assertArrayHasKey('deletedAt', $data[0]);
+        self::assertArrayHasKey('id', $data[0]);
+    }
+
+    public function testPreviewReturns400ForInvalidDays(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/tools/purge/preview?days=0');
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testPreviewDefaultsTo30Days(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/tools/purge/preview');
+
+        self::assertResponseIsSuccessful();
+        $data = $client->getResponse()->toArray();
+        self::assertIsArray($data);
+    }
+
+    // ---------------------------------------------------------------
+    // POST /api/tools/purge/execute
+    // ---------------------------------------------------------------
+
+    public function testExecutePurgesSeries(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+        $series = EntityFactory::createComicSeries('To Purge');
+        $em->persist($series);
+        $em->flush();
+
+        $seriesId = $series->getId();
+        $series->delete();
+        $em->flush();
+
+        $em->getConnection()->executeStatement(
+            'UPDATE comic_series SET deleted_at = :date WHERE id = :id',
+            [
+                'date' => (new \DateTime('-60 days'))->format('Y-m-d H:i:s'),
+                'id' => $seriesId,
+            ]
+        );
+
+        $client->request('POST', '/api/tools/purge/execute', [
+            'json' => ['seriesIds' => [$seriesId]],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        $data = $client->getResponse()->toArray();
+        self::assertSame(1, $data['purged']);
+
+        // Vérifier la suppression définitive
+        $em->getFilters()->disable('soft_delete');
+        $em->clear();
+        self::assertNull($em->getRepository(\App\Entity\ComicSeries::class)->find($seriesId));
+        $em->getFilters()->enable('soft_delete');
+    }
+
+    public function testExecuteReturns400ForMissingSeriesIds(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('POST', '/api/tools/purge/execute', [
+            'json' => [],
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testExecuteReturns400ForEmptySeriesIds(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('POST', '/api/tools/purge/execute', [
+            'json' => ['seriesIds' => []],
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+}

--- a/backend/tests/Unit/Service/PurgeServiceTest.php
+++ b/backend/tests/Unit/Service/PurgeServiceTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\DTO\PurgeableSeries;
+use App\Entity\ComicSeries;
+use App\Repository\ComicSeriesRepository;
+use App\Service\ComicSeriesService;
+use App\Service\PurgeService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\FilterCollection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires pour PurgeService.
+ */
+final class PurgeServiceTest extends TestCase
+{
+    private ComicSeriesRepository&MockObject $comicSeriesRepository;
+    private ComicSeriesService&MockObject $comicSeriesService;
+    private EntityManagerInterface&MockObject $entityManager;
+    private FilterCollection&MockObject $filterCollection;
+    private PurgeService $purgeService;
+
+    protected function setUp(): void
+    {
+        $this->comicSeriesRepository = $this->createMock(ComicSeriesRepository::class);
+        $this->comicSeriesService = $this->createMock(ComicSeriesService::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->filterCollection = $this->createMock(FilterCollection::class);
+
+        $this->entityManager->method('getFilters')->willReturn($this->filterCollection);
+
+        $this->purgeService = new PurgeService(
+            $this->comicSeriesRepository,
+            $this->comicSeriesService,
+            $this->entityManager,
+        );
+    }
+
+    public function testExecutePurgeCallsPermanentDeleteForEachId(): void
+    {
+        $series1 = $this->createComicSeriesMock(1, 'Naruto', new \DateTimeImmutable());
+        $series2 = $this->createComicSeriesMock(2, 'One Piece', new \DateTimeImmutable());
+
+        $this->comicSeriesRepository->method('find')->willReturnCallback(
+            static fn (int $id): ?ComicSeries => match ($id) {
+                1 => $series1,
+                2 => $series2,
+                default => null,
+            },
+        );
+
+        $this->comicSeriesService->expects(self::exactly(2))
+            ->method('permanentDelete')
+            ->willReturnCallback(function (int $id, ComicSeries $series) use ($series1, $series2): void {
+                match ($id) {
+                    1 => self::assertSame($series1, $series),
+                    2 => self::assertSame($series2, $series),
+                    default => self::fail('Unexpected series ID: '.$id),
+                };
+            });
+
+        $count = $this->purgeService->executePurge([1, 2]);
+
+        self::assertSame(2, $count);
+    }
+
+    public function testExecutePurgeDisablesAndReenablesSoftDeleteFilter(): void
+    {
+        $this->filterCollection->expects(self::once())->method('disable')->with('soft_delete');
+        $this->filterCollection->expects(self::once())->method('enable')->with('soft_delete');
+
+        $this->purgeService->executePurge([999]);
+    }
+
+    public function testExecutePurgeSkipsNonexistentIds(): void
+    {
+        $series1 = $this->createComicSeriesMock(1, 'Naruto', new \DateTimeImmutable());
+
+        $this->comicSeriesRepository->method('find')->willReturnCallback(
+            static fn (int $id): ?ComicSeries => 1 === $id ? $series1 : null,
+        );
+
+        $this->comicSeriesService->expects(self::once())
+            ->method('permanentDelete')
+            ->with(1, $series1);
+
+        $count = $this->purgeService->executePurge([1, 999]);
+
+        self::assertSame(1, $count);
+    }
+
+    public function testExecutePurgeReturnsZeroForEmptyArray(): void
+    {
+        $count = $this->purgeService->executePurge([]);
+
+        self::assertSame(0, $count);
+    }
+
+    public function testPurgeableSeriesIsJsonSerializable(): void
+    {
+        $dto = new PurgeableSeries(
+            deletedAt: new \DateTimeImmutable('2025-06-15T10:30:00+00:00'),
+            id: 42,
+            title: 'Test Series',
+        );
+
+        $json = \json_encode($dto);
+        self::assertNotFalse($json);
+
+        $data = \json_decode($json, true);
+        self::assertSame(42, $data['id']);
+        self::assertSame('Test Series', $data['title']);
+        self::assertSame('2025-06-15T10:30:00+00:00', $data['deletedAt']);
+    }
+
+    private function createComicSeriesMock(int $id, string $title, \DateTimeImmutable $deletedAt): ComicSeries&MockObject
+    {
+        $series = $this->createMock(ComicSeries::class);
+        $series->method('getDeletedAt')->willReturn($deletedAt);
+        $series->method('getId')->willReturn($id);
+        $series->method('getTitle')->willReturn($title);
+
+        return $series;
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,6 +56,7 @@ const ComicForm = lazyWithRetry(() => import("./pages/ComicForm"));
 const Login = lazyWithRetry(() => import("./pages/Login"));
 const MergeSeries = lazyWithRetry(() => import("./pages/MergeSeries"));
 const NotFound = lazyWithRetry(() => import("./pages/NotFound"));
+const PurgeTool = lazyWithRetry(() => import("./pages/PurgeTool"));
 const Tools = lazyWithRetry(() => import("./pages/Tools"));
 const Trash = lazyWithRetry(() => import("./pages/Trash"));
 
@@ -95,6 +96,7 @@ const router = createBrowserRouter(
         <Route element={<ComicForm />} path="comic/:id/edit" />
         <Route element={<Tools />} path="tools" />
         <Route element={<MergeSeries />} path="tools/merge-series" />
+        <Route element={<PurgeTool />} path="tools/purge" />
         <Route element={<Trash />} path="trash" />
         <Route element={<NotFound />} path="*" />
       </Route>

--- a/frontend/src/__tests__/integration/hooks/usePurge.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/usePurge.test.tsx
@@ -1,0 +1,72 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { usePurgePreview, useExecutePurge } from "../../../hooks/usePurge";
+import { server } from "../../helpers/server";
+import { createTestQueryClient } from "../../helpers/test-utils";
+import { QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+const API_BASE = "/api";
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("usePurgePreview", () => {
+  it("fetches purgeable series for given days", async () => {
+    server.use(
+      http.get(`${API_BASE}/tools/purge/preview`, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get("days")).toBe("30");
+        return HttpResponse.json([
+          { deletedAt: "2025-01-01T00:00:00+00:00", id: 1, title: "Naruto" },
+        ]);
+      }),
+    );
+
+    const { result } = renderHook(() => usePurgePreview(30), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data![0].title).toBe("Naruto");
+  });
+
+  it("does not fetch when days is 0", () => {
+    const { result } = renderHook(() => usePurgePreview(0), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isFetching).toBe(false);
+  });
+});
+
+describe("useExecutePurge", () => {
+  it("sends seriesIds and returns purge count", async () => {
+    server.use(
+      http.post(`${API_BASE}/tools/purge/execute`, async ({ request }) => {
+        const body = (await request.json()) as { seriesIds: number[] };
+        expect(body.seriesIds).toEqual([1, 2]);
+        return HttpResponse.json({ purged: 2 });
+      }),
+    );
+
+    const { result } = renderHook(() => useExecutePurge(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate([1, 2]);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual({ purged: 2 });
+  });
+});

--- a/frontend/src/__tests__/integration/pages/PurgeTool.test.tsx
+++ b/frontend/src/__tests__/integration/pages/PurgeTool.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import PurgeTool from "../../../pages/PurgeTool";
+import { server } from "../../helpers/server";
+import { renderWithProviders } from "../../helpers/test-utils";
+
+const API_BASE = "/api";
+
+describe("PurgeTool", () => {
+  it("renders the page title and days input", () => {
+    renderWithProviders(<PurgeTool />);
+
+    expect(screen.getByText("Purge de la corbeille")).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton")).toBeInTheDocument();
+  });
+
+  it("loads preview on mount with default days", async () => {
+    server.use(
+      http.get(`${API_BASE}/tools/purge/preview`, () =>
+        HttpResponse.json([
+          { deletedAt: "2025-01-01T00:00:00+00:00", id: 1, title: "Naruto" },
+          { deletedAt: "2025-01-15T00:00:00+00:00", id: 2, title: "One Piece" },
+        ]),
+      ),
+    );
+
+    renderWithProviders(<PurgeTool />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Naruto")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("One Piece")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no series to purge", async () => {
+    server.use(
+      http.get(`${API_BASE}/tools/purge/preview`, () =>
+        HttpResponse.json([]),
+      ),
+    );
+
+    renderWithProviders(<PurgeTool />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Aucune serie a purger")).toBeInTheDocument();
+    });
+  });
+
+  it("opens confirm modal when clicking purge button", async () => {
+    server.use(
+      http.get(`${API_BASE}/tools/purge/preview`, () =>
+        HttpResponse.json([
+          { deletedAt: "2025-01-01T00:00:00+00:00", id: 1, title: "Naruto" },
+        ]),
+      ),
+    );
+
+    renderWithProviders(<PurgeTool />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Naruto")).toBeInTheDocument();
+    });
+
+    const purgeButton = screen.getByRole("button", { name: /purger/i });
+    fireEvent.click(purgeButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+  });
+
+  it("allows changing the days parameter", async () => {
+    let requestedDays = "";
+    server.use(
+      http.get(`${API_BASE}/tools/purge/preview`, ({ request }) => {
+        const url = new URL(request.url);
+        requestedDays = url.searchParams.get("days") ?? "";
+        return HttpResponse.json([]);
+      }),
+    );
+
+    renderWithProviders(<PurgeTool />);
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(requestedDays).toBe("30");
+    });
+
+    // Change days
+    const input = screen.getByRole("spinbutton");
+    fireEvent.change(input, { target: { value: "60" } });
+
+    await waitFor(() => {
+      expect(requestedDays).toBe("60");
+    });
+  });
+});

--- a/frontend/src/hooks/usePurge.ts
+++ b/frontend/src/hooks/usePurge.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiFetch } from "../services/api";
+import type { PurgeableSeries } from "../types/api";
+
+export function usePurgePreview(days: number) {
+  return useQuery({
+    enabled: days > 0,
+    queryFn: () =>
+      apiFetch<PurgeableSeries[]>(`/tools/purge/preview?days=${days}`),
+    queryKey: ["purge-preview", days],
+  });
+}
+
+export function useExecutePurge() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (seriesIds: number[]) =>
+      apiFetch<{ purged: number }>("/tools/purge/execute", {
+        body: JSON.stringify({ seriesIds }),
+        method: "POST",
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["purge-preview"] });
+      queryClient.invalidateQueries({ queryKey: ["comics"] });
+    },
+  });
+}

--- a/frontend/src/pages/PurgeTool.tsx
+++ b/frontend/src/pages/PurgeTool.tsx
@@ -1,0 +1,121 @@
+import { Loader2, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import ConfirmModal from "../components/ConfirmModal";
+import EmptyState from "../components/EmptyState";
+import { useExecutePurge, usePurgePreview } from "../hooks/usePurge";
+
+export default function PurgeTool() {
+  const [days, setDays] = useState(30);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const { data: purgeable, isLoading } = usePurgePreview(days);
+  const executePurge = useExecutePurge();
+
+  const handlePurge = () => {
+    if (!purgeable || purgeable.length === 0) return;
+
+    const ids = purgeable.map((s) => s.id);
+    executePurge.mutate(ids, {
+      onSuccess: (data) => {
+        toast.success(`${data.purged} serie(s) purgee(s)`);
+      },
+    });
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-6">
+      <h1 className="text-xl font-bold text-text-primary">
+        Purge de la corbeille
+      </h1>
+
+      <div className="mt-4 flex items-center gap-3">
+        <label className="text-sm text-text-secondary" htmlFor="purge-days">
+          Series supprimees depuis plus de
+        </label>
+        <input
+          className="w-20 rounded-lg border border-surface-border bg-surface-primary px-3 py-1.5 text-sm text-text-primary focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+          id="purge-days"
+          min={1}
+          onChange={(e) => setDays(Number(e.target.value))}
+          type="number"
+          value={days}
+        />
+        <span className="text-sm text-text-secondary">jours</span>
+      </div>
+
+      {isLoading && (
+        <div className="mt-8 flex items-center justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-primary-600" />
+        </div>
+      )}
+
+      {!isLoading && purgeable && purgeable.length === 0 && (
+        <EmptyState
+          description={`Aucune serie dans la corbeille depuis plus de ${days} jours`}
+          icon={Trash2}
+          title="Aucune serie a purger"
+        />
+      )}
+
+      {!isLoading && purgeable && purgeable.length > 0 && (
+        <div className="mt-6">
+          <div className="overflow-hidden rounded-lg border border-surface-border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-surface-border bg-surface-secondary">
+                  <th className="px-4 py-2 text-left font-medium text-text-secondary">
+                    Titre
+                  </th>
+                  <th className="px-4 py-2 text-left font-medium text-text-secondary">
+                    Supprimee le
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {purgeable.map((series) => (
+                  <tr
+                    className="border-b border-surface-border last:border-0"
+                    key={series.id}
+                  >
+                    <td className="px-4 py-2 text-text-primary">
+                      {series.title}
+                    </td>
+                    <td className="px-4 py-2 text-text-secondary">
+                      {new Date(series.deletedAt).toLocaleDateString("fr-FR")}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="mt-4">
+            <button
+              className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              disabled={executePurge.isPending}
+              onClick={() => setConfirmOpen(true)}
+              type="button"
+            >
+              {executePurge.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Trash2 className="h-4 w-4" />
+              )}
+              Purger {purgeable.length} serie(s)
+            </button>
+          </div>
+        </div>
+      )}
+
+      <ConfirmModal
+        confirmLabel="Confirmer la purge"
+        description={`${purgeable?.length ?? 0} serie(s) seront definitivement supprimees. Cette action est irreversible.`}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={handlePurge}
+        open={confirmOpen}
+        title="Confirmer la purge"
+      />
+    </div>
+  );
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -59,6 +59,12 @@ export interface ComicSeries {
   updatedAt: string;
 }
 
+export interface PurgeableSeries {
+  deletedAt: string;
+  id: number;
+  title: string;
+}
+
 export interface MergeGroup {
   entries: MergeGroupEntry[];
   suggestedTitle: string;


### PR DESCRIPTION
## Summary
- **PurgeService** : extraction de la logique de `PurgeDeletedCommand` en service réutilisable (`findPurgeable` + `executePurge`)
- **PurgeController** : `GET /api/tools/purge/preview?days=30` + `POST /api/tools/purge/execute` avec authentification JWT
- **Page PurgeTool** : aperçu des séries éligibles, saisie du nombre de jours, confirmation modale, exécution
- **Refactoring** : `PurgeDeletedCommand` simplifié, délègue au `PurgeService`

Chunk 1/3 de #135

## Test plan
- [x] 5 tests unitaires `PurgeServiceTest`
- [x] 9 tests fonctionnels `PurgeControllerTest`
- [x] 7 tests d'intégration existants `PurgeDeletedCommandTest` toujours verts
- [x] 3 tests hooks `usePurge.test.tsx`
- [x] 5 tests page `PurgeTool.test.tsx`
- [x] PHPStan + CS Fixer + TypeScript clean
- [ ] Manuel : `/tools` → cliquer "Purge corbeille" → vérifier le flux

fixes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)