### PR TITLE
test(merge): compléter la couverture de tests du modal de confirmation

### DIFF
--- a/frontend/src/__tests__/integration/components/MergeSeriesConfirmModal.test.tsx
+++ b/frontend/src/__tests__/integration/components/MergeSeriesConfirmModal.test.tsx
@@ -87,6 +87,38 @@ describe("MergeSeriesConfirmModal", () => {
     expect(screen.queryByText("Naruto Tome 1")).not.toBeInTheDocument();
   });
 
+  it("enables confirm button when exactly 2 series are checked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<MergeSeriesConfirmModal {...defaultProps} />);
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    // Uncheck one of three → exactly 2 left
+    await user.click(checkboxes[0]);
+
+    expect(screen.getByRole("button", { name: /continuer/i })).toBeEnabled();
+  });
+
+  it("allows re-checking a previously unchecked entry", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<MergeSeriesConfirmModal {...defaultProps} />);
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]);
+    expect(checkboxes[1]).not.toBeChecked();
+
+    await user.click(checkboxes[1]);
+    expect(checkboxes[1]).toBeChecked();
+  });
+
+  it("renders without crash when entries is empty", () => {
+    renderWithProviders(
+      <MergeSeriesConfirmModal {...defaultProps} entries={[]} />,
+    );
+
+    expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
+    expect(screen.getByRole("button", { name: /continuer/i })).toBeDisabled();
+  });
+
   it("resets checkboxes when entries change", async () => {
     const user = userEvent.setup();
     const { rerender } = renderWithProviders(

--- a/frontend/src/__tests__/integration/pages/MergeSeries.test.tsx
+++ b/frontend/src/__tests__/integration/pages/MergeSeries.test.tsx
@@ -133,6 +133,55 @@ describe("MergeSeries", () => {
     expect(previewCalled).toBe(false);
   });
 
+  it("opens confirmation modal from auto-detect tab with correct field mapping", async () => {
+    const user = userEvent.setup();
+    let previewCalled = false;
+
+    server.use(
+      http.post("/api/merge-series/detect", () =>
+        HttpResponse.json(mockGroups),
+      ),
+      http.post("/api/merge-series/preview", async () => {
+        previewCalled = true;
+        return HttpResponse.json(mockPreview);
+      }),
+    );
+
+    renderWithProviders(<MergeSeries />);
+
+    // Select type "Manga" from listbox
+    await user.click(screen.getByText("Type"));
+    await user.click(screen.getByText("Manga"));
+
+    // Select letter "N" from listbox
+    await user.click(screen.getByText("Lettre"));
+    await user.click(screen.getByText("N"));
+
+    // Click detect
+    await user.click(screen.getByRole("button", { name: /detecter les groupes/i }));
+
+    // Wait for group card to appear
+    await waitFor(() => {
+      expect(screen.getByText("Naruto")).toBeInTheDocument();
+    });
+
+    // Click "Apercu et fusion" on the group card
+    await user.click(screen.getByRole("button", { name: /apercu et fusion/i }));
+
+    // Confirmation modal should open with entries mapped from seriesId/originalTitle
+    await waitFor(() => {
+      expect(screen.getByText("Confirmer les series a fusionner")).toBeInTheDocument();
+    });
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("Naruto Tome 1")).toBeInTheDocument();
+    expect(within(dialog).getByText("Naruto Tome 2")).toBeInTheDocument();
+    expect(within(dialog).getByText("Naruto Tome 3")).toBeInTheDocument();
+
+    // Preview API should NOT have been called yet
+    expect(previewCalled).toBe(false);
+  });
+
   it("calls preview API only after confirming series selection", async () => {
     const user = userEvent.setup();
     let previewCalledWith: number[] = [];
@@ -169,9 +218,8 @@ describe("MergeSeries", () => {
 
     // Uncheck series 2 in the confirmation modal
     const dialog = screen.getByRole("dialog");
-    const naruto2Label = within(dialog).getByText("Naruto Tome 2").closest("label");
-    const naruto2Checkbox = naruto2Label!.querySelector('input[type="checkbox"]')!;
-    await user.click(naruto2Checkbox);
+    const dialogCheckboxes = within(dialog).getAllByRole("checkbox");
+    await user.click(dialogCheckboxes[1]);
 
     // Click "Continuer"
     await user.click(screen.getByRole("button", { name: /continuer/i }));


### PR DESCRIPTION
## Summary

- Ajouter 3 tests unitaires pour `MergeSeriesConfirmModal` : boundary exact 2 cochées, re-check toggle, entrées vides
- Ajouter 1 test d'intégration pour le flux auto-détection (mapping `seriesId`/`originalTitle`)
- Corriger sélecteur DOM fragile (`querySelector` → `getAllByRole("checkbox")`)

## Test plan

- [x] 567 tests passent (+4 nouveaux), TypeScript clean

fixes #157