### PR TITLE
Backend : qualité du code — final, DRY, pattern repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 - **CI GitHub Actions** : Workflow lint (PHPStan, CS Fixer, TypeScript) + tests (PHPUnit, Vitest) sur chaque PR, avec protection de la branche `main` (#166)
 
+### Changed
+
+- **Backend qualité du code** : Ajout `final` sur ~45 classes feuilles, extraction `GoogleBooksUrlHelper`/`GeminiJsonParser`/`MergePreviewHydrator`, déplacement des requêtes dans les repositories, enum `BatchLookupStatus`, constante `CACHE_TTL` (#167)
+
 ### Fixed
 
 - **PHPStan** : Baseline régénérée, imports inutilisés nettoyés, tolérance des différences DDEV/CI

--- a/backend/src/Command/ImportBooksCommand.php
+++ b/backend/src/Command/ImportBooksCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'app:import-books',
     description: 'Importe des livres depuis un fichier Excel (format Livres.xlsx)',
 )]
-class ImportBooksCommand extends Command
+final class ImportBooksCommand extends Command
 {
     public function __construct(
         private readonly ImportBooksService $importBooksService,

--- a/backend/src/Command/ImportExcelCommand.php
+++ b/backend/src/Command/ImportExcelCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'app:import-excel',
     description: 'Importe les données depuis un fichier Excel',
 )]
-class ImportExcelCommand extends Command
+final class ImportExcelCommand extends Command
 {
     public function __construct(
         private readonly ImportExcelService $importExcelService,

--- a/backend/src/Command/InvalidateTokensCommand.php
+++ b/backend/src/Command/InvalidateTokensCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Command;
 
-use App\Entity\User;
+use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -20,10 +20,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'app:invalidate-tokens',
     description: 'Invalide tous les tokens JWT (ou ceux d\'un utilisateur spécifique)',
 )]
-class InvalidateTokensCommand extends Command
+final class InvalidateTokensCommand extends Command
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
+        private readonly UserRepository $userRepository,
     ) {
         parent::__construct();
     }
@@ -49,7 +50,7 @@ class InvalidateTokensCommand extends Command
 
     private function invalidateAll(SymfonyStyle $io): int
     {
-        $users = $this->entityManager->getRepository(User::class)->findAll();
+        $users = $this->userRepository->findAll();
 
         foreach ($users as $user) {
             $user->incrementTokenVersion();
@@ -64,7 +65,7 @@ class InvalidateTokensCommand extends Command
 
     private function invalidateForUser(SymfonyStyle $io, string $email): int
     {
-        $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => $email]);
+        $user = $this->userRepository->findOneBy(['email' => $email]);
 
         if (null === $user) {
             $io->error(\sprintf('Utilisateur "%s" introuvable.', $email));

--- a/backend/src/Command/LookupMissingCommand.php
+++ b/backend/src/Command/LookupMissingCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Command;
 
 use App\Entity\ComicSeries;
+use App\Enum\BatchLookupStatus;
 use App\Enum\ComicType;
 use App\Repository\ComicSeriesRepository;
 use App\Service\BatchLookupService;
@@ -24,7 +25,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'app:lookup-missing',
     description: 'Recherche les métadonnées manquantes pour les séries sans données',
 )]
-class LookupMissingCommand extends Command
+final class LookupMissingCommand extends Command
 {
     public function __construct(
         private readonly BatchLookupService $batchLookupService,
@@ -106,17 +107,16 @@ class LookupMissingCommand extends Command
                 $progress->current,
                 $progress->total,
                 $progress->seriesTitle,
-                $progress->status,
+                $progress->status->value,
                 [] !== $progress->updatedFields ? ' ('.\implode(', ', $progress->updatedFields).')' : '',
             ));
 
             ++$processed;
 
             match ($progress->status) {
-                'failed' => ++$failed,
-                'skipped' => ++$skipped,
-                'updated' => ++$updated,
-                default => null,
+                BatchLookupStatus::FAILED => ++$failed,
+                BatchLookupStatus::SKIPPED => ++$skipped,
+                BatchLookupStatus::UPDATED => ++$updated,
             };
         }
 

--- a/backend/src/Command/PurgeDeletedCommand.php
+++ b/backend/src/Command/PurgeDeletedCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'app:purge-deleted',
     description: 'Purge les séries supprimées depuis plus de N jours',
 )]
-class PurgeDeletedCommand extends Command
+final class PurgeDeletedCommand extends Command
 {
     public function __construct(
         private readonly PurgeService $purgeService,

--- a/backend/src/Controller/ApiController.php
+++ b/backend/src/Controller/ApiController.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[IsGranted('ROLE_USER')]
 #[Route('/api/lookup')]
-class ApiController
+final class ApiController
 {
     use RateLimitTrait;
 

--- a/backend/src/Controller/BatchLookupController.php
+++ b/backend/src/Controller/BatchLookupController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 
 use App\Controller\Trait\RateLimitTrait;
 use App\DTO\BatchLookupSummary;
+use App\Enum\BatchLookupStatus;
 use App\Enum\ComicType;
 use App\Service\BatchLookupService;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -20,7 +21,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
  */
 #[IsGranted('ROLE_USER')]
 #[Route('/api/tools/batch-lookup')]
-class BatchLookupController
+final class BatchLookupController
 {
     use RateLimitTrait;
 
@@ -91,10 +92,9 @@ class BatchLookupController
                 ++$processed;
 
                 match ($progress->status) {
-                    'failed' => ++$failed,
-                    'skipped' => ++$skipped,
-                    'updated' => ++$updated,
-                    default => null,
+                    BatchLookupStatus::FAILED => ++$failed,
+                    BatchLookupStatus::SKIPPED => ++$skipped,
+                    BatchLookupStatus::UPDATED => ++$updated,
                 };
             }
 

--- a/backend/src/Controller/GoogleLoginController.php
+++ b/backend/src/Controller/GoogleLoginController.php
@@ -18,7 +18,7 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-class GoogleLoginController
+final class GoogleLoginController
 {
     public function __construct(
         #[Autowire('%env(OAUTH_ALLOWED_EMAIL)%')]

--- a/backend/src/Controller/ImportController.php
+++ b/backend/src/Controller/ImportController.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
  */
 #[IsGranted('ROLE_USER')]
 #[Route('/api/tools/import')]
-class ImportController
+final class ImportController
 {
     use RateLimitTrait;
 

--- a/backend/src/Controller/MergeSeriesController.php
+++ b/backend/src/Controller/MergeSeriesController.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Controller\Trait\RateLimitTrait;
-use App\DTO\MergePreview;
-use App\DTO\MergePreviewTome;
 use App\Enum\ComicType;
 use App\Repository\ComicSeriesRepository;
 use App\Service\Merge\MergePreviewBuilder;
+use App\Service\Merge\MergePreviewHydrator;
 use App\Service\Merge\SeriesGroupDetector;
 use App\Service\Merge\SeriesMerger;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -24,13 +23,14 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
  */
 #[IsGranted('ROLE_USER')]
 #[Route('/api/merge-series')]
-class MergeSeriesController
+final class MergeSeriesController
 {
     use RateLimitTrait;
 
     public function __construct(
         private readonly ComicSeriesRepository $comicSeriesRepository,
         private readonly MergePreviewBuilder $mergePreviewBuilder,
+        private readonly MergePreviewHydrator $mergePreviewHydrator,
         private readonly RateLimiterFactory $mergeSeriesLimiter,
         private readonly SeriesGroupDetector $seriesGroupDetector,
         private readonly SeriesMerger $seriesMerger,
@@ -128,7 +128,7 @@ class MergeSeriesController
         $data = \json_decode($request->getContent(), true) ?? [];
 
         try {
-            $preview = $this->hydrateMergePreview($data);
+            $preview = $this->mergePreviewHydrator->hydrate($data);
         } catch (\InvalidArgumentException $e) {
             return new JsonResponse(
                 ['error' => $e->getMessage()],
@@ -150,72 +150,5 @@ class MergeSeriesController
             'title' => $mergedSeries->getTitle(),
             'type' => $mergedSeries->getType()->value,
         ]);
-    }
-
-    /**
-     * Hydrate un MergePreview depuis les données JSON.
-     *
-     * @param array<string, mixed> $data
-     *
-     * @throws \InvalidArgumentException si les données sont invalides
-     */
-    private function hydrateMergePreview(array $data): MergePreview
-    {
-        if (!isset($data['title']) || !\is_string($data['title'])) {
-            throw new \InvalidArgumentException('Le champ "title" est requis.');
-        }
-
-        if (!isset($data['type']) || !\is_string($data['type'])) {
-            throw new \InvalidArgumentException('Le champ "type" est requis.');
-        }
-
-        if (!isset($data['sourceSeriesIds']) || !\is_array($data['sourceSeriesIds'])) {
-            throw new \InvalidArgumentException('Le champ "sourceSeriesIds" est requis.');
-        }
-
-        if (!isset($data['tomes']) || !\is_array($data['tomes'])) {
-            throw new \InvalidArgumentException('Le champ "tomes" est requis.');
-        }
-
-        /** @var list<MergePreviewTome> $tomes */
-        $tomes = \array_values(\array_map(
-            static function (mixed $tomeData): MergePreviewTome {
-                if (!\is_array($tomeData)) {
-                    throw new \InvalidArgumentException('Chaque tome doit être un objet.');
-                }
-
-                return new MergePreviewTome(
-                    bought: (bool) ($tomeData['bought'] ?? false),
-                    downloaded: (bool) ($tomeData['downloaded'] ?? false),
-                    isbn: isset($tomeData['isbn']) && \is_string($tomeData['isbn']) ? $tomeData['isbn'] : null,
-                    number: (int) ($tomeData['number'] ?? 0),
-                    onNas: (bool) ($tomeData['onNas'] ?? false),
-                    read: (bool) ($tomeData['read'] ?? false),
-                    title: isset($tomeData['title']) && \is_string($tomeData['title']) ? $tomeData['title'] : null,
-                    tomeEnd: isset($tomeData['tomeEnd']) && \is_numeric($tomeData['tomeEnd']) ? (int) $tomeData['tomeEnd'] : null,
-                );
-            },
-            $data['tomes'],
-        ));
-
-        /** @var list<string> $authors */
-        $authors = \is_array($data['authors'] ?? null) ? \array_values($data['authors']) : [];
-
-        /** @var list<int> $sourceSeriesIds */
-        $sourceSeriesIds = \array_values(\array_map('\intval', $data['sourceSeriesIds']));
-
-        return new MergePreview(
-            authors: $authors,
-            coverUrl: isset($data['coverUrl']) && \is_string($data['coverUrl']) ? $data['coverUrl'] : null,
-            description: isset($data['description']) && \is_string($data['description']) ? $data['description'] : null,
-            isOneShot: (bool) ($data['isOneShot'] ?? false),
-            latestPublishedIssue: isset($data['latestPublishedIssue']) && \is_numeric($data['latestPublishedIssue']) ? (int) $data['latestPublishedIssue'] : null,
-            latestPublishedIssueComplete: (bool) ($data['latestPublishedIssueComplete'] ?? false),
-            publisher: isset($data['publisher']) && \is_string($data['publisher']) ? $data['publisher'] : null,
-            sourceSeriesIds: $sourceSeriesIds,
-            title: $data['title'],
-            tomes: $tomes,
-            type: $data['type'],
-        );
     }
 }

--- a/backend/src/Controller/PurgeController.php
+++ b/backend/src/Controller/PurgeController.php
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
  */
 #[IsGranted('ROLE_USER')]
 #[Route('/api/tools/purge')]
-class PurgeController
+final class PurgeController
 {
     use RateLimitTrait;
 

--- a/backend/src/DTO/BatchLookupProgress.php
+++ b/backend/src/DTO/BatchLookupProgress.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace App\DTO;
 
+use App\Enum\BatchLookupStatus;
+
 /**
  * Progression d'un lookup batch pour une série.
  */
-readonly class BatchLookupProgress implements \JsonSerializable
+final readonly class BatchLookupProgress implements \JsonSerializable
 {
     public function __construct(
         public int $current,
         public string $seriesTitle,
-        public string $status,
+        public BatchLookupStatus $status,
         public int $total,
         /** @var list<string> */
         public array $updatedFields = [],
@@ -27,7 +29,7 @@ readonly class BatchLookupProgress implements \JsonSerializable
         return [
             'current' => $this->current,
             'seriesTitle' => $this->seriesTitle,
-            'status' => $this->status,
+            'status' => $this->status->value,
             'total' => $this->total,
             'updatedFields' => $this->updatedFields,
         ];

--- a/backend/src/DTO/BatchLookupSummary.php
+++ b/backend/src/DTO/BatchLookupSummary.php
@@ -7,7 +7,7 @@ namespace App\DTO;
 /**
  * Résumé final d'un lookup batch.
  */
-readonly class BatchLookupSummary implements \JsonSerializable
+final readonly class BatchLookupSummary implements \JsonSerializable
 {
     public function __construct(
         public int $failed,

--- a/backend/src/DTO/BookGroup.php
+++ b/backend/src/DTO/BookGroup.php
@@ -7,7 +7,7 @@ namespace App\DTO;
 /**
  * Groupe de lignes d'import partageant la même série.
  */
-readonly class BookGroup
+final readonly class BookGroup
 {
     /**
      * @param list<BookRow> $rows

--- a/backend/src/DTO/BookRow.php
+++ b/backend/src/DTO/BookRow.php
@@ -7,7 +7,7 @@ namespace App\DTO;
 /**
  * Ligne d'import : titre original, données brutes et numéro de tome.
  */
-readonly class BookRow
+final readonly class BookRow
 {
     /**
      * @param array<int, mixed> $row

--- a/backend/src/DTO/ComicSeriesFilter.php
+++ b/backend/src/DTO/ComicSeriesFilter.php
@@ -10,7 +10,7 @@ use App\Enum\ComicType;
 /**
  * Filtres pour la recherche de series.
  */
-readonly class ComicSeriesFilter
+final readonly class ComicSeriesFilter
 {
     public function __construct(
         public ?bool $isWishlist = null,

--- a/backend/src/DTO/ComicSeriesListItem.php
+++ b/backend/src/DTO/ComicSeriesListItem.php
@@ -12,7 +12,7 @@ use App\Entity\ComicSeries;
  * Utilisé pour le cache applicatif : la méthode __unserialize() gère
  * la compatibilité avec les entrées de cache précédentes.
  */
-readonly class ComicSeriesListItem implements \JsonSerializable
+final readonly class ComicSeriesListItem implements \JsonSerializable
 {
     /**
      * @param int[] $missingTomesNumbers

--- a/backend/src/DTO/CoverSearchResult.php
+++ b/backend/src/DTO/CoverSearchResult.php
@@ -7,7 +7,7 @@ namespace App\DTO;
 /**
  * Résultat d'une recherche de couverture via Google Custom Search.
  */
-readonly class CoverSearchResult implements \JsonSerializable
+final readonly class CoverSearchResult implements \JsonSerializable
 {
     public function __construct(
         public int $height,

--- a/backend/src/DTO/ImportResult.php
+++ b/backend/src/DTO/ImportResult.php
@@ -9,7 +9,7 @@ use App\Entity\ComicSeries;
 /**
  * Resultat de l'import d'une ligne Excel.
  */
-readonly class ImportResult
+final readonly class ImportResult
 {
     public function __construct(
         public bool $isUpdate,

--- a/backend/src/DTO/MergeGroup.php
+++ b/backend/src/DTO/MergeGroup.php
@@ -7,7 +7,7 @@ namespace App\DTO;
 /**
  * Groupe de séries détectées comme tomes d'une même série.
  */
-readonly class MergeGroup implements \JsonSerializable
+final readonly class MergeGroup implements \JsonSerializable
 {
     /**
      * @param list<MergeGroupEntry> $entries

--- a/backend/src/DTO/MergeGroupEntry.php
+++ b/backend/src/DTO/MergeGroupEntry.php
@@ -7,7 +7,7 @@ namespace App\DTO;
 /**
  * Entrée d'un groupe de fusion : une série avec son numéro de tome suggéré.
  */
-readonly class MergeGroupEntry implements \JsonSerializable
+final readonly class MergeGroupEntry implements \JsonSerializable
 {
     public function __construct(
         public string $originalTitle,

--- a/backend/src/DTO/MergePreview.php
+++ b/backend/src/DTO/MergePreview.php
@@ -7,7 +7,7 @@ namespace App\DTO;
 /**
  * Aperçu complet du résultat d'une fusion de séries.
  */
-readonly class MergePreview implements \JsonSerializable
+final readonly class MergePreview implements \JsonSerializable
 {
     /**
      * @param list<string>           $authors

--- a/backend/src/DTO/MergePreviewTome.php
+++ b/backend/src/DTO/MergePreviewTome.php
@@ -7,7 +7,7 @@ namespace App\DTO;
 /**
  * Tome dans l'aperçu de fusion.
  */
-readonly class MergePreviewTome implements \JsonSerializable
+final readonly class MergePreviewTome implements \JsonSerializable
 {
     public function __construct(
         public bool $bought,

--- a/backend/src/DTO/ParsedIntegerValue.php
+++ b/backend/src/DTO/ParsedIntegerValue.php
@@ -7,7 +7,7 @@ namespace App\DTO;
 /**
  * Valeur entiere parsee depuis une cellule Excel, pouvant etre "fini" (complete).
  */
-readonly class ParsedIntegerValue
+final readonly class ParsedIntegerValue
 {
     public function __construct(
         public bool $isComplete,

--- a/backend/src/DTO/SeriesInfo.php
+++ b/backend/src/DTO/SeriesInfo.php
@@ -7,7 +7,7 @@ namespace App\DTO;
 /**
  * Informations extraites d'un titre : nom de série et numéro de tome.
  */
-readonly class SeriesInfo
+final readonly class SeriesInfo
 {
     public function __construct(
         public string $name,

--- a/backend/src/Enum/BatchLookupStatus.php
+++ b/backend/src/Enum/BatchLookupStatus.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+/**
+ * Statuts possibles pour le traitement batch lookup d'une série.
+ */
+enum BatchLookupStatus: string
+{
+    case FAILED = 'failed';
+    case SKIPPED = 'skipped';
+    case UPDATED = 'updated';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::FAILED => 'Échoué',
+            self::SKIPPED => 'Ignoré',
+            self::UPDATED => 'Mis à jour',
+        };
+    }
+}

--- a/backend/src/EventListener/ComicSeriesCacheInvalidator.php
+++ b/backend/src/EventListener/ComicSeriesCacheInvalidator.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\Cache\CacheInterface;
 #[AsDoctrineListener(event: Events::postPersist)]
 #[AsDoctrineListener(event: Events::postRemove)]
 #[AsDoctrineListener(event: Events::postUpdate)]
-class ComicSeriesCacheInvalidator
+final class ComicSeriesCacheInvalidator
 {
     private const array WATCHED_ENTITIES = [
         Author::class,

--- a/backend/src/EventListener/ComicSeriesEventListener.php
+++ b/backend/src/EventListener/ComicSeriesEventListener.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[AsDoctrineListener(event: Events::postPersist)]
 #[AsDoctrineListener(event: Events::postRemove)]
 #[AsDoctrineListener(event: Events::postUpdate)]
-class ComicSeriesEventListener
+final class ComicSeriesEventListener
 {
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,

--- a/backend/src/EventListener/JwtTokenVersionListener.php
+++ b/backend/src/EventListener/JwtTokenVersionListener.php
@@ -19,7 +19,7 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
  */
 #[AsEventListener(event: 'lexik_jwt_authentication.on_jwt_created', method: 'onJWTCreated')]
 #[AsEventListener(event: 'lexik_jwt_authentication.on_jwt_decoded', method: 'onJWTDecoded')]
-class JwtTokenVersionListener
+final class JwtTokenVersionListener
 {
     public function __construct(
         private readonly UserRepository $userRepository,

--- a/backend/src/EventListener/PlaceholderSecretChecker.php
+++ b/backend/src/EventListener/PlaceholderSecretChecker.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * le démarrage de l'application avec des secrets non sécurisés.
  */
 #[AsEventListener(event: KernelEvents::REQUEST, method: 'onKernelRequest', priority: 255)]
-class PlaceholderSecretChecker
+final class PlaceholderSecretChecker
 {
     private const array PLACEHOLDERS = [
         'APP_SECRET' => 'change_this_secret_in_env_local',

--- a/backend/src/Repository/ComicSeriesRepository.php
+++ b/backend/src/Repository/ComicSeriesRepository.php
@@ -179,6 +179,57 @@ class ComicSeriesRepository extends ServiceEntityRepository
     }
 
     /**
+     * Retourne les séries soft-deleted depuis plus de N jours.
+     *
+     * Désactive temporairement le filtre soft-delete pour accéder aux séries supprimées.
+     *
+     * @return ComicSeries[]
+     */
+    public function findPurgeable(int $days): array
+    {
+        $cutoffDate = new \DateTime(\sprintf('-%d days', $days));
+
+        $this->getEntityManager()->getFilters()->disable('soft_delete');
+
+        try {
+            /** @var ComicSeries[] $series */
+            $series = $this->createQueryBuilder('c')
+                ->where('c.deletedAt IS NOT NULL')
+                ->andWhere('c.deletedAt <= :cutoff')
+                ->setParameter('cutoff', $cutoffDate)
+                ->getQuery()
+                ->getResult();
+        } finally {
+            $this->getEntityManager()->getFilters()->enable('soft_delete');
+        }
+
+        return $series;
+    }
+
+    /**
+     * Retourne les séries en corbeille (soft-deleted), triées par date de suppression décroissante.
+     *
+     * @return ComicSeries[]
+     */
+    public function findTrashed(): array
+    {
+        $this->getEntityManager()->getFilters()->disable('soft_delete');
+
+        try {
+            /** @var ComicSeries[] $series */
+            $series = $this->createQueryBuilder('c')
+                ->where('c.deletedAt IS NOT NULL')
+                ->orderBy('c.deletedAt', 'DESC')
+                ->getQuery()
+                ->getResult();
+        } finally {
+            $this->getEntityManager()->getFilters()->enable('soft_delete');
+        }
+
+        return $series;
+    }
+
+    /**
      * Retourne toutes les séries avec leurs relations pour l'API PWA.
      *
      * Utilise un cache applicatif (15 min) pour éviter de requêter la base

--- a/backend/src/Repository/TomeRepository.php
+++ b/backend/src/Repository/TomeRepository.php
@@ -13,7 +13,7 @@ use Doctrine\Persistence\ManagerRegistry;
  *
  * @extends ServiceEntityRepository<Tome>
  */
-class TomeRepository extends ServiceEntityRepository
+final class TomeRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
     {

--- a/backend/src/Service/BatchLookupService.php
+++ b/backend/src/Service/BatchLookupService.php
@@ -7,6 +7,7 @@ namespace App\Service;
 use App\DTO\BatchLookupProgress;
 use App\Entity\ComicSeries;
 use App\Enum\ApiLookupStatus;
+use App\Enum\BatchLookupStatus;
 use App\Enum\ComicType;
 use App\Repository\ComicSeriesRepository;
 use App\Service\Lookup\LookupApplier;
@@ -18,7 +19,7 @@ use Doctrine\ORM\EntityManagerInterface;
  *
  * Utilise un générateur pour permettre le streaming (SSE) ou l'affichage CLI.
  */
-class BatchLookupService
+final class BatchLookupService
 {
     private const int BATCH_SIZE = 10;
     private const int MAX_DELAY = 60;
@@ -115,7 +116,7 @@ class BatchLookupService
                     'progress' => new BatchLookupProgress(
                         current: $index + 1,
                         seriesTitle: $title,
-                        status: 'failed',
+                        status: BatchLookupStatus::FAILED,
                         total: $total,
                     ),
                 ];
@@ -132,7 +133,7 @@ class BatchLookupService
                 'progress' => new BatchLookupProgress(
                     current: $index + 1,
                     seriesTitle: $title,
-                    status: 'skipped',
+                    status: BatchLookupStatus::SKIPPED,
                     total: $total,
                 ),
             ];
@@ -151,7 +152,7 @@ class BatchLookupService
                 'progress' => new BatchLookupProgress(
                     current: $index + 1,
                     seriesTitle: $title,
-                    status: 'updated',
+                    status: BatchLookupStatus::UPDATED,
                     total: $total,
                     updatedFields: $updatedFields,
                 ),
@@ -163,7 +164,7 @@ class BatchLookupService
             'progress' => new BatchLookupProgress(
                 current: $index + 1,
                 seriesTitle: $title,
-                status: 'skipped',
+                status: BatchLookupStatus::SKIPPED,
                 total: $total,
             ),
         ];

--- a/backend/src/Service/CoverSearchService.php
+++ b/backend/src/Service/CoverSearchService.php
@@ -6,6 +6,7 @@ namespace App\Service;
 
 use App\DTO\CoverSearchResult;
 use App\Enum\ComicType;
+use App\Service\Lookup\GoogleBooksUrlHelper;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -14,7 +15,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * Recherche de couvertures via Google Books + Serper Images.
  */
-class CoverSearchService
+final class CoverSearchService
 {
     private const string GOOGLE_BOOKS_URL = 'https://www.googleapis.com/books/v1/volumes';
     private const string SERPER_URL = 'https://google.serper.dev/images';
@@ -62,22 +63,6 @@ class CoverSearchService
     }
 
     /**
-     * Optimise l'URL d'une couverture Google Books.
-     */
-    private function optimizeThumbnailUrl(string $url): string
-    {
-        if (!\str_contains($url, 'books.google.com/')) {
-            return $url;
-        }
-
-        $url = (string) \preg_replace('#^http://#', 'https://', $url);
-        $url = \str_replace('zoom=1', 'zoom=0', $url);
-        $url = (string) \preg_replace('/&?edge=curl&?/', '&', $url);
-
-        return \rtrim($url, '&');
-    }
-
-    /**
      * @return CoverSearchResult[]
      */
     private function parseGoogleBooksResponse(?ResponseInterface $response): array
@@ -114,7 +99,7 @@ class CoverSearchService
                 continue;
             }
 
-            $url = $this->optimizeThumbnailUrl($rawThumbnail);
+            $url = GoogleBooksUrlHelper::optimizeThumbnailUrl($rawThumbnail);
             $title = \is_string($volumeInfo['title'] ?? null) ? $volumeInfo['title'] : '';
 
             $results[] = new CoverSearchResult(

--- a/backend/src/Service/Import/ImportBooksService.php
+++ b/backend/src/Service/Import/ImportBooksService.php
@@ -20,7 +20,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 /**
  * Service d'import des livres depuis un fichier Excel (format Livres.xlsx).
  */
-class ImportBooksService
+final class ImportBooksService
 {
     /**
      * Correspondance catégorie → ComicType (par ordre de priorité).

--- a/backend/src/Service/Import/ImportExcelService.php
+++ b/backend/src/Service/Import/ImportExcelService.php
@@ -19,7 +19,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 /**
  * Service d'import des données depuis un fichier Excel de suivi.
  */
-class ImportExcelService
+final class ImportExcelService
 {
     private const array SHEET_TYPE_MAP = [
         'BD' => ComicType::BD,

--- a/backend/src/Service/Lookup/AbstractGeminiLookupProvider.php
+++ b/backend/src/Service/Lookup/AbstractGeminiLookupProvider.php
@@ -20,6 +20,8 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
  */
 abstract class AbstractGeminiLookupProvider extends AbstractLookupProvider
 {
+    private const int CACHE_TTL = 2592000; // 30 jours
+
     public function __construct(
         protected readonly AdapterInterface $cache,
         protected readonly GeminiClientPool $geminiClientPool,
@@ -44,7 +46,7 @@ abstract class AbstractGeminiLookupProvider extends AbstractLookupProvider
         if ($result instanceof LookupResult) {
             $item = $this->cache->getItem($state['cacheKey']);
             $item->set($result);
-            $item->expiresAfter(2592000); // 30 jours
+            $item->expiresAfter(self::CACHE_TTL);
             $this->cache->save($item);
         }
 
@@ -116,24 +118,6 @@ abstract class AbstractGeminiLookupProvider extends AbstractLookupProvider
         return true;
     }
 
-    /**
-     * Parse le JSON depuis la réponse texte de Gemini (avec ou sans bloc markdown).
-     *
-     * @return array<string, mixed>|null
-     */
-    protected function parseJsonFromText(string $text): ?array
-    {
-        $cleaned = \preg_replace('/^```(?:json)?\s*\n?(.*?)\n?```$/s', '$1', \trim($text));
-
-        $data = \json_decode($cleaned ?? $text, true);
-
-        if (!\is_array($data)) {
-            return null;
-        }
-
-        return $data; // @phpstan-ignore return.type
-    }
-
     private function callGemini(string $prompt): ?LookupResult
     {
         $logName = $this->getLogName();
@@ -146,7 +130,7 @@ abstract class AbstractGeminiLookupProvider extends AbstractLookupProvider
                     ->generateContent($prompt);
 
                 $text = $response->text();
-                $data = $this->parseJsonFromText($text);
+                $data = GeminiJsonParser::parseJsonFromText($text);
 
                 if (null === $data) {
                     $this->recordApiMessage(ApiLookupStatus::ERROR, 'Réponse JSON invalide');

--- a/backend/src/Service/Lookup/AniListLookup.php
+++ b/backend/src/Service/Lookup/AniListLookup.php
@@ -20,7 +20,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * Provider de recherche via l'API AniList (manga uniquement, par titre).
  */
 #[AutoconfigureTag('app.lookup_provider', ['priority' => 60])]
-class AniListLookup extends AbstractLookupProvider
+final class AniListLookup extends AbstractLookupProvider
 {
     private const string API_URL = 'https://graphql.anilist.co';
 

--- a/backend/src/Service/Lookup/ApiMessage.php
+++ b/backend/src/Service/Lookup/ApiMessage.php
@@ -7,7 +7,7 @@ namespace App\Service\Lookup;
 /**
  * DTO representant un message de statut d'appel API.
  */
-readonly class ApiMessage implements \JsonSerializable
+final readonly class ApiMessage implements \JsonSerializable
 {
     public function __construct(
         public string $message,

--- a/backend/src/Service/Lookup/BedethequeLookup.php
+++ b/backend/src/Service/Lookup/BedethequeLookup.php
@@ -19,7 +19,7 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
  * les données structurées depuis site:bedetheque.com.
  */
 #[AutoconfigureTag('app.lookup_provider', ['priority' => 45])]
-class BedethequeLookup extends AbstractGeminiLookupProvider
+final class BedethequeLookup extends AbstractGeminiLookupProvider
 {
     private const string JSON_INSTRUCTIONS = <<<'TEXT'
         Réponds UNIQUEMENT avec un objet JSON (sans bloc markdown) contenant ces champs :

--- a/backend/src/Service/Lookup/BnfLookup.php
+++ b/backend/src/Service/Lookup/BnfLookup.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * Réponses au format Dublin Core (XML).
  */
 #[AutoconfigureTag('app.lookup_provider', ['priority' => 90])]
-class BnfLookup extends AbstractLookupProvider
+final class BnfLookup extends AbstractLookupProvider
 {
     private const string API_URL = 'https://catalogue.bnf.fr/api/SRU';
 

--- a/backend/src/Service/Lookup/GeminiJsonParser.php
+++ b/backend/src/Service/Lookup/GeminiJsonParser.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Lookup;
+
+/**
+ * Utilitaire pour parser les réponses JSON de Gemini.
+ *
+ * Gère les réponses encapsulées dans des blocs de code Markdown (```json ... ```).
+ */
+final class GeminiJsonParser
+{
+    /**
+     * Parse du texte JSON potentiellement encapsulé dans un bloc de code Markdown.
+     *
+     * @return array<mixed>|null
+     */
+    public static function parseJsonFromText(string $text): ?array
+    {
+        $cleaned = \preg_replace('/^```(?:json)?\s*\n?(.*?)\n?```$/s', '$1', \trim($text));
+
+        $data = \json_decode($cleaned ?? $text, true);
+
+        if (!\is_array($data)) {
+            return null;
+        }
+
+        return $data; // @phpstan-ignore return.type
+    }
+}

--- a/backend/src/Service/Lookup/GeminiLookup.php
+++ b/backend/src/Service/Lookup/GeminiLookup.php
@@ -15,7 +15,7 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
  * Provider de recherche via l'API Google Gemini avec Google Search grounding.
  */
 #[AutoconfigureTag('app.lookup_provider', ['priority' => 40])]
-class GeminiLookup extends AbstractGeminiLookupProvider implements EnrichableLookupProviderInterface
+final class GeminiLookup extends AbstractGeminiLookupProvider implements EnrichableLookupProviderInterface
 {
     private const string JSON_INSTRUCTIONS = <<<'TEXT'
         Réponds UNIQUEMENT avec un objet JSON (sans bloc markdown) contenant ces champs :

--- a/backend/src/Service/Lookup/GoogleBooksLookup.php
+++ b/backend/src/Service/Lookup/GoogleBooksLookup.php
@@ -21,7 +21,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * Provider de recherche via l'API Google Books.
  */
 #[AutoconfigureTag('app.lookup_provider', ['priority' => 100])]
-class GoogleBooksLookup extends AbstractLookupProvider
+final class GoogleBooksLookup extends AbstractLookupProvider
 {
     private const string API_URL = 'https://www.googleapis.com/books/v1/volumes';
 
@@ -189,7 +189,7 @@ class GoogleBooksLookup extends AbstractLookupProvider
                     : null;
 
                 if (\is_string($rawThumbnail)) {
-                    $thumbnail = $this->optimizeThumbnailUrl($rawThumbnail);
+                    $thumbnail = GoogleBooksUrlHelper::optimizeThumbnailUrl($rawThumbnail);
                 }
             }
 
@@ -221,25 +221,5 @@ class GoogleBooksLookup extends AbstractLookupProvider
             thumbnail: $thumbnail,
             title: $title,
         );
-    }
-
-    /**
-     * Optimise l'URL d'une couverture Google Books pour obtenir une meilleure résolution.
-     *
-     * - Remplace zoom=1 par zoom=0 (plus grande image disponible)
-     * - Supprime edge=curl (effet de page cornée)
-     * - Force HTTPS
-     */
-    private function optimizeThumbnailUrl(string $url): string
-    {
-        if (!\str_contains($url, 'books.google.com/')) {
-            return $url;
-        }
-
-        $url = (string) \preg_replace('#^http://#', 'https://', $url);
-        $url = \str_replace('zoom=1', 'zoom=0', $url);
-        $url = (string) \preg_replace('/&?edge=curl&?/', '&', $url);
-
-        return \rtrim($url, '&');
     }
 }

--- a/backend/src/Service/Lookup/GoogleBooksUrlHelper.php
+++ b/backend/src/Service/Lookup/GoogleBooksUrlHelper.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Lookup;
+
+/**
+ * Utilitaire pour optimiser les URLs de couvertures Google Books.
+ *
+ * Transforme les URLs pour obtenir une meilleure qualité d'image :
+ * HTTPS, zoom=0 (plus grande résolution), suppression du curl de page.
+ */
+final class GoogleBooksUrlHelper
+{
+    public static function optimizeThumbnailUrl(string $url): string
+    {
+        if (!\str_contains($url, 'books.google.com/')) {
+            return $url;
+        }
+
+        $url = (string) \preg_replace('#^http://#', 'https://', $url);
+        $url = \str_replace('zoom=1', 'zoom=0', $url);
+        $url = (string) \preg_replace('/&?edge=curl&?/', '&', $url);
+
+        return \rtrim($url, '&');
+    }
+}

--- a/backend/src/Service/Lookup/LookupResult.php
+++ b/backend/src/Service/Lookup/LookupResult.php
@@ -7,7 +7,7 @@ namespace App\Service\Lookup;
 /**
  * Résultat d'un lookup depuis un provider.
  */
-class LookupResult implements \JsonSerializable
+final class LookupResult implements \JsonSerializable
 {
     public function __construct(
         public readonly ?string $authors = null,

--- a/backend/src/Service/Lookup/OpenLibraryLookup.php
+++ b/backend/src/Service/Lookup/OpenLibraryLookup.php
@@ -20,7 +20,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * Provider de recherche via l'API Open Library (ISBN uniquement).
  */
 #[AutoconfigureTag('app.lookup_provider', ['priority' => 80])]
-class OpenLibraryLookup extends AbstractLookupProvider
+final class OpenLibraryLookup extends AbstractLookupProvider
 {
     private const string API_URL = 'https://openlibrary.org/isbn/';
 

--- a/backend/src/Service/Lookup/WikipediaLookup.php
+++ b/backend/src/Service/Lookup/WikipediaLookup.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * Extraction des métadonnées depuis les claims Wikidata, synopsis depuis Wikipedia FR.
  */
 #[AutoconfigureTag('app.lookup_provider', ['priority' => 120])]
-class WikipediaLookup extends AbstractLookupProvider implements EnrichableLookupProviderInterface
+final class WikipediaLookup extends AbstractLookupProvider implements EnrichableLookupProviderInterface
 {
     private const int CACHE_TTL = 604800; // 7 jours
 

--- a/backend/src/Service/Merge/MergePreviewBuilder.php
+++ b/backend/src/Service/Merge/MergePreviewBuilder.php
@@ -19,7 +19,7 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 /**
  * Construit un aperçu de fusion à partir d'un groupe détecté ou d'une sélection manuelle.
  */
-class MergePreviewBuilder
+final class MergePreviewBuilder
 {
     public function __construct(
         private readonly GeminiClientPool $geminiClientPool,

--- a/backend/src/Service/Merge/MergePreviewHydrator.php
+++ b/backend/src/Service/Merge/MergePreviewHydrator.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Merge;
+
+use App\DTO\MergePreview;
+use App\DTO\MergePreviewTome;
+
+/**
+ * Hydrate un MergePreview depuis des données JSON brutes.
+ */
+final class MergePreviewHydrator
+{
+    /**
+     * Hydrate un MergePreview depuis les données JSON.
+     *
+     * @param array<string, mixed> $data
+     *
+     * @throws \InvalidArgumentException si les données sont invalides
+     */
+    public function hydrate(array $data): MergePreview
+    {
+        if (!isset($data['title']) || !\is_string($data['title'])) {
+            throw new \InvalidArgumentException('Le champ "title" est requis.');
+        }
+
+        if (!isset($data['type']) || !\is_string($data['type'])) {
+            throw new \InvalidArgumentException('Le champ "type" est requis.');
+        }
+
+        if (!isset($data['sourceSeriesIds']) || !\is_array($data['sourceSeriesIds'])) {
+            throw new \InvalidArgumentException('Le champ "sourceSeriesIds" est requis.');
+        }
+
+        if (!isset($data['tomes']) || !\is_array($data['tomes'])) {
+            throw new \InvalidArgumentException('Le champ "tomes" est requis.');
+        }
+
+        /** @var list<MergePreviewTome> $tomes */
+        $tomes = \array_values(\array_map(
+            static function (mixed $tomeData): MergePreviewTome {
+                if (!\is_array($tomeData)) {
+                    throw new \InvalidArgumentException('Chaque tome doit être un objet.');
+                }
+
+                return new MergePreviewTome(
+                    bought: (bool) ($tomeData['bought'] ?? false),
+                    downloaded: (bool) ($tomeData['downloaded'] ?? false),
+                    isbn: isset($tomeData['isbn']) && \is_string($tomeData['isbn']) ? $tomeData['isbn'] : null,
+                    number: (int) ($tomeData['number'] ?? 0),
+                    onNas: (bool) ($tomeData['onNas'] ?? false),
+                    read: (bool) ($tomeData['read'] ?? false),
+                    title: isset($tomeData['title']) && \is_string($tomeData['title']) ? $tomeData['title'] : null,
+                    tomeEnd: isset($tomeData['tomeEnd']) && \is_numeric($tomeData['tomeEnd']) ? (int) $tomeData['tomeEnd'] : null,
+                );
+            },
+            $data['tomes'],
+        ));
+
+        /** @var list<string> $authors */
+        $authors = \is_array($data['authors'] ?? null) ? \array_values($data['authors']) : [];
+
+        /** @var list<int> $sourceSeriesIds */
+        $sourceSeriesIds = \array_values(\array_map('\intval', $data['sourceSeriesIds']));
+
+        return new MergePreview(
+            authors: $authors,
+            coverUrl: isset($data['coverUrl']) && \is_string($data['coverUrl']) ? $data['coverUrl'] : null,
+            description: isset($data['description']) && \is_string($data['description']) ? $data['description'] : null,
+            isOneShot: (bool) ($data['isOneShot'] ?? false),
+            latestPublishedIssue: isset($data['latestPublishedIssue']) && \is_numeric($data['latestPublishedIssue']) ? (int) $data['latestPublishedIssue'] : null,
+            latestPublishedIssueComplete: (bool) ($data['latestPublishedIssueComplete'] ?? false),
+            publisher: isset($data['publisher']) && \is_string($data['publisher']) ? $data['publisher'] : null,
+            sourceSeriesIds: $sourceSeriesIds,
+            title: $data['title'],
+            tomes: $tomes,
+            type: $data['type'],
+        );
+    }
+}

--- a/backend/src/Service/Merge/SeriesGroupDetector.php
+++ b/backend/src/Service/Merge/SeriesGroupDetector.php
@@ -8,6 +8,7 @@ use App\DTO\MergeGroup;
 use App\DTO\MergeGroupEntry;
 use App\Entity\ComicSeries;
 use App\Service\Lookup\GeminiClientPool;
+use App\Service\Lookup\GeminiJsonParser;
 use Gemini\Data\GoogleSearch;
 use Gemini\Data\Tool;
 use Psr\Log\LoggerInterface;
@@ -17,7 +18,7 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 /**
  * Détecte les groupes de séries qui devraient être fusionnées via Gemini.
  */
-class SeriesGroupDetector
+final class SeriesGroupDetector
 {
     private const int MAX_BATCH_SIZE = 50;
 
@@ -144,7 +145,7 @@ class SeriesGroupDetector
             return [];
         }
 
-        $data = $this->parseJsonFromText($text);
+        $data = GeminiJsonParser::parseJsonFromText($text);
         if (null === $data) {
             $this->logger->warning('Réponse Gemini non parseable pour la détection de groupes.', [
                 'response' => $text,
@@ -186,23 +187,6 @@ class SeriesGroupDetector
             Titres :
             {$titlesList}
             PROMPT;
-    }
-
-    /**
-     * Parse une réponse JSON potentiellement enveloppée dans un bloc markdown.
-     *
-     * @return array<mixed>|null
-     */
-    private function parseJsonFromText(string $text): ?array
-    {
-        $cleaned = \preg_replace('/^```(?:json)?\s*\n?(.*?)\n?```$/s', '$1', \trim($text));
-        $data = \json_decode($cleaned ?? $text, true);
-
-        if (!\is_array($data)) {
-            return null;
-        }
-
-        return $data;
     }
 
     /**

--- a/backend/src/Service/PurgeService.php
+++ b/backend/src/Service/PurgeService.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\EntityManagerInterface;
 /**
  * Service de purge des séries soft-deleted.
  */
-class PurgeService
+final class PurgeService
 {
     public function __construct(
         private readonly ComicSeriesRepository $comicSeriesRepository,
@@ -59,19 +59,7 @@ class PurgeService
      */
     public function findPurgeable(int $days): array
     {
-        $cutoffDate = new \DateTime(\sprintf('-%d days', $days));
-
-        $this->entityManager->getFilters()->disable('soft_delete');
-
-        /** @var ComicSeries[] $series */
-        $series = $this->comicSeriesRepository->createQueryBuilder('c')
-            ->where('c.deletedAt IS NOT NULL')
-            ->andWhere('c.deletedAt <= :cutoff')
-            ->setParameter('cutoff', $cutoffDate)
-            ->getQuery()
-            ->getResult();
-
-        $this->entityManager->getFilters()->enable('soft_delete');
+        $series = $this->comicSeriesRepository->findPurgeable($days);
 
         return \array_map(
             static function (ComicSeries $s): PurgeableSeries {

--- a/backend/src/State/TrashCollectionProvider.php
+++ b/backend/src/State/TrashCollectionProvider.php
@@ -8,12 +8,11 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\Entity\ComicSeries;
 use App\Repository\ComicSeriesRepository;
-use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Provider pour la collection de séries supprimées (corbeille).
  *
- * Désactive le filtre soft-delete et retourne uniquement les séries avec deleted_at != NULL.
+ * Délègue au repository qui gère la désactivation du filtre soft-delete.
  *
  * @implements ProviderInterface<ComicSeries>
  */
@@ -21,7 +20,6 @@ final readonly class TrashCollectionProvider implements ProviderInterface
 {
     public function __construct(
         private ComicSeriesRepository $comicSeriesRepository,
-        private EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -30,19 +28,6 @@ final readonly class TrashCollectionProvider implements ProviderInterface
      */
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): array
     {
-        $this->entityManager->getFilters()->disable('soft_delete');
-
-        try {
-            /** @var array<int, ComicSeries> $comics */
-            $comics = $this->comicSeriesRepository->createQueryBuilder('c')
-                ->where('c.deletedAt IS NOT NULL')
-                ->orderBy('c.deletedAt', 'DESC')
-                ->getQuery()
-                ->getResult();
-        } finally {
-            $this->entityManager->getFilters()->enable('soft_delete');
-        }
-
-        return $comics;
+        return $this->comicSeriesRepository->findTrashed();
     }
 }

--- a/backend/tests/Integration/Repository/ComicSeriesRepositoryTest.php
+++ b/backend/tests/Integration/Repository/ComicSeriesRepositoryTest.php
@@ -790,6 +790,85 @@ final class ComicSeriesRepositoryTest extends KernelTestCase
         self::assertSame('Asterix', $result[0]->getTitle());
     }
 
+    // ---------------------------------------------------------------
+    // findPurgeable
+    // ---------------------------------------------------------------
+
+    public function testFindPurgeableReturnsSeriesDeletedBeforeCutoff(): void
+    {
+        $old = EntityFactory::createComicSeries('Old Deleted');
+        $old->delete();
+        // Simuler une suppression il y a 60 jours
+        $reflection = new \ReflectionProperty($old, 'deletedAt');
+        $reflection->setValue($old, new \DateTime('-60 days'));
+
+        $recent = EntityFactory::createComicSeries('Recent Deleted');
+        $recent->delete();
+
+        $active = EntityFactory::createComicSeries('Active');
+
+        $this->em->persist($old);
+        $this->em->persist($recent);
+        $this->em->persist($active);
+        $this->em->flush();
+
+        $result = $this->repository->findPurgeable(30);
+
+        self::assertCount(1, $result);
+        self::assertSame('Old Deleted', $result[0]->getTitle());
+    }
+
+    public function testFindPurgeableReturnsEmptyWhenNoPurgeableSeries(): void
+    {
+        $active = EntityFactory::createComicSeries('Active');
+        $this->em->persist($active);
+        $this->em->flush();
+
+        $result = $this->repository->findPurgeable(30);
+
+        self::assertSame([], $result);
+    }
+
+    // ---------------------------------------------------------------
+    // findTrashed
+    // ---------------------------------------------------------------
+
+    public function testFindTrashedReturnsSoftDeletedOrderedByDeletedAtDesc(): void
+    {
+        $deleted1 = EntityFactory::createComicSeries('First Deleted');
+        $deleted1->delete();
+        $reflection = new \ReflectionProperty($deleted1, 'deletedAt');
+        $reflection->setValue($deleted1, new \DateTime('-2 days'));
+
+        $deleted2 = EntityFactory::createComicSeries('Second Deleted');
+        $deleted2->delete();
+
+        $active = EntityFactory::createComicSeries('Active');
+
+        $this->em->persist($deleted1);
+        $this->em->persist($deleted2);
+        $this->em->persist($active);
+        $this->em->flush();
+
+        $result = $this->repository->findTrashed();
+
+        self::assertCount(2, $result);
+        // Le plus récemment supprimé en premier
+        self::assertSame('Second Deleted', $result[0]->getTitle());
+        self::assertSame('First Deleted', $result[1]->getTitle());
+    }
+
+    public function testFindTrashedReturnsEmptyWhenNoDeletedSeries(): void
+    {
+        $active = EntityFactory::createComicSeries('Active');
+        $this->em->persist($active);
+        $this->em->flush();
+
+        $result = $this->repository->findTrashed();
+
+        self::assertSame([], $result);
+    }
+
     public function testFindWithMissingLookupDataForceIgnoresLookupCompletedAt(): void
     {
         $alreadyLooked = EntityFactory::createComicSeries('Already Looked');

--- a/backend/tests/Unit/Enum/BatchLookupStatusTest.php
+++ b/backend/tests/Unit/Enum/BatchLookupStatusTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Enum;
+
+use App\Enum\BatchLookupStatus;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires pour l'enum BatchLookupStatus.
+ */
+final class BatchLookupStatusTest extends TestCase
+{
+    // ---------------------------------------------------------------
+    // Valeurs des cases
+    // ---------------------------------------------------------------
+
+    public function testFailedValue(): void
+    {
+        self::assertSame('failed', BatchLookupStatus::FAILED->value);
+    }
+
+    public function testSkippedValue(): void
+    {
+        self::assertSame('skipped', BatchLookupStatus::SKIPPED->value);
+    }
+
+    public function testUpdatedValue(): void
+    {
+        self::assertSame('updated', BatchLookupStatus::UPDATED->value);
+    }
+
+    // ---------------------------------------------------------------
+    // Labels
+    // ---------------------------------------------------------------
+
+    public function testFailedLabel(): void
+    {
+        self::assertSame('Échoué', BatchLookupStatus::FAILED->getLabel());
+    }
+
+    public function testSkippedLabel(): void
+    {
+        self::assertSame('Ignoré', BatchLookupStatus::SKIPPED->getLabel());
+    }
+
+    public function testUpdatedLabel(): void
+    {
+        self::assertSame('Mis à jour', BatchLookupStatus::UPDATED->getLabel());
+    }
+
+    // ---------------------------------------------------------------
+    // Nombre de cases
+    // ---------------------------------------------------------------
+
+    public function testCaseCount(): void
+    {
+        self::assertCount(3, BatchLookupStatus::cases());
+    }
+
+    // ---------------------------------------------------------------
+    // Instanciation depuis la valeur
+    // ---------------------------------------------------------------
+
+    public function testFromValue(): void
+    {
+        self::assertSame(BatchLookupStatus::FAILED, BatchLookupStatus::from('failed'));
+        self::assertSame(BatchLookupStatus::SKIPPED, BatchLookupStatus::from('skipped'));
+        self::assertSame(BatchLookupStatus::UPDATED, BatchLookupStatus::from('updated'));
+    }
+
+    public function testTryFromInvalidValueReturnsNull(): void
+    {
+        self::assertNull(BatchLookupStatus::tryFrom('invalid')); // @phpstan-ignore staticMethod.alreadyNarrowedType
+    }
+}

--- a/backend/tests/Unit/Service/BatchLookupServiceTest.php
+++ b/backend/tests/Unit/Service/BatchLookupServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Service;
 
 use App\DTO\BatchLookupProgress;
+use App\Enum\BatchLookupStatus;
 use App\Enum\ComicType;
 use App\Repository\ComicSeriesRepository;
 use App\Service\BatchLookupService;
@@ -94,7 +95,7 @@ final class BatchLookupServiceTest extends TestCase
         self::assertSame(1, $progress->current);
         self::assertSame(1, $progress->total);
         self::assertSame('Naruto', $progress->seriesTitle);
-        self::assertSame('updated', $progress->status);
+        self::assertSame(BatchLookupStatus::UPDATED, $progress->status);
         self::assertSame(['description', 'publisher'], $progress->updatedFields);
     }
 
@@ -118,7 +119,7 @@ final class BatchLookupServiceTest extends TestCase
         $progressItems = \iterator_to_array($this->service->run(delay: 0));
 
         self::assertCount(1, $progressItems);
-        self::assertSame('skipped', $progressItems[0]->status);
+        self::assertSame(BatchLookupStatus::SKIPPED, $progressItems[0]->status);
     }
 
     #[Test]
@@ -147,7 +148,7 @@ final class BatchLookupServiceTest extends TestCase
         $progressItems = \iterator_to_array($this->service->run(delay: 0));
 
         self::assertCount(1, $progressItems);
-        self::assertSame('skipped', $progressItems[0]->status);
+        self::assertSame(BatchLookupStatus::SKIPPED, $progressItems[0]->status);
     }
 
     #[Test]
@@ -175,7 +176,7 @@ final class BatchLookupServiceTest extends TestCase
         $progressItems = \iterator_to_array($this->service->run(delay: 0));
 
         self::assertCount(1, $progressItems);
-        self::assertSame('failed', $progressItems[0]->status);
+        self::assertSame(BatchLookupStatus::FAILED, $progressItems[0]->status);
     }
 
     #[Test]

--- a/backend/tests/Unit/Service/Lookup/GeminiJsonParserTest.php
+++ b/backend/tests/Unit/Service/Lookup/GeminiJsonParserTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Lookup;
+
+use App\Service\Lookup\GeminiJsonParser;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires pour GeminiJsonParser.
+ */
+final class GeminiJsonParserTest extends TestCase
+{
+    #[Test]
+    public function parsesPlainJson(): void
+    {
+        $result = GeminiJsonParser::parseJsonFromText('{"key": "value"}');
+        self::assertSame(['key' => 'value'], $result);
+    }
+
+    #[Test]
+    public function parsesJsonWrappedInMarkdownCodeBlock(): void
+    {
+        $text = "```json\n{\"key\": \"value\"}\n```";
+        $result = GeminiJsonParser::parseJsonFromText($text);
+        self::assertSame(['key' => 'value'], $result);
+    }
+
+    #[Test]
+    public function parsesCodeBlockWithoutLanguageHint(): void
+    {
+        $text = "```\n{\"key\": \"value\"}\n```";
+        $result = GeminiJsonParser::parseJsonFromText($text);
+        self::assertSame(['key' => 'value'], $result);
+    }
+
+    #[Test]
+    public function returnsNullForInvalidJson(): void
+    {
+        self::assertNull(GeminiJsonParser::parseJsonFromText('not json'));
+    }
+
+    #[Test]
+    public function returnsNullForScalarJson(): void
+    {
+        self::assertNull(GeminiJsonParser::parseJsonFromText('"just a string"'));
+    }
+
+    #[Test]
+    public function handlesWhitespace(): void
+    {
+        $text = "  \n```json\n  {\"a\": 1}  \n```\n  ";
+        $result = GeminiJsonParser::parseJsonFromText($text);
+        self::assertSame(['a' => 1], $result);
+    }
+
+    #[Test]
+    public function parsesArray(): void
+    {
+        $result = GeminiJsonParser::parseJsonFromText('[{"a": 1}, {"b": 2}]');
+        self::assertSame([['a' => 1], ['b' => 2]], $result);
+    }
+}

--- a/backend/tests/Unit/Service/Lookup/GoogleBooksUrlHelperTest.php
+++ b/backend/tests/Unit/Service/Lookup/GoogleBooksUrlHelperTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Lookup;
+
+use App\Service\Lookup\GoogleBooksUrlHelper;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires pour GoogleBooksUrlHelper.
+ */
+final class GoogleBooksUrlHelperTest extends TestCase
+{
+    #[Test]
+    public function nonGoogleBooksUrlIsReturnedAsIs(): void
+    {
+        $url = 'https://example.com/image.jpg';
+        self::assertSame($url, GoogleBooksUrlHelper::optimizeThumbnailUrl($url));
+    }
+
+    #[Test]
+    public function httpIsUpgradedToHttps(): void
+    {
+        $url = 'http://books.google.com/books/content?id=abc&zoom=0';
+        $result = GoogleBooksUrlHelper::optimizeThumbnailUrl($url);
+        self::assertStringStartsWith('https://', $result);
+    }
+
+    #[Test]
+    public function zoomOneIsReplacedByZoomZero(): void
+    {
+        $url = 'https://books.google.com/books/content?id=abc&zoom=1';
+        $result = GoogleBooksUrlHelper::optimizeThumbnailUrl($url);
+        self::assertStringContainsString('zoom=0', $result);
+        self::assertStringNotContainsString('zoom=1', $result);
+    }
+
+    #[Test]
+    public function edgeCurlIsRemoved(): void
+    {
+        $url = 'https://books.google.com/books/content?id=abc&edge=curl&zoom=1';
+        $result = GoogleBooksUrlHelper::optimizeThumbnailUrl($url);
+        self::assertStringNotContainsString('edge=curl', $result);
+    }
+
+    #[Test]
+    public function trailingAmpersandIsRemoved(): void
+    {
+        $url = 'https://books.google.com/books/content?id=abc&edge=curl';
+        $result = GoogleBooksUrlHelper::optimizeThumbnailUrl($url);
+        self::assertStringEndsNotWith('&', $result);
+    }
+
+    #[Test]
+    public function fullOptimization(): void
+    {
+        $url = 'http://books.google.com/books/content?id=abc&zoom=1&edge=curl';
+        $expected = 'https://books.google.com/books/content?id=abc&zoom=0';
+        self::assertSame($expected, GoogleBooksUrlHelper::optimizeThumbnailUrl($url));
+    }
+}

--- a/backend/tests/Unit/Service/Merge/MergePreviewHydratorTest.php
+++ b/backend/tests/Unit/Service/Merge/MergePreviewHydratorTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Merge;
+
+use App\DTO\MergePreview;
+use App\Service\Merge\MergePreviewHydrator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires pour MergePreviewHydrator.
+ */
+final class MergePreviewHydratorTest extends TestCase
+{
+    private MergePreviewHydrator $hydrator;
+
+    protected function setUp(): void
+    {
+        $this->hydrator = new MergePreviewHydrator();
+    }
+
+    #[Test]
+    public function hydrateReturnsValidMergePreview(): void
+    {
+        $data = [
+            'authors' => ['Oda'],
+            'coverUrl' => 'https://example.com/cover.jpg',
+            'description' => 'Un manga populaire',
+            'isOneShot' => false,
+            'latestPublishedIssue' => 100,
+            'latestPublishedIssueComplete' => true,
+            'publisher' => 'Glénat',
+            'sourceSeriesIds' => [1, 2, 3],
+            'title' => 'One Piece',
+            'tomes' => [
+                [
+                    'bought' => true,
+                    'downloaded' => false,
+                    'isbn' => '978-2-7234-1234-5',
+                    'number' => 1,
+                    'onNas' => true,
+                    'read' => true,
+                    'title' => 'Romance Dawn',
+                    'tomeEnd' => null,
+                ],
+            ],
+            'type' => 'manga',
+        ];
+
+        $result = $this->hydrator->hydrate($data);
+
+        self::assertInstanceOf(MergePreview::class, $result);
+        self::assertSame('One Piece', $result->title);
+        self::assertSame('manga', $result->type);
+        self::assertSame([1, 2, 3], $result->sourceSeriesIds);
+        self::assertSame(['Oda'], $result->authors);
+        self::assertSame('https://example.com/cover.jpg', $result->coverUrl);
+        self::assertSame('Un manga populaire', $result->description);
+        self::assertFalse($result->isOneShot);
+        self::assertSame(100, $result->latestPublishedIssue);
+        self::assertTrue($result->latestPublishedIssueComplete);
+        self::assertSame('Glénat', $result->publisher);
+        self::assertCount(1, $result->tomes);
+        self::assertSame(1, $result->tomes[0]->number);
+        self::assertSame('Romance Dawn', $result->tomes[0]->title);
+        self::assertTrue($result->tomes[0]->bought);
+        self::assertSame('978-2-7234-1234-5', $result->tomes[0]->isbn);
+    }
+
+    #[Test]
+    public function hydrateThrowsWhenMissingTitle(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('title');
+
+        $this->hydrator->hydrate([
+            'sourceSeriesIds' => [1],
+            'tomes' => [],
+            'type' => 'manga',
+        ]);
+    }
+
+    #[Test]
+    public function hydrateThrowsWhenMissingType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('type');
+
+        $this->hydrator->hydrate([
+            'sourceSeriesIds' => [1],
+            'title' => 'Test',
+            'tomes' => [],
+        ]);
+    }
+
+    #[Test]
+    public function hydrateThrowsWhenMissingSourceSeriesIds(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('sourceSeriesIds');
+
+        $this->hydrator->hydrate([
+            'title' => 'Test',
+            'tomes' => [],
+            'type' => 'manga',
+        ]);
+    }
+
+    #[Test]
+    public function hydrateThrowsWhenMissingTomes(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('tomes');
+
+        $this->hydrator->hydrate([
+            'sourceSeriesIds' => [1],
+            'title' => 'Test',
+            'type' => 'manga',
+        ]);
+    }
+
+    #[Test]
+    public function hydrateHandlesMinimalTomeData(): void
+    {
+        $data = [
+            'sourceSeriesIds' => [1],
+            'title' => 'Test',
+            'tomes' => [
+                ['number' => 1],
+            ],
+            'type' => 'bd',
+        ];
+
+        $result = $this->hydrator->hydrate($data);
+
+        self::assertCount(1, $result->tomes);
+        self::assertSame(1, $result->tomes[0]->number);
+        self::assertFalse($result->tomes[0]->bought);
+        self::assertNull($result->tomes[0]->isbn);
+        self::assertNull($result->tomes[0]->title);
+    }
+
+    #[Test]
+    public function hydrateHandlesOptionalFieldsDefault(): void
+    {
+        $data = [
+            'sourceSeriesIds' => [1],
+            'title' => 'Test',
+            'tomes' => [],
+            'type' => 'bd',
+        ];
+
+        $result = $this->hydrator->hydrate($data);
+
+        self::assertNull($result->coverUrl);
+        self::assertNull($result->description);
+        self::assertFalse($result->isOneShot);
+        self::assertNull($result->latestPublishedIssue);
+        self::assertFalse($result->latestPublishedIssueComplete);
+        self::assertNull($result->publisher);
+        self::assertSame([], $result->authors);
+    }
+}

--- a/backend/tests/Unit/State/TrashCollectionProviderTest.php
+++ b/backend/tests/Unit/State/TrashCollectionProviderTest.php
@@ -8,10 +8,6 @@ use ApiPlatform\Metadata\Operation;
 use App\Entity\ComicSeries;
 use App\Repository\ComicSeriesRepository;
 use App\State\TrashCollectionProvider;
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Query;
-use Doctrine\ORM\Query\FilterCollection;
-use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -19,43 +15,19 @@ use PHPUnit\Framework\TestCase;
  */
 final class TrashCollectionProviderTest extends TestCase
 {
-    private ComicSeriesRepository $repository;
-
-    protected function setUp(): void
-    {
-        $this->repository = $this->createStub(ComicSeriesRepository::class);
-    }
-
-    public function testProvideReturnsDeletedComics(): void
+    public function testProvideDelegatesToRepository(): void
     {
         $comic1 = new ComicSeries();
         $comic2 = new ComicSeries();
         $expectedResult = [$comic1, $comic2];
 
-        $query = $this->createStub(Query::class);
-        $query->method('getResult')->willReturn($expectedResult);
-
-        $queryBuilder = $this->createStub(QueryBuilder::class);
-        $queryBuilder->method('where')->willReturn($queryBuilder);
-        $queryBuilder->method('orderBy')->willReturn($queryBuilder);
-        $queryBuilder->method('getQuery')->willReturn($query);
-
-        $this->repository
-            ->method('createQueryBuilder')
-            ->willReturn($queryBuilder);
-
-        $filterCollection = $this->createMock(FilterCollection::class);
-        $filterCollection
+        $repository = $this->createMock(ComicSeriesRepository::class);
+        $repository
             ->expects(self::once())
-            ->method('disable')
-            ->with('soft_delete');
+            ->method('findTrashed')
+            ->willReturn($expectedResult);
 
-        $filterCollection
-            ->expects(self::once())
-            ->method('enable')
-            ->with('soft_delete');
-
-        $provider = $this->createProvider($filterCollection);
+        $provider = new TrashCollectionProvider($repository);
         $operation = $this->createStub(Operation::class);
 
         $result = $provider->provide($operation);
@@ -65,66 +37,17 @@ final class TrashCollectionProviderTest extends TestCase
 
     public function testProvideReturnsEmptyArrayWhenNoDeletedComics(): void
     {
-        $query = $this->createStub(Query::class);
-        $query->method('getResult')->willReturn([]);
+        $repository = $this->createMock(ComicSeriesRepository::class);
+        $repository
+            ->expects(self::once())
+            ->method('findTrashed')
+            ->willReturn([]);
 
-        $queryBuilder = $this->createStub(QueryBuilder::class);
-        $queryBuilder->method('where')->willReturn($queryBuilder);
-        $queryBuilder->method('orderBy')->willReturn($queryBuilder);
-        $queryBuilder->method('getQuery')->willReturn($query);
-
-        $this->repository
-            ->method('createQueryBuilder')
-            ->willReturn($queryBuilder);
-
-        $provider = $this->createProvider($this->createStub(FilterCollection::class));
+        $provider = new TrashCollectionProvider($repository);
         $operation = $this->createStub(Operation::class);
 
         $result = $provider->provide($operation);
 
         self::assertSame([], $result);
-    }
-
-    public function testProvideReEnablesFilterEvenOnException(): void
-    {
-        $queryBuilder = $this->createStub(QueryBuilder::class);
-        $queryBuilder->method('where')->willReturn($queryBuilder);
-        $queryBuilder->method('orderBy')->willReturn($queryBuilder);
-        $queryBuilder->method('getQuery')->willThrowException(new \RuntimeException('DB error'));
-
-        $this->repository
-            ->method('createQueryBuilder')
-            ->willReturn($queryBuilder);
-
-        $filterCollection = $this->createMock(FilterCollection::class);
-        $filterCollection
-            ->expects(self::once())
-            ->method('disable')
-            ->with('soft_delete');
-
-        $filterCollection
-            ->expects(self::once())
-            ->method('enable')
-            ->with('soft_delete');
-
-        $provider = $this->createProvider($filterCollection);
-        $operation = $this->createStub(Operation::class);
-
-        $this->expectException(\RuntimeException::class);
-
-        $provider->provide($operation);
-    }
-
-    private function createProvider(FilterCollection $filterCollection): TrashCollectionProvider
-    {
-        $entityManager = $this->createStub(EntityManagerInterface::class);
-        $entityManager
-            ->method('getFilters')
-            ->willReturn($filterCollection);
-
-        return new TrashCollectionProvider(
-            $this->repository,
-            $entityManager,
-        );
     }
 }


### PR DESCRIPTION
## Summary

- Ajoute `final` sur ~45 classes feuilles (services, controllers, commands, listeners, DTOs, state processors)
- Extrait `GoogleBooksUrlHelper`, `GeminiJsonParser` et `MergePreviewHydrator` pour éliminer les duplications
- Déplace les requêtes de `PurgeService` et `TrashCollectionProvider` dans `ComicSeriesRepository`
- Injecte `UserRepository` dans `InvalidateTokensCommand` au lieu de `EntityManagerInterface::getRepository()`
- Crée l'enum `BatchLookupStatus` (FAILED, SKIPPED, UPDATED) pour remplacer les magic strings
- Ajoute la constante `CACHE_TTL` dans `AbstractGeminiLookupProvider`

fixes #167

## Test plan

- [x] 790 tests PHPUnit passent (dont 4 nouveaux tests d'intégration et 4 nouvelles suites unitaires)
- [x] PHPStan : 0 erreur
- [x] PHP CS Fixer : aucune correction restante
- [x] Aucun changement de comportement — refactoring structurel uniquement