### PR TITLE
Sélecteur de couverture série via recherche d'images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Sélecteur de couverture série** : Bouton de recherche d'images à côté du champ URL de couverture, modale avec grille d'images Google Custom Search, sélection visuelle (#137)
 - **Ajout de tomes dans la prévisualisation de fusion** : Bouton "Ajouter un tome" dans la modale de fusion, avec numérotation automatique (#146)
 
 ### Fixed

--- a/backend/.env
+++ b/backend/.env
@@ -51,6 +51,10 @@ GEMINI_MODELS=gemini-2.5-flash,gemini-3-flash,gemini-2.5-flash-lite,gemini-3.1-f
 GOOGLE_BOOKS_API_KEY=
 ###< google-books ###
 
+###> serper ###
+SERPER_API_KEY=
+###< serper ###
+
 ###> lexik/jwt-authentication-bundle ###
 JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem

--- a/backend/config/packages/rate_limiter.yaml
+++ b/backend/config/packages/rate_limiter.yaml
@@ -4,6 +4,10 @@ framework:
             interval: '1 minute'
             limit: 30
             policy: sliding_window
+        cover_search:
+            interval: '1 minute'
+            limit: 20
+            policy: sliding_window
         gemini_api:
             interval: '1 minute'
             limit: 20

--- a/backend/src/Controller/ApiController.php
+++ b/backend/src/Controller/ApiController.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Enum\ComicType;
+use App\Service\CoverSearchService;
 use App\Service\Lookup\LookupOrchestrator;
 use App\Service\Lookup\LookupResult;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,6 +22,8 @@ class ApiController
 {
     public function __construct(
         private readonly RateLimiterFactory $apiLookupLimiter,
+        #[Autowire(service: 'limiter.cover_search')]
+        private readonly RateLimiterFactory $coverSearchLimiter,
     ) {
     }
 
@@ -70,11 +74,35 @@ class ApiController
     }
 
     /**
+     * Recherche des images de couverture.
+     */
+    #[Route('/covers', name: 'api_lookup_covers', methods: ['GET'])]
+    public function coverSearch(Request $request, CoverSearchService $coverSearchService): JsonResponse
+    {
+        $rateLimitResponse = $this->checkRateLimit($request, $this->coverSearchLimiter);
+        if ($rateLimitResponse instanceof JsonResponse) {
+            return $rateLimitResponse;
+        }
+
+        $query = $request->query->get('query', '');
+        $type = $this->resolveComicType($request);
+
+        if (empty($query)) {
+            return new JsonResponse(['error' => 'Requête requise'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $results = $coverSearchService->search($query, $type);
+
+        return new JsonResponse($results);
+    }
+
+    /**
      * Vérifie le rate limit pour la requête courante.
      */
-    private function checkRateLimit(Request $request): ?JsonResponse
+    private function checkRateLimit(Request $request, ?RateLimiterFactory $limiterFactory = null): ?JsonResponse
     {
-        $limiter = $this->apiLookupLimiter->create($request->getClientIp() ?? 'unknown');
+        $factory = $limiterFactory ?? $this->apiLookupLimiter;
+        $limiter = $factory->create($request->getClientIp() ?? 'unknown');
         $limit = $limiter->consume();
 
         if (false === $limit->isAccepted()) {

--- a/backend/src/DTO/CoverSearchResult.php
+++ b/backend/src/DTO/CoverSearchResult.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+/**
+ * Résultat d'une recherche de couverture via Google Custom Search.
+ */
+readonly class CoverSearchResult implements \JsonSerializable
+{
+    public function __construct(
+        public int $height,
+        public string $thumbnail,
+        public string $title,
+        public string $url,
+        public int $width,
+    ) {
+    }
+
+    /**
+     * @return array{height: int, thumbnail: string, title: string, url: string, width: int}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'height' => $this->height,
+            'thumbnail' => $this->thumbnail,
+            'title' => $this->title,
+            'url' => $this->url,
+            'width' => $this->width,
+        ];
+    }
+}

--- a/backend/src/Service/CoverSearchService.php
+++ b/backend/src/Service/CoverSearchService.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\DTO\CoverSearchResult;
+use App\Enum\ComicType;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Recherche de couvertures via Google Books + Serper Images.
+ */
+class CoverSearchService
+{
+    private const string GOOGLE_BOOKS_URL = 'https://www.googleapis.com/books/v1/volumes';
+    private const string SERPER_URL = 'https://google.serper.dev/images';
+
+    public function __construct(
+        #[Autowire('%env(GOOGLE_BOOKS_API_KEY)%')]
+        private readonly string $googleBooksApiKey,
+        private readonly HttpClientInterface $httpClient,
+        private readonly LoggerInterface $logger,
+        #[Autowire('%env(SERPER_API_KEY)%')]
+        private readonly string $serperApiKey,
+    ) {
+    }
+
+    /**
+     * Recherche des images de couverture pour une série.
+     * Combine Google Books (couvertures de livres) et Serper (images web).
+     *
+     * @return CoverSearchResult[]
+     */
+    public function search(string $query, ?ComicType $type = null): array
+    {
+        $serperQuery = $query.' '.$this->getQuerySuffix($type);
+
+        // Lancer les deux requêtes en parallèle
+        $googleBooksResponse = $this->requestGoogleBooks($query);
+        $serperResponse = $this->requestSerper($serperQuery);
+
+        $googleBooksResults = $this->parseGoogleBooksResponse($googleBooksResponse);
+        $serperResults = $this->parseSerperResponse($serperResponse);
+
+        // Google Books en premier (plus pertinents pour les couvertures), puis Serper
+        return \array_values(\array_merge($googleBooksResults, $serperResults));
+    }
+
+    /**
+     * Retourne le suffixe de recherche selon le type.
+     */
+    private function getQuerySuffix(?ComicType $type): string
+    {
+        return match ($type) {
+            ComicType::MANGA => 'cover',
+            default => 'couverture',
+        };
+    }
+
+    /**
+     * Optimise l'URL d'une couverture Google Books.
+     */
+    private function optimizeThumbnailUrl(string $url): string
+    {
+        if (!\str_contains($url, 'books.google.com/')) {
+            return $url;
+        }
+
+        $url = (string) \preg_replace('#^http://#', 'https://', $url);
+        $url = \str_replace('zoom=1', 'zoom=0', $url);
+        $url = (string) \preg_replace('/&?edge=curl&?/', '&', $url);
+
+        return \rtrim($url, '&');
+    }
+
+    /**
+     * @return CoverSearchResult[]
+     */
+    private function parseGoogleBooksResponse(?ResponseInterface $response): array
+    {
+        if (!$response instanceof ResponseInterface) {
+            return [];
+        }
+
+        try {
+            $data = $response->toArray();
+        } catch (\Throwable $e) {
+            $this->logger->error('Erreur Google Books cover search : {message}', [
+                'message' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+
+        $items = $data['items'] ?? [];
+        $results = [];
+
+        foreach ($items as $item) {
+            $volumeInfo = $item['volumeInfo'] ?? [];
+            if (!\is_array($volumeInfo)) {
+                continue;
+            }
+
+            $imageLinks = $volumeInfo['imageLinks'] ?? null;
+            $rawThumbnail = \is_array($imageLinks)
+                ? ($imageLinks['thumbnail'] ?? $imageLinks['smallThumbnail'] ?? null)
+                : null;
+
+            if (!\is_string($rawThumbnail)) {
+                continue;
+            }
+
+            $url = $this->optimizeThumbnailUrl($rawThumbnail);
+            $title = \is_string($volumeInfo['title'] ?? null) ? $volumeInfo['title'] : '';
+
+            $results[] = new CoverSearchResult(
+                height: 0,
+                thumbnail: $url,
+                title: $title,
+                url: $url,
+                width: 0,
+            );
+        }
+
+        return $results;
+    }
+
+    /**
+     * @return CoverSearchResult[]
+     */
+    private function parseSerperResponse(?ResponseInterface $response): array
+    {
+        if (!$response instanceof ResponseInterface) {
+            return [];
+        }
+
+        try {
+            $data = $response->toArray();
+        } catch (\Throwable $e) {
+            $this->logger->error('Erreur Serper cover search : {message}', [
+                'message' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+
+        $images = $data['images'] ?? [];
+
+        return \array_map(
+            static fn (array $image): CoverSearchResult => new CoverSearchResult(
+                height: (int) ($image['imageHeight'] ?? 0),
+                thumbnail: $image['thumbnailUrl'] ?? $image['imageUrl'] ?? '',
+                title: $image['title'] ?? '',
+                url: $image['imageUrl'] ?? '',
+                width: (int) ($image['imageWidth'] ?? 0),
+            ),
+            $images,
+        );
+    }
+
+    private function requestGoogleBooks(string $query): ?ResponseInterface
+    {
+        if ('' === $this->googleBooksApiKey) {
+            return null;
+        }
+
+        try {
+            return $this->httpClient->request('GET', self::GOOGLE_BOOKS_URL, [
+                'query' => [
+                    'key' => $this->googleBooksApiKey,
+                    'maxResults' => 5,
+                    'q' => $query,
+                ],
+                'timeout' => 10,
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('Erreur requête Google Books : {message}', [
+                'message' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    private function requestSerper(string $query): ?ResponseInterface
+    {
+        if ('' === $this->serperApiKey) {
+            return null;
+        }
+
+        try {
+            return $this->httpClient->request('POST', self::SERPER_URL, [
+                'headers' => [
+                    'Content-Type' => 'application/json',
+                    'X-API-KEY' => $this->serperApiKey,
+                ],
+                'json' => [
+                    'num' => 10,
+                    'q' => $query,
+                ],
+                'timeout' => 10,
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('Erreur requête Serper : {message}', [
+                'message' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+}

--- a/backend/tests/Functional/Api/LookupApiTest.php
+++ b/backend/tests/Functional/Api/LookupApiTest.php
@@ -188,4 +188,43 @@ final class LookupApiTest extends ApiTestCase
         $statusCode = $client->getResponse()->getStatusCode();
         self::assertContains($statusCode, [200, 404], 'Doit être 200 ou 404, pas une erreur serveur');
     }
+
+    // ---------------------------------------------------------------
+    // GET /api/lookup/covers
+    // ---------------------------------------------------------------
+
+    public function testCoverSearchUnauthenticatedReturns401(): void
+    {
+        $client = $this->createUnauthenticatedClient();
+
+        $client->request('GET', '/api/lookup/covers', [
+            'query' => ['query' => 'Naruto'],
+        ]);
+
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testCoverSearchMissingQueryReturns400(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/lookup/covers');
+
+        self::assertResponseStatusCodeSame(400);
+
+        $data = $client->getResponse()->toArray(false);
+
+        self::assertSame('Requête requise', $data['error']);
+    }
+
+    public function testCoverSearchEmptyQueryReturns400(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/lookup/covers', [
+            'query' => ['query' => ''],
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
 }

--- a/backend/tests/Unit/DTO/CoverSearchResultTest.php
+++ b/backend/tests/Unit/DTO/CoverSearchResultTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\DTO;
+
+use App\DTO\CoverSearchResult;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires pour CoverSearchResult.
+ */
+final class CoverSearchResultTest extends TestCase
+{
+    public function testConstructorAndProperties(): void
+    {
+        $result = new CoverSearchResult(
+            height: 600,
+            thumbnail: 'https://example.com/thumb.jpg',
+            title: 'Naruto Vol. 1',
+            url: 'https://example.com/cover.jpg',
+            width: 400,
+        );
+
+        self::assertSame(600, $result->height);
+        self::assertSame('https://example.com/thumb.jpg', $result->thumbnail);
+        self::assertSame('Naruto Vol. 1', $result->title);
+        self::assertSame('https://example.com/cover.jpg', $result->url);
+        self::assertSame(400, $result->width);
+    }
+
+    public function testJsonSerialize(): void
+    {
+        $result = new CoverSearchResult(
+            height: 800,
+            thumbnail: 'https://example.com/thumb.jpg',
+            title: 'One Piece',
+            url: 'https://example.com/cover.jpg',
+            width: 500,
+        );
+
+        $json = $result->jsonSerialize();
+
+        self::assertSame([
+            'height' => 800,
+            'thumbnail' => 'https://example.com/thumb.jpg',
+            'title' => 'One Piece',
+            'url' => 'https://example.com/cover.jpg',
+            'width' => 500,
+        ], $json);
+    }
+}

--- a/backend/tests/Unit/Service/CoverSearchServiceTest.php
+++ b/backend/tests/Unit/Service/CoverSearchServiceTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\DTO\CoverSearchResult;
+use App\Enum\ComicType;
+use App\Service\CoverSearchService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Tests unitaires pour CoverSearchService.
+ */
+final class CoverSearchServiceTest extends TestCase
+{
+    private HttpClientInterface $httpClient;
+    private LoggerInterface $logger;
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createStub(HttpClientInterface::class);
+        $this->logger = $this->createStub(LoggerInterface::class);
+    }
+
+    private function createService(string $googleBooksApiKey = 'test-books-key', string $serperApiKey = 'test-serper-key'): CoverSearchService
+    {
+        return new CoverSearchService(
+            $googleBooksApiKey,
+            $this->httpClient,
+            $this->logger,
+            $serperApiKey,
+        );
+    }
+
+    public function testSearchCombinesGoogleBooksAndSerperResults(): void
+    {
+        $googleBooksResponse = $this->createStub(ResponseInterface::class);
+        $googleBooksResponse->method('toArray')->willReturn([
+            'items' => [
+                [
+                    'volumeInfo' => [
+                        'imageLinks' => ['thumbnail' => 'https://books.google.com/thumb1?zoom=1'],
+                        'title' => 'Naruto Vol. 1',
+                    ],
+                ],
+            ],
+        ]);
+
+        $serperResponse = $this->createStub(ResponseInterface::class);
+        $serperResponse->method('toArray')->willReturn([
+            'images' => [
+                [
+                    'imageHeight' => 800,
+                    'imageUrl' => 'https://example.com/naruto.jpg',
+                    'imageWidth' => 600,
+                    'thumbnailUrl' => 'https://example.com/naruto_thumb.jpg',
+                    'title' => 'Naruto Cover',
+                ],
+            ],
+        ]);
+
+        $this->httpClient->method('request')
+            ->willReturnCallback(static function (string $method) use ($googleBooksResponse, $serperResponse): ResponseInterface {
+                return 'GET' === $method ? $googleBooksResponse : $serperResponse;
+            });
+
+        $results = $this->createService()->search('Naruto', ComicType::MANGA);
+
+        self::assertCount(2, $results);
+
+        // Google Books en premier
+        self::assertSame('Naruto Vol. 1', $results[0]->title);
+        self::assertStringContainsString('zoom=0', $results[0]->url);
+
+        // Serper ensuite
+        self::assertSame('https://example.com/naruto.jpg', $results[1]->url);
+        self::assertSame('https://example.com/naruto_thumb.jpg', $results[1]->thumbnail);
+        self::assertSame(800, $results[1]->height);
+        self::assertSame(600, $results[1]->width);
+    }
+
+    public function testSearchSerperCallsWithCorrectQueryForManga(): void
+    {
+        $emptyResponse = $this->createStub(ResponseInterface::class);
+        $emptyResponse->method('toArray')->willReturn([]);
+
+        $this->httpClient = $this->createMock(HttpClientInterface::class);
+        $this->httpClient
+            ->expects(self::exactly(2))
+            ->method('request')
+            ->willReturnCallback(static function (string $method, string $url, array $options) use ($emptyResponse): ResponseInterface {
+                if ('POST' === $method) {
+                    self::assertSame('https://google.serper.dev/images', $url);
+                    self::assertSame('Naruto cover', $options['json']['q']);
+                    self::assertSame('test-serper-key', $options['headers']['X-API-KEY']);
+                }
+
+                return $emptyResponse;
+            });
+
+        $this->createService()->search('Naruto', ComicType::MANGA);
+    }
+
+    public function testSearchSerperCallsWithCouvertureForBd(): void
+    {
+        $emptyResponse = $this->createStub(ResponseInterface::class);
+        $emptyResponse->method('toArray')->willReturn([]);
+
+        $this->httpClient = $this->createMock(HttpClientInterface::class);
+        $this->httpClient
+            ->expects(self::exactly(2))
+            ->method('request')
+            ->willReturnCallback(static function (string $method, string $url, array $options) use ($emptyResponse): ResponseInterface {
+                if ('POST' === $method) {
+                    self::assertSame('Astérix couverture', $options['json']['q']);
+                }
+
+                return $emptyResponse;
+            });
+
+        $this->createService()->search('Astérix', ComicType::BD);
+    }
+
+    public function testSearchReturnsEmptyArrayWhenBothSourcesFail(): void
+    {
+        $this->httpClient->method('request')->willThrowException(
+            new \RuntimeException('API error'),
+        );
+
+        $results = $this->createService()->search('Test');
+
+        self::assertSame([], $results);
+    }
+
+    public function testSearchSkipsGoogleBooksWithoutThumbnail(): void
+    {
+        $googleBooksResponse = $this->createStub(ResponseInterface::class);
+        $googleBooksResponse->method('toArray')->willReturn([
+            'items' => [
+                ['volumeInfo' => ['title' => 'No Cover Book']],
+            ],
+        ]);
+
+        $serperResponse = $this->createStub(ResponseInterface::class);
+        $serperResponse->method('toArray')->willReturn(['images' => []]);
+
+        $this->httpClient->method('request')
+            ->willReturnCallback(static function (string $method) use ($googleBooksResponse, $serperResponse): ResponseInterface {
+                return 'GET' === $method ? $googleBooksResponse : $serperResponse;
+            });
+
+        $results = $this->createService()->search('Test');
+
+        self::assertSame([], $results);
+    }
+
+    public function testSearchSkipsSourcesWithEmptyApiKey(): void
+    {
+        $results = $this->createService('', '')->search('Test');
+
+        self::assertSame([], $results);
+    }
+
+    public function testSearchGoogleBooksOptimizesThumbnailUrl(): void
+    {
+        $googleBooksResponse = $this->createStub(ResponseInterface::class);
+        $googleBooksResponse->method('toArray')->willReturn([
+            'items' => [
+                [
+                    'volumeInfo' => [
+                        'imageLinks' => ['thumbnail' => 'http://books.google.com/thumb?zoom=1&edge=curl'],
+                        'title' => 'Test',
+                    ],
+                ],
+            ],
+        ]);
+
+        $serperResponse = $this->createStub(ResponseInterface::class);
+        $serperResponse->method('toArray')->willReturn(['images' => []]);
+
+        $this->httpClient->method('request')
+            ->willReturnCallback(static function (string $method) use ($googleBooksResponse, $serperResponse): ResponseInterface {
+                return 'GET' === $method ? $googleBooksResponse : $serperResponse;
+            });
+
+        $results = $this->createService()->search('Test');
+
+        self::assertCount(1, $results);
+        self::assertStringStartsWith('https://', $results[0]->url);
+        self::assertStringContainsString('zoom=0', $results[0]->url);
+        self::assertStringNotContainsString('edge=curl', $results[0]->url);
+    }
+}

--- a/frontend/src/__tests__/helpers/handlers.ts
+++ b/frontend/src/__tests__/helpers/handlers.ts
@@ -111,6 +111,9 @@ export const handlers = [
     }),
   ),
 
+  // Lookup covers
+  http.get(`${API_BASE}/lookup/covers`, () => HttpResponse.json([])),
+
   // Google login
   http.post(`${API_BASE}/login/google`, () =>
     HttpResponse.json({ token: "fake-jwt-token" }),

--- a/frontend/src/__tests__/integration/components/CoverSearchModal.test.tsx
+++ b/frontend/src/__tests__/integration/components/CoverSearchModal.test.tsx
@@ -1,0 +1,123 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import CoverSearchModal from "../../../components/CoverSearchModal";
+import type { CoverSearchResult } from "../../../types/api";
+import { server } from "../../helpers/server";
+import { renderWithProviders } from "../../helpers/test-utils";
+
+const mockResults: CoverSearchResult[] = [
+  {
+    height: 800,
+    thumbnail: "https://example.com/thumb1.jpg",
+    title: "Naruto Vol. 1",
+    url: "https://example.com/cover1.jpg",
+    width: 600,
+  },
+  {
+    height: 900,
+    thumbnail: "https://example.com/thumb2.jpg",
+    title: "Naruto Vol. 2",
+    url: "https://example.com/cover2.jpg",
+    width: 650,
+  },
+];
+
+describe("CoverSearchModal", () => {
+  const defaultProps = {
+    defaultQuery: "Naruto",
+    onClose: vi.fn(),
+    onSelect: vi.fn(),
+    open: true,
+    type: "manga",
+  };
+
+  beforeEach(() => {
+    defaultProps.onClose = vi.fn();
+    defaultProps.onSelect = vi.fn();
+  });
+
+  it("renders with title and search input when open", () => {
+    renderWithProviders(<CoverSearchModal {...defaultProps} />);
+
+    expect(screen.getByText("Rechercher une couverture")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Rechercher...")).toHaveValue("Naruto");
+  });
+
+  it("is not visible when open is false", () => {
+    renderWithProviders(<CoverSearchModal {...defaultProps} open={false} />);
+
+    expect(screen.queryByText("Rechercher une couverture")).not.toBeInTheDocument();
+  });
+
+  it("displays results as images", async () => {
+    server.use(
+      http.get("/api/lookup/covers", () => HttpResponse.json(mockResults)),
+    );
+
+    renderWithProviders(<CoverSearchModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByAltText("Naruto Vol. 1")).toBeInTheDocument();
+      expect(screen.getByAltText("Naruto Vol. 2")).toBeInTheDocument();
+    });
+  });
+
+  it("calls onSelect with url when an image is clicked", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get("/api/lookup/covers", () => HttpResponse.json(mockResults)),
+    );
+
+    renderWithProviders(<CoverSearchModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByAltText("Naruto Vol. 1")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByAltText("Naruto Vol. 1"));
+
+    expect(defaultProps.onSelect).toHaveBeenCalledWith("https://example.com/cover1.jpg");
+  });
+
+  it("displays empty state when no results", async () => {
+    server.use(
+      http.get("/api/lookup/covers", () => HttpResponse.json([])),
+    );
+
+    renderWithProviders(<CoverSearchModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Aucune image trouvée")).toBeInTheDocument();
+    });
+  });
+
+  it("shows skeleton loading state", () => {
+    server.use(
+      http.get("/api/lookup/covers", () =>
+        new Promise(() => {}),
+      ),
+    );
+
+    renderWithProviders(<CoverSearchModal {...defaultProps} />);
+
+    expect(screen.getAllByTestId("skeleton-box")).toHaveLength(8);
+  });
+
+  it("shows minimum characters message when query is too short", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CoverSearchModal {...defaultProps} defaultQuery="" />);
+
+    expect(screen.getByText("Saisissez au moins 2 caractères")).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CoverSearchModal {...defaultProps} />);
+
+    const closeButton = screen.getByRole("button", { name: "" });
+    await user.click(closeButton);
+
+    expect(defaultProps.onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/__tests__/integration/hooks/useCoverSearch.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useCoverSearch.test.tsx
@@ -1,0 +1,100 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { useCoverSearch } from "../../../hooks/useCoverSearch";
+import type { CoverSearchResult } from "../../../types/api";
+import { createTestQueryClient } from "../../helpers/test-utils";
+import { server } from "../../helpers/server";
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+const mockResults: CoverSearchResult[] = [
+  {
+    height: 800,
+    thumbnail: "https://example.com/thumb1.jpg",
+    title: "Naruto Vol. 1",
+    url: "https://example.com/cover1.jpg",
+    width: 600,
+  },
+  {
+    height: 900,
+    thumbnail: "https://example.com/thumb2.jpg",
+    title: "Naruto Vol. 2",
+    url: "https://example.com/cover2.jpg",
+    width: 650,
+  },
+];
+
+describe("useCoverSearch", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("is disabled when query is shorter than 2 characters", () => {
+    const { result } = renderHook(() => useCoverSearch("A"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("returns cover search results", async () => {
+    server.use(
+      http.get("/api/lookup/covers", () => HttpResponse.json(mockResults)),
+    );
+
+    const { result } = renderHook(() => useCoverSearch("Naruto"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.data?.[0].url).toBe("https://example.com/cover1.jpg");
+    expect(result.current.data?.[0].title).toBe("Naruto Vol. 1");
+  });
+
+  it("includes type parameter in request URL", async () => {
+    let capturedUrl = "";
+
+    server.use(
+      http.get("/api/lookup/covers", ({ request }) => {
+        capturedUrl = new URL(request.url).search;
+        return HttpResponse.json(mockResults);
+      }),
+    );
+
+    const { result } = renderHook(() => useCoverSearch("Naruto", "manga"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(capturedUrl).toContain("type=manga");
+  });
+
+  it("handles error state", async () => {
+    server.use(
+      http.get("/api/lookup/covers", () =>
+        HttpResponse.json({ detail: "Server error" }, { status: 500 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useCoverSearch("Test"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/frontend/src/components/CoverSearchModal.tsx
+++ b/frontend/src/components/CoverSearchModal.tsx
@@ -1,0 +1,129 @@
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+} from "@headlessui/react";
+import { Search, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useCoverSearch } from "../hooks/useCoverSearch";
+import SkeletonBox from "./SkeletonBox";
+
+interface CoverSearchModalProps {
+  defaultQuery: string;
+  onClose: () => void;
+  onSelect: (url: string) => void;
+  open: boolean;
+  type?: string;
+}
+
+export default function CoverSearchModal({
+  defaultQuery,
+  onClose,
+  onSelect,
+  open,
+  type,
+}: CoverSearchModalProps) {
+  const [searchQuery, setSearchQuery] = useState(defaultQuery);
+  const [debouncedQuery, setDebouncedQuery] = useState(defaultQuery);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const { data: results, isLoading } = useCoverSearch(debouncedQuery, type);
+
+  useEffect(() => {
+    setSearchQuery(defaultQuery);
+    setDebouncedQuery(defaultQuery);
+  }, [defaultQuery]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(searchQuery), 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    if (open) {
+      setTimeout(() => inputRef.current?.select(), 50);
+    }
+  }, [open]);
+
+  return (
+    <Dialog className="relative z-50" onClose={onClose} open={open}>
+      <DialogBackdrop className="fixed inset-0 bg-black/30" />
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        <DialogPanel className="flex max-h-[80vh] w-full max-w-2xl flex-col rounded-xl bg-surface-primary shadow-lg">
+          <div className="flex items-center justify-between border-b border-surface-border px-4 py-3">
+            <DialogTitle className="text-lg font-semibold text-text-primary">
+              Rechercher une couverture
+            </DialogTitle>
+            <button
+              className="rounded-lg p-1 text-text-secondary hover:bg-surface-tertiary"
+              onClick={onClose}
+              type="button"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="border-b border-surface-border px-4 py-3">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-secondary" />
+              <input
+                className="w-full rounded-lg border border-surface-border bg-surface-primary py-2 pl-9 pr-3 text-sm text-text-primary placeholder:text-text-secondary"
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Rechercher..."
+                ref={inputRef}
+                type="text"
+                value={searchQuery}
+              />
+            </div>
+          </div>
+
+          <div className="overflow-y-auto p-4">
+            {isLoading && debouncedQuery.length >= 2 && (
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+                {Array.from({ length: 8 }).map((_, i) => (
+                  <SkeletonBox className="aspect-[2/3]" key={i} />
+                ))}
+              </div>
+            )}
+
+            {!isLoading && results && results.length === 0 && debouncedQuery.length >= 2 && (
+              <p className="py-8 text-center text-sm text-text-secondary">
+                Aucune image trouvée
+              </p>
+            )}
+
+            {!isLoading && results && results.length > 0 && (
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+                {results.map((result) => (
+                  <button
+                    className="group relative overflow-hidden rounded-lg border border-surface-border transition hover:ring-2 hover:ring-accent-primary"
+                    key={result.url}
+                    onClick={() => onSelect(result.url)}
+                    type="button"
+                  >
+                    <img
+                      alt={result.title}
+                      className="aspect-[2/3] w-full object-cover"
+                      loading="lazy"
+                      src={result.thumbnail}
+                    />
+                    <span className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent px-2 py-1 text-xs text-white opacity-0 transition group-hover:opacity-100">
+                      {result.width}×{result.height}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {debouncedQuery.length < 2 && (
+              <p className="py-8 text-center text-sm text-text-secondary">
+                Saisissez au moins 2 caractères
+              </p>
+            )}
+          </div>
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+}

--- a/frontend/src/hooks/useCoverSearch.ts
+++ b/frontend/src/hooks/useCoverSearch.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiFetch } from "../services/api";
+import type { CoverSearchResult } from "../types/api";
+
+export function useCoverSearch(query: string, type?: string) {
+  const params = new URLSearchParams({ query });
+  if (type) params.set("type", type);
+
+  return useQuery({
+    enabled: query.length >= 2,
+    queryFn: () => apiFetch<CoverSearchResult[]>(`/lookup/covers?${params}`),
+    queryKey: ["lookup", "covers", query, type],
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/frontend/src/pages/ComicForm.tsx
+++ b/frontend/src/pages/ComicForm.tsx
@@ -8,11 +8,12 @@ import {
   ListboxOption,
   ListboxOptions,
 } from "@headlessui/react";
-import { AlertTriangle, ArrowLeft, Check, ChevronDown, Layers, Loader2, Plus, Search, Trash2, X } from "lucide-react";
+import { AlertTriangle, ArrowLeft, Check, ChevronDown, Image, Layers, Loader2, Plus, Search, Trash2, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import BarcodeScanner from "../components/BarcodeScanner";
+import CoverSearchModal from "../components/CoverSearchModal";
 import SkeletonBox from "../components/SkeletonBox";
 import { useAuthors } from "../hooks/useAuthors";
 import { useOnlineStatus } from "../hooks/useOnlineStatus";
@@ -244,6 +245,9 @@ export default function ComicForm() {
   const [lookupTitle, setLookupTitle] = useState("");
   const [lookupMode, setLookupMode] = useState<"isbn" | "title">("title");
   const [tomeLookupLoading, setTomeLookupLoading] = useState<number | null>(null);
+
+  // Cover search state
+  const [coverSearchOpen, setCoverSearchOpen] = useState(false);
 
   // Batch add state
   const [batchFrom, setBatchFrom] = useState(1);
@@ -700,18 +704,39 @@ export default function ComicForm() {
           <label className="mb-1 block text-sm font-medium text-text-secondary" htmlFor="coverUrl">
             URL de couverture
           </label>
-          <input
-            className="w-full rounded-lg border border-surface-border bg-surface-primary px-3 py-2 text-sm text-text-primary"
-            id="coverUrl"
-            onChange={(e) => update("coverUrl", e.target.value)}
-            placeholder="https://..."
-            type="url"
-            value={form.coverUrl}
-          />
+          <div className="flex gap-2">
+            <input
+              className="min-w-0 flex-1 rounded-lg border border-surface-border bg-surface-primary px-3 py-2 text-sm text-text-primary"
+              id="coverUrl"
+              onChange={(e) => update("coverUrl", e.target.value)}
+              placeholder="https://..."
+              type="url"
+              value={form.coverUrl}
+            />
+            <button
+              className="shrink-0 rounded-lg border border-surface-border px-3 py-2 text-sm text-text-secondary hover:bg-surface-tertiary disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={!isOnline}
+              onClick={() => setCoverSearchOpen(true)}
+              title="Rechercher une couverture"
+              type="button"
+            >
+              <Image className="h-4 w-4" />
+            </button>
+          </div>
           {form.coverUrl && (
             <img alt="Aperçu" className="mt-2 h-32 rounded-lg shadow" src={form.coverUrl} />
           )}
         </div>
+        <CoverSearchModal
+          defaultQuery={form.title}
+          onClose={() => setCoverSearchOpen(false)}
+          onSelect={(url) => {
+            update("coverUrl", url);
+            setCoverSearchOpen(false);
+          }}
+          open={coverSearchOpen}
+          type={form.type}
+        />
 
         {/* Authors */}
         <div>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -113,6 +113,14 @@ export interface ImportBooksResult {
   groupCount: number;
 }
 
+export interface CoverSearchResult {
+  height: number;
+  thumbnail: string;
+  title: string;
+  url: string;
+  width: number;
+}
+
 export interface BatchLookupProgress {
   current: number;
   seriesTitle: string;


### PR DESCRIPTION
## Summary

- Ajout d'un bouton de recherche d'images à côté du champ URL de couverture dans le formulaire série
- Modale avec champ de recherche (pré-rempli avec le titre), grille d'images cliquables, états loading/vide
- Backend : endpoint `GET /api/lookup/covers` combinant Google Books (couvertures de livres) et Serper (images web), rate-limité (20/min)
- Bouton désactivé en mode hors-ligne

## Test plan

- [ ] Ouvrir le formulaire d'édition d'une série → cliquer sur le bouton image → la modale s'ouvre avec le titre pré-rempli
- [ ] Les résultats s'affichent (Google Books en premier, puis Serper)
- [ ] Cliquer sur une image → l'URL est mise dans le champ coverUrl et l'aperçu s'affiche
- [ ] Modifier la recherche dans la modale → les résultats se mettent à jour (debounce 300ms)
- [ ] En mode hors-ligne, le bouton est grisé

Fixes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)