### PR TITLE
fix(filters): remplace les dropdowns tronqués par un drawer mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 ### Fixed
 
 - **Vignettes en production** : CSP `connect-src` autorise désormais `https:` pour les couvertures externes, et priorité aux fichiers locaux dans le frontend (#180)
+- **Filtres mobile** : Remplacement des dropdowns tronqués par un bouton icône ouvrant un bottom sheet avec des `<select>` natifs, suppression du scroll horizontal (#181, #183)
 
 ### Changed
 

--- a/frontend/src/__tests__/integration/components/Filters.test.tsx
+++ b/frontend/src/__tests__/integration/components/Filters.test.tsx
@@ -3,12 +3,27 @@ import userEvent from "@testing-library/user-event";
 import Filters from "../../../components/Filters";
 import { renderWithProviders } from "../../helpers/test-utils";
 
+function mockMatchMedia(mobile: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      addEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      matches: mobile && query === "(max-width: 639px)",
+      media: query,
+      onchange: null,
+      removeEventListener: vi.fn(),
+    })),
+    writable: true,
+  });
+}
+
 describe("Filters", () => {
   const defaultProps = {
     onSortChange: vi.fn(),
     onStatusChange: vi.fn(),
     onTypeChange: vi.fn(),
-    sort: "title-asc",
+    sort: "title-asc" as const,
     status: "",
     type: "",
   };
@@ -19,85 +34,181 @@ describe("Filters", () => {
     defaultProps.onTypeChange = vi.fn();
   });
 
-  it("renders type filter with default label", () => {
-    renderWithProviders(<Filters {...defaultProps} />);
+  describe("Desktop (>= 640px)", () => {
+    beforeEach(() => mockMatchMedia(false));
 
-    expect(screen.getByText("Tous les types")).toBeInTheDocument();
+    it("renders type filter with default label", () => {
+      renderWithProviders(<Filters {...defaultProps} />);
+
+      expect(screen.getByText("Tous les types")).toBeInTheDocument();
+    });
+
+    it("renders status filter with default label", () => {
+      renderWithProviders(<Filters {...defaultProps} />);
+
+      expect(screen.getByText("Tous les statuts")).toBeInTheDocument();
+    });
+
+    it("calls onTypeChange when type filter is changed", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Filters {...defaultProps} />);
+
+      await user.click(screen.getByText("Tous les types"));
+      await user.click(screen.getByText("Manga"));
+
+      expect(defaultProps.onTypeChange).toHaveBeenCalledWith("manga");
+    });
+
+    it("calls onStatusChange when status filter is changed", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Filters {...defaultProps} />);
+
+      await user.click(screen.getByText("Tous les statuts"));
+      await user.click(screen.getByText("Terminé"));
+
+      expect(defaultProps.onStatusChange).toHaveBeenCalledWith("finished");
+    });
+
+    it("shows selected type label", () => {
+      renderWithProviders(<Filters {...defaultProps} type="manga" />);
+
+      expect(screen.getByText("Manga")).toBeInTheDocument();
+    });
+
+    it("shows selected status label", () => {
+      renderWithProviders(<Filters {...defaultProps} status="buying" />);
+
+      expect(screen.getByText("En cours d'achat")).toBeInTheDocument();
+    });
+
+    it("calls onTypeChange with empty string when selecting 'Tous les types'", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Filters {...defaultProps} type="manga" />);
+
+      await user.click(screen.getByText("Manga"));
+      await user.click(screen.getByText("Tous les types"));
+
+      expect(defaultProps.onTypeChange).toHaveBeenCalledWith("");
+    });
+
+    it("renders sort selector with default label", () => {
+      renderWithProviders(<Filters {...defaultProps} />);
+
+      expect(screen.getByText("Titre A→Z")).toBeInTheDocument();
+    });
+
+    it("calls onSortChange when sort option is changed", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Filters {...defaultProps} />);
+
+      await user.click(screen.getByText("Titre A→Z"));
+      await user.click(screen.getByText("Plus récent"));
+
+      expect(defaultProps.onSortChange).toHaveBeenCalledWith("createdAt-desc");
+    });
+
+    it("shows selected sort label", () => {
+      renderWithProviders(<Filters {...defaultProps} sort="tomes-desc" />);
+
+      expect(screen.getByText("Plus de tomes")).toBeInTheDocument();
+    });
+
+    it("does not render mobile filter button", () => {
+      renderWithProviders(<Filters {...defaultProps} />);
+
+      expect(screen.queryByTestId("filters-button")).not.toBeInTheDocument();
+    });
   });
 
-  it("renders status filter with default label", () => {
-    renderWithProviders(<Filters {...defaultProps} />);
+  describe("Mobile (< 640px)", () => {
+    beforeEach(() => mockMatchMedia(true));
 
-    expect(screen.getByText("Tous les statuts")).toBeInTheDocument();
-  });
+    it("renders icon button instead of Listbox dropdowns", () => {
+      renderWithProviders(<Filters {...defaultProps} />);
 
-  it("calls onTypeChange when type filter is changed", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<Filters {...defaultProps} />);
+      expect(screen.getByTestId("filters-button")).toBeInTheDocument();
+      expect(screen.queryByText("Tous les types")).not.toBeInTheDocument();
+      expect(screen.queryByText("Tous les statuts")).not.toBeInTheDocument();
+    });
 
-    // Open the type listbox
-    await user.click(screen.getByText("Tous les types"));
-    // Select "Manga"
-    await user.click(screen.getByText("Manga"));
+    it("shows indicator dot when filters are active", () => {
+      renderWithProviders(<Filters {...defaultProps} status="buying" type="manga" />);
 
-    expect(defaultProps.onTypeChange).toHaveBeenCalledWith("manga");
-  });
+      expect(screen.getByTestId("filters-indicator")).toBeInTheDocument();
+    });
 
-  it("calls onStatusChange when status filter is changed", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<Filters {...defaultProps} />);
+    it("shows no indicator when no filters active", () => {
+      renderWithProviders(<Filters {...defaultProps} />);
 
-    // Open the status listbox
-    await user.click(screen.getByText("Tous les statuts"));
-    // Select a status option
-    await user.click(screen.getByText("Terminé"));
+      expect(screen.queryByTestId("filters-indicator")).not.toBeInTheDocument();
+    });
 
-    expect(defaultProps.onStatusChange).toHaveBeenCalledWith("finished");
-  });
+    it("shows indicator with only type active", () => {
+      renderWithProviders(<Filters {...defaultProps} type="manga" />);
 
-  it("shows selected type label", () => {
-    renderWithProviders(<Filters {...defaultProps} type="manga" />);
+      expect(screen.getByTestId("filters-indicator")).toBeInTheDocument();
+    });
 
-    expect(screen.getByText("Manga")).toBeInTheDocument();
-  });
+    it("opens drawer on button click with 3 select elements", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Filters {...defaultProps} />);
 
-  it("shows selected status label", () => {
-    renderWithProviders(<Filters {...defaultProps} status="buying" />);
+      await user.click(screen.getByTestId("filters-button"));
 
-    expect(screen.getByText("En cours d'achat")).toBeInTheDocument();
-  });
+      expect(screen.getByText("Type")).toBeInTheDocument();
+      expect(screen.getByText("Statut")).toBeInTheDocument();
+      expect(screen.getByText("Tri")).toBeInTheDocument();
 
-  it("calls onTypeChange with empty string when selecting 'Tous les types'", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<Filters {...defaultProps} type="manga" />);
+      const selects = screen.getAllByRole("combobox");
+      expect(selects).toHaveLength(3);
+    });
 
-    // Open type filter (currently showing "Manga")
-    await user.click(screen.getByText("Manga"));
-    // Select "Tous les types"
-    await user.click(screen.getByText("Tous les types"));
+    it("calls onTypeChange when selecting a type in drawer", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Filters {...defaultProps} />);
 
-    expect(defaultProps.onTypeChange).toHaveBeenCalledWith("");
-  });
+      await user.click(screen.getByTestId("filters-button"));
 
-  it("renders sort selector with default label", () => {
-    renderWithProviders(<Filters {...defaultProps} />);
+      const typeSelect = screen.getAllByRole("combobox")[0];
+      await user.selectOptions(typeSelect, "manga");
 
-    expect(screen.getByText("Titre A→Z")).toBeInTheDocument();
-  });
+      expect(defaultProps.onTypeChange).toHaveBeenCalledWith("manga");
+    });
 
-  it("calls onSortChange when sort option is changed", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<Filters {...defaultProps} />);
+    it("calls onStatusChange when selecting a status in drawer", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Filters {...defaultProps} />);
 
-    await user.click(screen.getByText("Titre A→Z"));
-    await user.click(screen.getByText("Plus récent"));
+      await user.click(screen.getByTestId("filters-button"));
 
-    expect(defaultProps.onSortChange).toHaveBeenCalledWith("createdAt-desc");
-  });
+      const statusSelect = screen.getAllByRole("combobox")[1];
+      await user.selectOptions(statusSelect, "finished");
 
-  it("shows selected sort label", () => {
-    renderWithProviders(<Filters {...defaultProps} sort="tomes-desc" />);
+      expect(defaultProps.onStatusChange).toHaveBeenCalledWith("finished");
+    });
 
-    expect(screen.getByText("Plus de tomes")).toBeInTheDocument();
+    it("calls onSortChange when selecting a sort in drawer", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Filters {...defaultProps} />);
+
+      await user.click(screen.getByTestId("filters-button"));
+
+      const sortSelect = screen.getAllByRole("combobox")[2];
+      await user.selectOptions(sortSelect, "createdAt-desc");
+
+      expect(defaultProps.onSortChange).toHaveBeenCalledWith("createdAt-desc");
+    });
+
+    it("closes drawer when clicking close button", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Filters {...defaultProps} />);
+
+      await user.click(screen.getByTestId("filters-button"));
+      expect(screen.getByText("Type")).toBeInTheDocument();
+
+      await user.click(screen.getByLabelText("Fermer"));
+
+      expect(screen.queryByText("Type")).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/Filters.tsx
+++ b/frontend/src/components/Filters.tsx
@@ -1,10 +1,14 @@
 import {
+  Dialog,
+  DialogPanel,
   Listbox,
   ListboxButton,
   ListboxOption,
   ListboxOptions,
 } from "@headlessui/react";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, SlidersHorizontal, X } from "lucide-react";
+import { useState } from "react";
+import { useMediaQuery } from "../hooks/useMediaQuery";
 import {
   ComicStatus,
   ComicStatusLabel,
@@ -91,6 +95,85 @@ function SelectListbox({
   );
 }
 
+function FilterSelect({
+  label,
+  onChange,
+  options,
+  value,
+}: {
+  label: string;
+  onChange: (v: string) => void;
+  options: Option[];
+  value: string;
+}) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-sm font-medium text-text-primary">{label}</span>
+      <select
+        className="w-full rounded-lg border border-surface-border bg-surface-primary px-3 py-2.5 text-sm text-text-primary focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+        onChange={(e) => onChange(e.target.value)}
+        value={value}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function FilterDrawer({
+  onClose,
+  onSortChange,
+  onStatusChange,
+  onTypeChange,
+  open,
+  sort,
+  status,
+  type,
+}: FiltersProps & { onClose: () => void; open: boolean }) {
+  return (
+    <Dialog onClose={onClose} open={open}>
+      <div className="fixed inset-0 z-40 bg-black/40" aria-hidden="true" />
+      <DialogPanel className="fixed inset-x-0 bottom-0 z-50 rounded-t-2xl bg-surface-primary p-5 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-text-primary">Filtres</h2>
+          <button
+            aria-label="Fermer"
+            className="rounded-lg p-1.5 text-text-muted hover:bg-surface-secondary"
+            onClick={onClose}
+            type="button"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="flex flex-col gap-4">
+          <FilterSelect
+            label="Type"
+            onChange={onTypeChange}
+            options={typeOptions}
+            value={type}
+          />
+          <FilterSelect
+            label="Statut"
+            onChange={onStatusChange}
+            options={statusOptions}
+            value={status}
+          />
+          <FilterSelect
+            label="Tri"
+            onChange={(v) => onSortChange(v as SortOption)}
+            options={sortOptions}
+            value={sort}
+          />
+        </div>
+      </DialogPanel>
+    </Dialog>
+  );
+}
+
 export default function Filters({
   onSortChange,
   onStatusChange,
@@ -99,6 +182,43 @@ export default function Filters({
   status,
   type,
 }: FiltersProps) {
+  const isMobile = useMediaQuery("(max-width: 639px)");
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  if (isMobile) {
+    const hasActiveFilters = type !== "" || status !== "";
+
+    return (
+      <>
+        <button
+          aria-label="Filtres"
+          className="relative shrink-0 rounded-lg border border-surface-border bg-surface-primary p-2 text-text-muted transition hover:border-primary-400 hover:text-text-primary"
+          data-testid="filters-button"
+          onClick={() => setDrawerOpen(true)}
+          type="button"
+        >
+          <SlidersHorizontal className="h-5 w-5" />
+          {hasActiveFilters && (
+            <span
+              className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-primary-500"
+              data-testid="filters-indicator"
+            />
+          )}
+        </button>
+        <FilterDrawer
+          onClose={() => setDrawerOpen(false)}
+          onSortChange={onSortChange}
+          onStatusChange={onStatusChange}
+          onTypeChange={onTypeChange}
+          open={drawerOpen}
+          sort={sort}
+          status={status}
+          type={type}
+        />
+      </>
+    );
+  }
+
   return (
     <div className="flex min-w-0 flex-1 items-center gap-3">
       <div className="min-w-0 flex-1">

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(query).matches;
+  });
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    setMatches(mql.matches);
+
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -10,6 +10,7 @@ import EmptyState from "../components/EmptyState";
 import Filters from "../components/Filters";
 import { useComics } from "../hooks/useComics";
 import { useDeleteComic } from "../hooks/useDeleteComic";
+import { useMediaQuery } from "../hooks/useMediaQuery";
 import type { ComicSeries } from "../types/api";
 import { searchComics } from "../utils/searchComics";
 import { sortComics } from "../utils/sortComics";
@@ -80,6 +81,7 @@ export default function Home() {
     [updateParam],
   );
 
+  const isMobile = useMediaQuery("(max-width: 639px)");
   const { data, isFetching, isLoading } = useComics();
   const deleteComic = useDeleteComic();
   const allComics = data?.member ?? [];
@@ -95,28 +97,28 @@ export default function Home() {
 
   return (
     <div className="space-y-4">
-      {/* Search bar */}
-      <div className="relative">
-        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" />
-        <input
-          className="w-full rounded-lg border border-surface-border bg-surface-primary py-2 pl-10 pr-4 text-sm text-text-primary placeholder:text-text-muted focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
-          onChange={(e) => handleSearchChange(e.target.value)}
-          placeholder="Rechercher par titre, auteur, éditeur…"
-          type="search"
-          value={search}
-        />
-      </div>
-
-      {/* Filters + count */}
-      <div className="flex items-center gap-3">
-        <Filters
-          onSortChange={handleSortChange}
-          onStatusChange={handleStatusChange}
-          onTypeChange={handleTypeChange}
-          sort={sort}
-          status={status}
-          type={type}
-        />
+      {/* Search bar + filter button (mobile) + count */}
+      <div className="flex items-center gap-2">
+        <div className="relative min-w-0 flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" />
+          <input
+            className="w-full rounded-lg border border-surface-border bg-surface-primary py-2 pl-10 pr-4 text-sm text-text-primary placeholder:text-text-muted focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+            onChange={(e) => handleSearchChange(e.target.value)}
+            placeholder="Rechercher par titre, auteur, éditeur…"
+            type="search"
+            value={search}
+          />
+        </div>
+        {isMobile && (
+          <Filters
+            onSortChange={handleSortChange}
+            onStatusChange={handleStatusChange}
+            onTypeChange={handleTypeChange}
+            sort={sort}
+            status={status}
+            type={type}
+          />
+        )}
         <span className="flex shrink-0 items-center gap-1.5 text-sm text-text-muted">
           {isFetching && !isLoading && (
             <Loader2 className="h-3.5 w-3.5 animate-spin" data-testid="search-loading" />
@@ -124,6 +126,20 @@ export default function Home() {
           {filtered.length}/{allComics.length}
         </span>
       </div>
+
+      {/* Desktop filters */}
+      {!isMobile && (
+        <div className="flex min-w-0 items-center gap-3">
+          <Filters
+            onSortChange={handleSortChange}
+            onStatusChange={handleStatusChange}
+            onTypeChange={handleTypeChange}
+            sort={sort}
+            status={status}
+            type={type}
+          />
+        </div>
+      )}
 
       {isLoading ? (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">


### PR DESCRIPTION
## Summary
- Sur mobile (< 640px), les 3 Listbox inline sont remplacés par un bouton icône intégré au champ de recherche, avec un indicateur (point coloré) quand des filtres sont actifs
- Le bouton ouvre un bottom sheet (Headless UI `Dialog`) contenant 3 `<select>` natifs (type, statut, tri)
- Le comportement desktop (>= 640px) reste strictement inchangé
- Nouveau hook `useMediaQuery` pour la détection responsive

## Test plan
- [x] 589 tests passent (dont 20 tests Filters : 11 desktop + 9 mobile)
- [x] `tsc --noEmit` clean
- [ ] Manuel : resize < 640px → bouton icône au bout de la barre de recherche, point si filtres actifs
- [ ] Manuel : tap → bottom sheet avec 3 selects natifs, sélection fonctionne
- [ ] Manuel : resize >= 640px → dropdowns Listbox classiques inchangés

Fixes #181, fixes #183