### PR TITLE
Ne plus déconnecter les autres appareils lors du login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Fixed
 
+- **Login multi-appareils** : Le login n'invalide plus les tokens JWT des autres appareils. Le mécanisme de token versioning reste disponible via `app:invalidate-tokens` (#142)
+
 - **UX recherche** : Debounce de la synchronisation URL (300ms) pour supprimer le lag de saisie, indicateur de chargement lors du refetch, transition CSS sur la grille de résultats (#147)
 
 - **Tomes supprimés lors de l'édition d'une série** : Le PUT API Platform vidait silencieusement la collection de tomes. Migration vers PATCH (merge-patch+json) avec `@id` pour identifier les tomes existants. Les tomes sont maintenant correctement préservés, ajoutés et supprimés (#145)

--- a/backend/src/EventListener/JwtTokenVersionListener.php
+++ b/backend/src/EventListener/JwtTokenVersionListener.php
@@ -6,7 +6,6 @@ namespace App\EventListener;
 
 use App\Entity\User;
 use App\Repository\UserRepository;
-use Doctrine\ORM\EntityManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTDecodedEvent;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
@@ -14,22 +13,21 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 /**
  * Ajoute et vérifie la version du token JWT pour permettre l'invalidation.
  *
- * À chaque création de token (login), la version est incrémentée,
- * ce qui invalide automatiquement tous les tokens précédents.
+ * La version est ajoutée au payload lors de la création du token,
+ * et vérifiée lors du décodage. L'incrémentation manuelle via
+ * la commande app:invalidate-tokens permet d'invalider les tokens existants.
  */
 #[AsEventListener(event: 'lexik_jwt_authentication.on_jwt_created', method: 'onJWTCreated')]
 #[AsEventListener(event: 'lexik_jwt_authentication.on_jwt_decoded', method: 'onJWTDecoded')]
 class JwtTokenVersionListener
 {
     public function __construct(
-        private readonly EntityManagerInterface $entityManager,
         private readonly UserRepository $userRepository,
     ) {
     }
 
     /**
-     * Incrémente la tokenVersion et l'ajoute au payload du JWT lors de la création.
-     * Chaque nouveau token invalide les précédents.
+     * Ajoute la tokenVersion actuelle au payload du JWT lors de la création.
      */
     public function onJWTCreated(JWTCreatedEvent $event): void
     {
@@ -38,9 +36,6 @@ class JwtTokenVersionListener
         if (!$user instanceof User) {
             return;
         }
-
-        $user->incrementTokenVersion();
-        $this->entityManager->flush();
 
         $data = $event->getData();
         $data['tokenVersion'] = $user->getTokenVersion();

--- a/backend/tests/Unit/EventListener/JwtTokenVersionListenerTest.php
+++ b/backend/tests/Unit/EventListener/JwtTokenVersionListenerTest.php
@@ -7,7 +7,6 @@ namespace App\Tests\Unit\EventListener;
 use App\Entity\User;
 use App\EventListener\JwtTokenVersionListener;
 use App\Repository\UserRepository;
-use Doctrine\ORM\EntityManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTDecodedEvent;
 use PHPUnit\Framework\TestCase;
@@ -18,46 +17,36 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 final class JwtTokenVersionListenerTest extends TestCase
 {
-    private EntityManagerInterface $entityManager;
     private JwtTokenVersionListener $listener;
     private UserRepository $userRepository;
 
     protected function setUp(): void
     {
-        $this->entityManager = $this->createStub(EntityManagerInterface::class);
         $this->userRepository = $this->createStub(UserRepository::class);
 
         $this->listener = new JwtTokenVersionListener(
-            $this->entityManager,
             $this->userRepository,
         );
     }
 
     /**
-     * Teste que onJWTCreated incr\u00e9mente la version, flush et ajoute tokenVersion au payload.
+     * Teste que onJWTCreated ajoute tokenVersion au payload sans incrémenter la version.
      */
-    public function testOnJwtCreatedWithUserIncrementsVersionAndAddsToPayload(): void
+    public function testOnJwtCreatedAddsCurrentVersionToPayloadWithoutIncrementing(): void
     {
         $user = new User();
         $user->setEmail('test@example.com');
         $initialVersion = $user->getTokenVersion();
 
-        $entityManager = $this->createMock(EntityManagerInterface::class);
-        $entityManager
-            ->expects(self::once())
-            ->method('flush');
-
-        $listener = new JwtTokenVersionListener($entityManager, $this->userRepository);
-
         $event = new JWTCreatedEvent(['username' => 'test@example.com'], $user);
 
-        $listener->onJWTCreated($event);
+        $this->listener->onJWTCreated($event);
 
-        self::assertSame($initialVersion + 1, $user->getTokenVersion());
+        self::assertSame($initialVersion, $user->getTokenVersion());
 
         $data = $event->getData();
         self::assertArrayHasKey('tokenVersion', $data);
-        self::assertSame($user->getTokenVersion(), $data['tokenVersion']);
+        self::assertSame($initialVersion, $data['tokenVersion']);
     }
 
     /**
@@ -92,16 +81,9 @@ final class JwtTokenVersionListenerTest extends TestCase
     {
         $user = $this->createStub(UserInterface::class);
 
-        $entityManager = $this->createMock(EntityManagerInterface::class);
-        $entityManager
-            ->expects(self::never())
-            ->method('flush');
-
-        $listener = new JwtTokenVersionListener($entityManager, $this->userRepository);
-
         $event = new JWTCreatedEvent(['username' => 'test@example.com'], $user);
 
-        $listener->onJWTCreated($event);
+        $this->listener->onJWTCreated($event);
 
         $data = $event->getData();
         self::assertArrayNotHasKey('tokenVersion', $data);
@@ -124,7 +106,7 @@ final class JwtTokenVersionListenerTest extends TestCase
             ->with(['email' => 'test@example.com'])
             ->willReturn($user);
 
-        $listener = new JwtTokenVersionListener($this->entityManager, $userRepository);
+        $listener = new JwtTokenVersionListener($userRepository);
 
         $event = new JWTDecodedEvent([
             'tokenVersion' => $tokenVersion,
@@ -146,7 +128,7 @@ final class JwtTokenVersionListenerTest extends TestCase
             ->expects(self::never())
             ->method('findOneBy');
 
-        $listener = new JwtTokenVersionListener($this->entityManager, $userRepository);
+        $listener = new JwtTokenVersionListener($userRepository);
 
         $event = new JWTDecodedEvent([
             'username' => 'test@example.com',
@@ -167,7 +149,7 @@ final class JwtTokenVersionListenerTest extends TestCase
             ->expects(self::never())
             ->method('findOneBy');
 
-        $listener = new JwtTokenVersionListener($this->entityManager, $userRepository);
+        $listener = new JwtTokenVersionListener($userRepository);
 
         $event = new JWTDecodedEvent([
             'tokenVersion' => 1,
@@ -190,7 +172,7 @@ final class JwtTokenVersionListenerTest extends TestCase
             ->with(['email' => 'unknown@example.com'])
             ->willReturn(null);
 
-        $listener = new JwtTokenVersionListener($this->entityManager, $userRepository);
+        $listener = new JwtTokenVersionListener($userRepository);
 
         $event = new JWTDecodedEvent([
             'tokenVersion' => 1,
@@ -217,7 +199,7 @@ final class JwtTokenVersionListenerTest extends TestCase
             ->with(['email' => 'test@example.com'])
             ->willReturn($user);
 
-        $listener = new JwtTokenVersionListener($this->entityManager, $userRepository);
+        $listener = new JwtTokenVersionListener($userRepository);
 
         // Version de l'utilisateur = 1, version dans le token = 99
         $event = new JWTDecodedEvent([


### PR DESCRIPTION
## Summary

- Supprime l'incrémentation automatique de `tokenVersion` dans `JwtTokenVersionListener::onJWTCreated` — le login ne déconnecte plus les autres appareils
- Supprime la dépendance `EntityManagerInterface` devenue inutile dans le listener
- Le mécanisme d'invalidation manuelle via `app:invalidate-tokens` reste fonctionnel

## Test plan

- [x] Tests unitaires `JwtTokenVersionListenerTest` mis à jour et passants (8 tests, 20 assertions)
- [x] Suite complète backend passante (720 tests)
- [x] PHPStan et PHP-CS-Fixer propres

fixes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)