### PR TITLE
feat(merge): ajout de tomes dans la prévisualisation de fusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Added
+
+- **Ajout de tomes dans la prévisualisation de fusion** : Bouton "Ajouter un tome" dans la modale de fusion, avec numérotation automatique (#146)
+
 ### Fixed
 
 - **Tomes supprimés lors de l'édition d'une série** : Le PUT API Platform vidait silencieusement la collection de tomes. Migration vers PATCH (merge-patch+json) avec `@id` pour identifier les tomes existants. Les tomes sont maintenant correctement préservés, ajoutés et supprimés (#145)

--- a/frontend/src/__tests__/integration/components/MergePreviewModal.test.tsx
+++ b/frontend/src/__tests__/integration/components/MergePreviewModal.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import MergePreviewModal from "../../../components/MergePreviewModal";
+import type { MergePreview, MergePreviewTome } from "../../../types/api";
+
+function createMockTome(overrides: Partial<MergePreviewTome> = {}): MergePreviewTome {
+  return {
+    bought: false,
+    downloaded: false,
+    isbn: null,
+    number: 1,
+    onNas: false,
+    read: false,
+    title: null,
+    tomeEnd: null,
+    ...overrides,
+  };
+}
+
+function createMockPreview(overrides: Partial<MergePreview> = {}): MergePreview {
+  return {
+    authors: [],
+    coverUrl: null,
+    description: null,
+    isOneShot: false,
+    latestPublishedIssue: null,
+    latestPublishedIssueComplete: false,
+    publisher: null,
+    sourceSeriesIds: [1, 2],
+    title: "Test Series",
+    tomes: [createMockTome({ number: 1 }), createMockTome({ number: 2 })],
+    type: "manga",
+    ...overrides,
+  };
+}
+
+const defaultProps = {
+  isExecuting: false,
+  onClose: vi.fn(),
+  onConfirm: vi.fn(),
+  open: true,
+};
+
+describe("MergePreviewModal — add tome", () => {
+  it("renders an 'Ajouter un tome' button", () => {
+    render(
+      <MergePreviewModal {...defaultProps} preview={createMockPreview()} />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /ajouter un tome/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("adds a new tome row when clicking the add button", async () => {
+    const user = userEvent.setup();
+    render(
+      <MergePreviewModal
+        {...defaultProps}
+        preview={createMockPreview({ tomes: [createMockTome({ number: 1 })] })}
+      />,
+    );
+
+    const rows = () => within(screen.getByRole("table")).getAllByRole("row");
+    // Header + 1 tome = 2 rows
+    expect(rows()).toHaveLength(2);
+
+    await user.click(screen.getByRole("button", { name: /ajouter un tome/i }));
+
+    // Header + 2 tomes = 3 rows
+    expect(rows()).toHaveLength(3);
+  });
+
+  it("assigns next number to the new tome", async () => {
+    const user = userEvent.setup();
+    render(
+      <MergePreviewModal
+        {...defaultProps}
+        preview={createMockPreview({
+          tomes: [createMockTome({ number: 3 }), createMockTome({ number: 5 })],
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /ajouter un tome/i }));
+
+    // New tome should have number = max + 1 = 6
+    const numberInputs = screen.getAllByRole("spinbutton");
+    const lastNumberInput = numberInputs[numberInputs.length - 2]; // last # input (before tomeEnd inputs)
+    expect(lastNumberInput).toHaveValue(6);
+  });
+
+  it("includes added tome in confirm payload", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    render(
+      <MergePreviewModal
+        {...defaultProps}
+        onConfirm={onConfirm}
+        preview={createMockPreview({
+          tomes: [createMockTome({ number: 1 })],
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /ajouter un tome/i }));
+    await user.click(screen.getByRole("button", { name: /confirmer la fusion/i }));
+
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tomes: expect.arrayContaining([
+          expect.objectContaining({ number: 1 }),
+          expect.objectContaining({ number: 2 }),
+        ]),
+      }),
+    );
+    expect(onConfirm.mock.calls[0][0].tomes).toHaveLength(2);
+  });
+});

--- a/frontend/src/components/MergePreviewModal.tsx
+++ b/frontend/src/components/MergePreviewModal.tsx
@@ -4,7 +4,7 @@ import {
   DialogPanel,
   DialogTitle,
 } from "@headlessui/react";
-import { AlertTriangle, Loader2, X } from "lucide-react";
+import { AlertTriangle, Loader2, Plus, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import type { MergePreview, MergePreviewTome } from "../types/api";
 
@@ -60,6 +60,25 @@ export default function MergePreviewModal({
 
   const removeTome = (index: number) => {
     setEditedTomes((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const addTome = () => {
+    setEditedTomes((prev) => {
+      const maxNumber = prev.reduce((max, t) => Math.max(max, t.number, t.tomeEnd ?? 0), 0);
+      return [
+        ...prev,
+        {
+          bought: false,
+          downloaded: false,
+          isbn: null,
+          number: maxNumber + 1,
+          onNas: false,
+          read: false,
+          title: null,
+          tomeEnd: null,
+        },
+      ];
+    });
   };
 
   if (!preview) return null;
@@ -259,6 +278,14 @@ export default function MergePreviewModal({
                   })}
                 </tbody>
               </table>
+              <button
+                className="mt-2 flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium text-primary-600 hover:bg-primary-50 dark:text-primary-400 dark:hover:bg-primary-950/30"
+                onClick={addTome}
+                type="button"
+              >
+                <Plus className="h-4 w-4" />
+                Ajouter un tome
+              </button>
           </div>
 
           {/* Footer */}


### PR DESCRIPTION
## Summary

- Ajout d'un bouton "Ajouter un tome" dans la modale de prévisualisation de fusion (`MergePreviewModal`)
- Numérotation automatique du nouveau tome (max existant + 1, tenant compte des `tomeEnd`)
- Tests d'intégration couvrant le rendu du bouton, l'ajout de ligne, la numérotation et l'inclusion dans le payload de confirmation

## Test plan

- [x] 4 tests d'intégration ajoutés et passants
- [x] 537 tests frontend passants (60 fichiers)
- [x] TypeScript clean (`tsc --noEmit`)
- [ ] Test manuel : ouvrir la modale de fusion, cliquer "Ajouter un tome", vérifier la numérotation, confirmer la fusion

fixes #146