### PR TITLE
feat(cache): vider le cache local au logout + bouton outils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Bouton vider le cache** : Bouton dans la page Outils pour purger le cache local (IndexedDB + TanStack Query) et recharger les données depuis le serveur, avec spinner et toast (#155)
 - **Sélecteur de couverture série** : Bouton de recherche d'images à côté du champ URL de couverture, modale avec grille d'images Google Custom Search, sélection visuelle (#137)
 - **Ajout de tomes dans la prévisualisation de fusion** : Bouton "Ajouter un tome" dans la modale de fusion, avec numérotation automatique (#146)
+
+### Changed
+
+- **Logout** : Le logout vide désormais le cache local (IndexedDB + TanStack Query) en plus de supprimer le token JWT (#155)
 
 ### Fixed
 

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,6 +1,7 @@
-import { useMutation } from "@tanstack/react-query";
+import { useQueryClient, useMutation } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
+import { del } from "idb-keyval";
 import {
   isAuthenticated,
   loginWithGoogle as apiLoginWithGoogle,
@@ -9,6 +10,7 @@ import {
 
 export function useAuth() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const loginMutation = useMutation({
     mutationFn: (credential: string) => apiLoginWithGoogle(credential),
@@ -18,9 +20,11 @@ export function useAuth() {
   });
 
   const logout = useCallback(() => {
+    queryClient.clear();
+    del("bibliotheque-query-cache");
     removeToken();
     navigate("/login", { viewTransition: true });
-  }, [navigate]);
+  }, [navigate, queryClient]);
 
   return {
     isAuthenticated: isAuthenticated(),

--- a/frontend/src/pages/Tools.tsx
+++ b/frontend/src/pages/Tools.tsx
@@ -1,6 +1,9 @@
-import { ArrowRight, FileSpreadsheet, Merge, Search, Trash2 } from "lucide-react";
-import type { ComponentType } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { del } from "idb-keyval";
+import { ArrowRight, DatabaseZap, FileSpreadsheet, LoaderCircle, Merge, Search, Trash2 } from "lucide-react";
+import { type ComponentType, useState } from "react";
 import { Link } from "react-router-dom";
+import { toast } from "sonner";
 
 interface ToolCard {
   description: string;
@@ -37,6 +40,22 @@ const tools: ToolCard[] = [
 ];
 
 export default function Tools() {
+  const queryClient = useQueryClient();
+
+  const [clearing, setClearing] = useState(false);
+
+  const handleClearCache = async () => {
+    setClearing(true);
+    try {
+      queryClient.clear();
+      await del("bibliotheque-query-cache");
+      await queryClient.refetchQueries();
+      toast.success("Cache vidé — les données ont été rechargées depuis le serveur.");
+    } finally {
+      setClearing(false);
+    }
+  };
+
   return (
     <div className="mx-auto max-w-4xl px-4 py-6">
       <h1 className="mb-6 text-2xl font-bold text-text-primary">Outils</h1>
@@ -61,6 +80,23 @@ export default function Tools() {
             </div>
           </Link>
         ))}
+
+        <button
+          className="group flex cursor-pointer items-start gap-4 rounded-xl border border-surface-border bg-surface-primary p-4 text-left transition hover:border-red-400 hover:shadow-sm disabled:opacity-60"
+          disabled={clearing}
+          onClick={handleClearCache}
+          type="button"
+        >
+          <div className="rounded-lg bg-red-50 p-2.5 dark:bg-red-950/30">
+            {clearing
+              ? <LoaderCircle className="h-5 w-5 animate-spin text-red-600 dark:text-red-400" />
+              : <DatabaseZap className="h-5 w-5 text-red-600 dark:text-red-400" />}
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="font-semibold text-text-primary">{clearing ? "Vidage en cours…" : "Vider le cache"}</h2>
+            <p className="mt-1 text-sm text-text-secondary">Supprimer le cache local et recharger les données depuis le serveur.</p>
+          </div>
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- **Logout** nettoie le cache TanStack Query (in-memory + IndexedDB) pour éviter que des données stales persistent après un reset DB ou changement de contexte
- **Page Outils** : nouveau bouton « Vider le cache » avec spinner pendant l'opération et toast de confirmation

Fixes #155

## Test plan

- [ ] Se connecter, naviguer pour remplir le cache
- [ ] Se déconnecter puis se reconnecter : vérifier que les données sont fraîches (pas de données stales)
- [ ] Aller dans Outils → cliquer sur « Vider le cache » : vérifier le spinner, le toast, et le rechargement des données

🤖 Generated with [Claude Code](https://claude.com/claude-code)