### PR TITLE
refactor(frontend): extrait les composants partagés et élimine les duplications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Frontend : extraction composants partagés** : `typeOptions`/`statusOptions` centralisés dans `enums.ts`, `getCoverSrc` dans `coverUtils.ts`, labels de sync dans `syncLabels.ts`, `SelectListbox` réutilisable, et `ComicForm.tsx` découpé en `useComicForm`, `TomeTable`, `LookupSection`, `AuthorAutocomplete` (1180 → 398 lignes) (#169)
+
 ### Added
 
 - **CI GitHub Actions** : Workflow lint (PHPStan, CS Fixer, TypeScript) + tests (PHPUnit, Vitest) sur chaque PR, avec protection de la branche `main` (#166)

--- a/frontend/src/__tests__/integration/components/SelectListbox.test.tsx
+++ b/frontend/src/__tests__/integration/components/SelectListbox.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import SelectListbox from "../../../components/SelectListbox";
+
+const options = [
+  { label: "Option A", value: "a" },
+  { label: "Option B", value: "b" },
+  { label: "Option C", value: "c" },
+];
+
+describe("SelectListbox", () => {
+  it("renders selected option label", () => {
+    render(<SelectListbox onChange={vi.fn()} options={options} value="b" />);
+    expect(screen.getByText("Option B")).toBeInTheDocument();
+  });
+
+  it("renders placeholder when no value matches and placeholder is set", () => {
+    render(
+      <SelectListbox
+        onChange={vi.fn()}
+        options={options}
+        placeholder="Choisir…"
+        value=""
+      />,
+    );
+    expect(screen.getByText("Choisir…")).toBeInTheDocument();
+  });
+
+  it("calls onChange when an option is selected", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SelectListbox onChange={onChange} options={options} value="a" />);
+
+    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByText("Option C"));
+
+    expect(onChange).toHaveBeenCalledWith("c");
+  });
+
+  it("renders label when provided", () => {
+    render(
+      <SelectListbox
+        label="Mon champ"
+        onChange={vi.fn()}
+        options={options}
+        value="a"
+      />,
+    );
+    expect(screen.getByText("Mon champ")).toBeInTheDocument();
+  });
+
+  it("falls back to first option when value doesn't match and no placeholder", () => {
+    render(<SelectListbox onChange={vi.fn()} options={options} value="z" />);
+    expect(screen.getByText("Option A")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/unit/types/enums.test.ts
+++ b/frontend/src/__tests__/unit/types/enums.test.ts
@@ -1,0 +1,44 @@
+import {
+  statusOptions,
+  statusOptionsAll,
+  typeOptions,
+  typeOptionsAll,
+} from "../../../types/enums";
+
+describe("typeOptions", () => {
+  it("contains all comic types without 'all' prefix", () => {
+    expect(typeOptions).toEqual([
+      { label: "BD", value: "bd" },
+      { label: "Comics", value: "comics" },
+      { label: "Livre", value: "livre" },
+      { label: "Manga", value: "manga" },
+    ]);
+  });
+
+  it("typeOptionsAll starts with 'Tous les types'", () => {
+    expect(typeOptionsAll[0]).toEqual({ label: "Tous les types", value: "" });
+    expect(typeOptionsAll.slice(1)).toEqual(typeOptions);
+  });
+});
+
+describe("statusOptions", () => {
+  it("contains all statuses without 'all' prefix", () => {
+    expect(statusOptions.map((o) => o.value)).toEqual(
+      expect.arrayContaining(["buying", "finished", "stopped", "wishlist"]),
+    );
+    expect(statusOptions).toHaveLength(4);
+  });
+
+  it("statusOptionsAll starts with 'Tous les statuts'", () => {
+    expect(statusOptionsAll[0]).toEqual({
+      label: "Tous les statuts",
+      value: "",
+    });
+    expect(statusOptionsAll.slice(1)).toEqual(statusOptions);
+  });
+
+  it("statusOptions are sorted alphabetically by label", () => {
+    const labels = statusOptions.map((o) => o.label);
+    expect(labels).toEqual([...labels].sort((a, b) => a.localeCompare(b)));
+  });
+});

--- a/frontend/src/__tests__/unit/utils/coverUtils.test.ts
+++ b/frontend/src/__tests__/unit/utils/coverUtils.test.ts
@@ -1,0 +1,26 @@
+import { getCoverSrc } from "../../../utils/coverUtils";
+
+describe("getCoverSrc", () => {
+  it("returns local path when coverImage is set", () => {
+    expect(getCoverSrc({ coverImage: "abc.jpg", coverUrl: "https://example.com/img.jpg" }))
+      .toBe("/uploads/covers/abc.jpg");
+  });
+
+  it("returns coverUrl when coverImage is null", () => {
+    expect(getCoverSrc({ coverImage: null, coverUrl: "https://example.com/img.jpg" }))
+      .toBe("https://example.com/img.jpg");
+  });
+
+  it("returns null when both are null", () => {
+    expect(getCoverSrc({ coverImage: null, coverUrl: null })).toBeNull();
+  });
+
+  it("returns null when coverImage is null and coverUrl is undefined", () => {
+    expect(getCoverSrc({ coverImage: null, coverUrl: undefined })).toBeNull();
+  });
+
+  it("prefers coverImage over coverUrl", () => {
+    expect(getCoverSrc({ coverImage: "local.jpg", coverUrl: "https://remote.com/img.jpg" }))
+      .toBe("/uploads/covers/local.jpg");
+  });
+});

--- a/frontend/src/__tests__/unit/utils/syncLabels.test.ts
+++ b/frontend/src/__tests__/unit/utils/syncLabels.test.ts
@@ -1,0 +1,53 @@
+import {
+  fieldLabels,
+  formatSyncValue,
+  operationLabels,
+  resourceLabels,
+} from "../../../utils/syncLabels";
+
+describe("syncLabels", () => {
+  describe("operationLabels", () => {
+    it("maps operations to French labels", () => {
+      expect(operationLabels.create).toBe("Création");
+      expect(operationLabels.delete).toBe("Suppression");
+      expect(operationLabels.update).toBe("Mise à jour");
+    });
+  });
+
+  describe("resourceLabels", () => {
+    it("maps resource types to French labels", () => {
+      expect(resourceLabels.comic_series).toBe("série");
+      expect(resourceLabels.tome).toBe("tome");
+    });
+  });
+
+  describe("fieldLabels", () => {
+    it("contains all expected fields", () => {
+      expect(fieldLabels.authors).toBe("Auteurs");
+      expect(fieldLabels.isbn).toBe("ISBN");
+      expect(fieldLabels.title).toBe("Titre");
+      expect(fieldLabels.bought).toBe("Acheté");
+    });
+  });
+
+  describe("formatSyncValue", () => {
+    it("returns dash for null/undefined", () => {
+      expect(formatSyncValue(null)).toBe("—");
+      expect(formatSyncValue(undefined)).toBe("—");
+    });
+
+    it("formats booleans", () => {
+      expect(formatSyncValue(true)).toBe("Oui");
+      expect(formatSyncValue(false)).toBe("Non");
+    });
+
+    it("formats arrays", () => {
+      expect(formatSyncValue([1, 2, 3])).toBe("3 élément(s)");
+    });
+
+    it("formats other values as string", () => {
+      expect(formatSyncValue("hello")).toBe("hello");
+      expect(formatSyncValue(42)).toBe("42");
+    });
+  });
+});

--- a/frontend/src/components/AuthorAutocomplete.tsx
+++ b/frontend/src/components/AuthorAutocomplete.tsx
@@ -1,0 +1,85 @@
+import {
+  Combobox,
+  ComboboxInput,
+  ComboboxOption,
+  ComboboxOptions,
+} from "@headlessui/react";
+import { Plus, Search, X } from "lucide-react";
+import type { Author } from "../types/api";
+
+interface AuthorAutocompleteProps {
+  addAuthor: (author: Author) => void;
+  authorOptions: Author[];
+  authorSearch: string;
+  authors: Author[];
+  removeAuthor: (index: number) => void;
+  setAuthorSearch: (v: string) => void;
+}
+
+export default function AuthorAutocomplete({
+  addAuthor,
+  authorOptions,
+  authorSearch,
+  authors,
+  removeAuthor,
+  setAuthorSearch,
+}: AuthorAutocompleteProps) {
+  return (
+    <div>
+      <label className="mb-1 block text-sm font-medium text-text-secondary">Auteurs</label>
+      <div className="flex flex-wrap gap-2 mb-2">
+        {authors.map((author, i) => (
+          <span
+            className="flex items-center gap-1 rounded-full bg-primary-100 px-3 py-1 text-sm font-medium text-primary-700 dark:bg-primary-950/30 dark:text-primary-400"
+            key={author.id}
+          >
+            {author.name}
+            <button
+              className="ml-1 rounded-full p-0.5 hover:bg-primary-200 dark:hover:bg-primary-900/40"
+              onClick={() => removeAuthor(i)}
+              type="button"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        ))}
+      </div>
+      <Combobox
+        onChange={(author: Author | null) => {
+          if (author) addAuthor(author);
+        }}
+        value={null}
+      >
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" />
+          <ComboboxInput
+            className="w-full rounded-lg border border-surface-border bg-surface-primary py-2 pl-10 pr-3 text-sm text-text-primary"
+            displayValue={() => authorSearch}
+            onChange={(e) => setAuthorSearch(e.target.value)}
+            placeholder="Rechercher ou créer un auteur…"
+          />
+          <ComboboxOptions className="absolute z-10 mt-1 max-h-48 w-full overflow-auto rounded-lg border border-surface-border bg-surface-primary shadow-lg">
+            {authorOptions.map((author) => (
+              <ComboboxOption
+                className="cursor-pointer px-3 py-2 text-sm text-text-primary data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-950/30"
+                key={author.id}
+                value={author}
+              >
+                {author.name}
+              </ComboboxOption>
+            ))}
+            {authorSearch.length >= 2 && !authorOptions.some((a) => a.name.toLowerCase() === authorSearch.toLowerCase()) && (
+              <ComboboxOption
+                className="cursor-pointer px-3 py-2 text-sm text-primary-700 dark:text-primary-400 data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-950/30"
+                value={{ "@id": "", id: -Date.now(), name: authorSearch } as Author}
+              >
+                <Plus className="mr-1 inline h-3 w-3" />
+                Créer « {authorSearch} »
+              </ComboboxOption>
+            )}
+          </ComboboxOptions>
+        </div>
+      </Combobox>
+    </div>
+  );
+}

--- a/frontend/src/components/ComicCard.tsx
+++ b/frontend/src/components/ComicCard.tsx
@@ -3,6 +3,7 @@ import { Edit, EllipsisVertical, Trash2 } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import type { ComicSeries } from "../types/api";
 import { ComicTypeLabel, ComicTypePlaceholder } from "../types/enums";
+import { getCoverSrc } from "../utils/coverUtils";
 import { countCoveredTomes } from "../utils/tomeUtils";
 import ProgressBar from "./ProgressBar";
 import SyncPendingIndicator from "./SyncPendingIndicator";
@@ -15,7 +16,7 @@ interface ComicCardProps {
 
 export default function ComicCard({ comic, onDelete, onMenuOpen }: ComicCardProps) {
   const navigate = useNavigate();
-  const coverSrc = comic.coverImage ? `/uploads/covers/${comic.coverImage}` : comic.coverUrl;
+  const coverSrc = getCoverSrc(comic);
   const tomes = comic.tomes ?? [];
   const coveredCount = countCoveredTomes(tomes);
   const boughtCount = countCoveredTomes(tomes, (t) => t.bought);

--- a/frontend/src/components/Filters.tsx
+++ b/frontend/src/components/Filters.tsx
@@ -1,21 +1,14 @@
-import {
-  Dialog,
-  DialogPanel,
-  Listbox,
-  ListboxButton,
-  ListboxOption,
-  ListboxOptions,
-} from "@headlessui/react";
-import { Check, ChevronDown, SlidersHorizontal, X } from "lucide-react";
+import { Dialog, DialogPanel } from "@headlessui/react";
+import { SlidersHorizontal, X } from "lucide-react";
 import { useState } from "react";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import {
-  ComicStatus,
-  ComicStatusLabel,
-  ComicType,
-  ComicTypeLabel,
+  type SelectOption,
+  statusOptionsAll,
+  typeOptionsAll,
 } from "../types/enums";
 import type { SortOption } from "../utils/sortComics";
+import SelectListbox from "./SelectListbox";
 
 interface FiltersProps {
   onSortChange: (sort: SortOption) => void;
@@ -26,20 +19,7 @@ interface FiltersProps {
   type: string;
 }
 
-interface Option {
-  label: string;
-  value: string;
-}
-
-const typeOptions: Option[] = [
-  { label: "Tous les types", value: "" },
-  ...Object.entries(ComicType).map(([, value]) => ({
-    label: ComicTypeLabel[value],
-    value,
-  })),
-];
-
-const sortOptions: Option[] = [
+const sortOptions: SelectOption[] = [
   { label: "Titre A→Z", value: "title-asc" },
   { label: "Titre Z→A", value: "title-desc" },
   { label: "Plus récent", value: "createdAt-desc" },
@@ -47,53 +27,6 @@ const sortOptions: Option[] = [
   { label: "Plus de tomes", value: "tomes-desc" },
   { label: "Moins de tomes", value: "tomes-asc" },
 ];
-
-const statusOptions: Option[] = [
-  { label: "Tous les statuts", value: "" },
-  ...Object.entries(ComicStatus)
-    .map(([, value]) => ({
-      label: ComicStatusLabel[value],
-      value,
-    }))
-    .sort((a, b) => a.label.localeCompare(b.label)),
-];
-
-function SelectListbox({
-  onChange,
-  options,
-  value,
-}: {
-  onChange: (v: string) => void;
-  options: Option[];
-  value: string;
-}) {
-  const selected = options.find((o) => o.value === value) ?? options[0];
-
-  return (
-    <Listbox onChange={onChange} value={value}>
-      <div className="relative">
-        <ListboxButton className="flex w-full items-center justify-between gap-2 rounded-lg border border-surface-border bg-surface-primary px-3 py-1.5 text-sm text-text-primary transition hover:border-primary-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
-          <span className="truncate">{selected.label}</span>
-          <ChevronDown className="h-4 w-4 text-text-muted" />
-        </ListboxButton>
-        <ListboxOptions className="absolute z-20 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-surface-border bg-surface-primary py-1 shadow-lg transition focus:outline-none">
-          {options.map((option) => (
-            <ListboxOption
-              className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm text-text-primary data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-950/30"
-              key={option.value}
-              value={option.value}
-            >
-              <Check
-                className={`h-4 w-4 shrink-0 ${option.value === value ? "text-primary-600" : "invisible"}`}
-              />
-              {option.label}
-            </ListboxOption>
-          ))}
-        </ListboxOptions>
-      </div>
-    </Listbox>
-  );
-}
 
 function FilterSelect({
   label,
@@ -103,7 +36,7 @@ function FilterSelect({
 }: {
   label: string;
   onChange: (v: string) => void;
-  options: Option[];
+  options: SelectOption[];
   value: string;
 }) {
   return (
@@ -153,13 +86,13 @@ function FilterDrawer({
           <FilterSelect
             label="Type"
             onChange={onTypeChange}
-            options={typeOptions}
+            options={typeOptionsAll}
             value={type}
           />
           <FilterSelect
             label="Statut"
             onChange={onStatusChange}
-            options={statusOptions}
+            options={statusOptionsAll}
             value={status}
           />
           <FilterSelect
@@ -222,10 +155,10 @@ export default function Filters({
   return (
     <div className="flex min-w-0 flex-1 items-center gap-3">
       <div className="min-w-0 flex-1">
-        <SelectListbox onChange={onTypeChange} options={typeOptions} value={type} />
+        <SelectListbox onChange={onTypeChange} options={typeOptionsAll} value={type} />
       </div>
       <div className="min-w-0 flex-1">
-        <SelectListbox onChange={onStatusChange} options={statusOptions} value={status} />
+        <SelectListbox onChange={onStatusChange} options={statusOptionsAll} value={status} />
       </div>
       <div className="min-w-0 flex-1">
         <SelectListbox onChange={(v) => onSortChange(v as SortOption)} options={sortOptions} value={sort} />

--- a/frontend/src/components/LookupSection.tsx
+++ b/frontend/src/components/LookupSection.tsx
@@ -1,0 +1,137 @@
+import { Layers, Loader2 } from "lucide-react";
+import type { UseQueryResult } from "@tanstack/react-query";
+import BarcodeScanner from "./BarcodeScanner";
+import type { LookupResult } from "../types/api";
+
+interface LookupSectionProps {
+  applyLookup: () => void;
+  formTitle: string;
+  isApplying: boolean;
+  isOnline: boolean;
+  lookupIsbn: string;
+  lookupMode: "isbn" | "title";
+  lookupResult: UseQueryResult<LookupResult>;
+  lookupTitle: string;
+  setLookupIsbn: (v: string) => void;
+  setLookupMode: (v: "isbn" | "title") => void;
+  setLookupTitle: (v: string) => void;
+}
+
+export default function LookupSection({
+  applyLookup,
+  formTitle,
+  isApplying,
+  isOnline,
+  lookupIsbn,
+  lookupMode,
+  lookupResult,
+  lookupTitle,
+  setLookupIsbn,
+  setLookupMode,
+  setLookupTitle,
+}: LookupSectionProps) {
+  if (!isOnline) {
+    return (
+      <div className="rounded-lg border border-surface-border bg-surface-tertiary p-4">
+        <p className="text-sm text-text-muted">Recherche indisponible hors ligne</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-surface-border bg-surface-tertiary p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-text-secondary">Recherche automatique</h2>
+        <div className="flex rounded-lg bg-surface-primary p-0.5 border border-surface-border">
+          <button
+            className={`rounded-md px-3 py-1 text-sm font-medium transition ${lookupMode === "isbn" ? "bg-primary-600 text-white shadow-sm" : "text-text-muted hover:text-text-secondary"}`}
+            onClick={() => setLookupMode("isbn")}
+            type="button"
+          >
+            ISBN
+          </button>
+          <button
+            className={`rounded-md px-3 py-1 text-sm font-medium transition ${lookupMode === "title" ? "bg-primary-600 text-white shadow-sm" : "text-text-muted hover:text-text-secondary"}`}
+            onClick={() => setLookupMode("title")}
+            type="button"
+          >
+            Titre
+          </button>
+        </div>
+      </div>
+
+      {lookupMode === "isbn" ? (
+        <div className="flex gap-2">
+          <input
+            className="flex-1 rounded-lg border border-surface-border bg-surface-primary px-3 py-2 text-sm text-text-primary"
+            onChange={(e) => setLookupIsbn(e.target.value)}
+            placeholder="ISBN (10 ou 13 chiffres)"
+            value={lookupIsbn}
+          />
+          <BarcodeScanner onScan={setLookupIsbn} />
+        </div>
+      ) : (
+        <div className="flex gap-2">
+          <input
+            className="flex-1 rounded-lg border border-surface-border bg-surface-primary px-3 py-2 text-sm text-text-primary"
+            onChange={(e) => setLookupTitle(e.target.value)}
+            placeholder="Titre de la série"
+            value={lookupTitle}
+          />
+          {formTitle && formTitle !== lookupTitle && (
+            <button
+              className="flex shrink-0 items-center gap-1.5 rounded-lg border border-surface-border bg-surface-primary px-3 py-1.5 text-sm text-text-muted hover:border-primary-400 hover:text-primary-600 transition"
+              onClick={() => setLookupTitle(formTitle)}
+              title="Utiliser le titre de la série"
+              type="button"
+            >
+              <Layers className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      )}
+
+      {lookupResult.isFetching && (
+        <div className="flex items-center gap-2 text-sm text-text-muted">
+          <Loader2 className="h-4 w-4 animate-spin" /> Recherche en cours…
+        </div>
+      )}
+
+      {lookupResult.data && !lookupResult.isFetching && (
+        <div className="rounded-lg bg-surface-primary p-3 border border-surface-border space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0 text-sm">
+              <p className="truncate font-medium text-text-primary">{lookupResult.data.title}</p>
+              <p className="truncate text-text-muted">
+                {lookupResult.data.authors ?? ""}
+                {lookupResult.data.publisher && ` — ${lookupResult.data.publisher}`}
+              </p>
+            </div>
+            <button
+              className="flex shrink-0 items-center gap-1.5 rounded-lg bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
+              disabled={isApplying}
+              onClick={applyLookup}
+              type="button"
+            >
+              {isApplying && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+              Appliquer
+            </button>
+          </div>
+          {lookupResult.data.sources.length > 0 && (
+            <p className="text-xs text-text-muted">
+              Sources : {lookupResult.data.sources.join(", ")}
+            </p>
+          )}
+          {Object.entries(lookupResult.data.apiMessages).filter(([, m]) => m.status !== "success").length > 0 && (
+            <p className="text-xs text-text-muted">
+              {Object.entries(lookupResult.data.apiMessages)
+                .filter(([, m]) => m.status !== "success")
+                .map(([provider, m]) => `${provider}: ${m.message}`)
+                .join(" · ")}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/SelectListbox.tsx
+++ b/frontend/src/components/SelectListbox.tsx
@@ -1,0 +1,70 @@
+import {
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+} from "@headlessui/react";
+import { Check, ChevronDown } from "lucide-react";
+import type { SelectOption } from "../types/enums";
+
+interface SelectListboxProps {
+  buttonClassName?: string;
+  label?: string;
+  onChange: (v: string) => void;
+  options: SelectOption[];
+  placeholder?: string;
+  value: string;
+}
+
+export default function SelectListbox({
+  buttonClassName,
+  label,
+  onChange,
+  options,
+  placeholder,
+  value,
+}: SelectListboxProps) {
+  const selected = options.find((o) => o.value === value);
+  const displayLabel = selected?.label ?? placeholder ?? options[0]?.label;
+
+  return (
+    <div>
+      {label && (
+        <span className="mb-1 block text-sm font-medium text-text-secondary">
+          {label}
+        </span>
+      )}
+      <Listbox onChange={onChange} value={value}>
+        <div className="relative">
+          <ListboxButton
+            className={
+              buttonClassName ??
+              "flex w-full items-center justify-between gap-2 rounded-lg border border-surface-border bg-surface-primary px-3 py-1.5 text-sm text-text-primary transition hover:border-primary-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+            }
+          >
+            <span
+              className={`truncate ${!selected && placeholder ? "text-text-muted" : ""}`}
+            >
+              {displayLabel}
+            </span>
+            <ChevronDown className="h-4 w-4 text-text-muted" />
+          </ListboxButton>
+          <ListboxOptions className="absolute z-20 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-surface-border bg-surface-primary py-1 shadow-lg transition focus:outline-none">
+            {options.map((option) => (
+              <ListboxOption
+                className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm text-text-primary data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-950/30"
+                key={option.value}
+                value={option.value}
+              >
+                <Check
+                  className={`h-4 w-4 shrink-0 ${option.value === value ? "text-primary-600" : "invisible"}`}
+                />
+                {option.label}
+              </ListboxOption>
+            ))}
+          </ListboxOptions>
+        </div>
+      </Listbox>
+    </div>
+  );
+}

--- a/frontend/src/components/SyncErrorBanner.tsx
+++ b/frontend/src/components/SyncErrorBanner.tsx
@@ -3,44 +3,7 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useSyncFailures } from "../hooks/useSyncFailures";
 import type { SyncFailure } from "../services/offlineQueue";
-
-const operationLabels: Record<string, string> = {
-  create: "Création",
-  delete: "Suppression",
-  update: "Mise à jour",
-};
-
-const resourceLabels: Record<string, string> = {
-  comic_series: "série",
-  tome: "tome",
-};
-
-const fieldLabels: Record<string, string> = {
-  authors: "Auteurs",
-  bought: "Acheté",
-  coverUrl: "Couverture",
-  description: "Description",
-  downloaded: "Téléchargé",
-  isbn: "ISBN",
-  isOneShot: "One-shot",
-  latestPublishedIssue: "Dernier tome paru",
-  number: "Numéro",
-  onNas: "NAS",
-  publisher: "Éditeur",
-  read: "Lu",
-  status: "Statut",
-  title: "Titre",
-  tomeEnd: "Fin",
-  tomes: "Tomes",
-  type: "Type",
-};
-
-function formatValue(value: unknown): string {
-  if (value === null || value === undefined) return "—";
-  if (typeof value === "boolean") return value ? "Oui" : "Non";
-  if (Array.isArray(value)) return `${value.length} élément(s)`;
-  return String(value);
-}
+import { fieldLabels, formatSyncValue, operationLabels, resourceLabels } from "../utils/syncLabels";
 
 function getEditLink(failure: SyncFailure): string | null {
   if (failure.operation === "delete") return null;
@@ -68,7 +31,7 @@ function PayloadDetails({ payload }: { payload: Record<string, unknown> }) {
             {fieldLabels[key] ?? key}
           </dt>
           <dd className="truncate text-red-600 dark:text-red-400">
-            {formatValue(value)}
+            {formatSyncValue(value)}
           </dd>
         </div>
       ))}

--- a/frontend/src/components/TomeTable.tsx
+++ b/frontend/src/components/TomeTable.tsx
@@ -1,0 +1,305 @@
+import { Layers, Loader2, Plus, Search, Trash2 } from "lucide-react";
+import type { FormData, TomeFormData } from "../hooks/useComicForm";
+
+interface TomeTableProps {
+  addBatchTomes: () => void;
+  addTome: () => void;
+  batchFrom: number;
+  batchSize: number;
+  batchTo: number;
+  form: FormData;
+  lookupTomeIsbn: (index: number) => void;
+  maxBatchSize: number;
+  removeTome: (index: number) => void;
+  setBatchFrom: (v: number) => void;
+  setBatchTo: (v: number) => void;
+  tomeLookupLoading: number | null;
+  updateTome: <K extends keyof TomeFormData>(index: number, key: K, value: TomeFormData[K]) => void;
+}
+
+export default function TomeTable({
+  addBatchTomes,
+  addTome,
+  batchFrom,
+  batchSize,
+  batchTo,
+  form,
+  lookupTomeIsbn,
+  maxBatchSize,
+  removeTome,
+  setBatchFrom,
+  setBatchTo,
+  tomeLookupLoading,
+  updateTome,
+}: TomeTableProps) {
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-text-secondary">
+          Tomes ({form.tomes.length})
+        </h2>
+        <button
+          className="flex items-center gap-1 rounded-lg bg-primary-100 px-3 py-1.5 text-sm font-medium text-primary-700 hover:bg-primary-200 dark:bg-primary-950/30 dark:text-primary-400 dark:hover:bg-primary-900/40"
+          onClick={addTome}
+          type="button"
+        >
+          <Plus className="h-4 w-4" /> Ajouter
+        </button>
+      </div>
+      <div className="mb-3 flex flex-wrap items-end gap-2 rounded-lg border border-surface-border bg-surface-tertiary p-3">
+        <div>
+          <label className="mb-1 block text-xs font-medium text-text-muted" htmlFor="batch-from">Du tome</label>
+          <input
+            className="w-16 rounded border border-surface-border bg-surface-primary px-2 py-1 text-center text-sm text-text-primary"
+            id="batch-from"
+            min="1"
+            onChange={(e) => setBatchFrom(Number(e.target.value))}
+            type="number"
+            value={batchFrom}
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium text-text-muted" htmlFor="batch-to">au tome</label>
+          <input
+            className="w-16 rounded border border-surface-border bg-surface-primary px-2 py-1 text-center text-sm text-text-primary"
+            id="batch-to"
+            min="1"
+            onChange={(e) => setBatchTo(Number(e.target.value))}
+            type="number"
+            value={batchTo}
+          />
+        </div>
+        <button
+          className="flex items-center gap-1 rounded-lg bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
+          disabled={batchFrom < 1 || batchFrom > batchTo || batchSize > maxBatchSize}
+          onClick={addBatchTomes}
+          type="button"
+        >
+          <Layers className="h-4 w-4" /> Générer
+        </button>
+        {batchSize > maxBatchSize && (
+          <span className="text-xs text-red-500">Max {maxBatchSize} tomes</span>
+        )}
+      </div>
+      {/* Mobile: card layout */}
+      <div className="space-y-3 sm:hidden" data-testid="tomes-cards">
+        {form.tomes
+          .map((tome, i) => ({ tome, originalIndex: i }))
+          .sort((a, b) => a.tome.number - b.tome.number)
+          .map(({ tome, originalIndex: i }) => (
+          <div className={`rounded-lg border p-3 space-y-2 ${tome.id ? "border-surface-border bg-surface-primary" : "border-emerald-300 bg-emerald-50 dark:border-emerald-700 dark:bg-emerald-950/30"}`} key={i}>
+            <div className="flex items-center gap-2">
+              {!tome.id && <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300">Nouveau</span>}
+              <input
+                className="w-14 rounded border border-surface-border bg-surface-tertiary px-2 py-1 text-center text-sm font-medium text-text-primary"
+                min="0"
+                onChange={(e) => updateTome(i, "number", Number(e.target.value))}
+                type="number"
+                value={tome.number}
+              />
+              <input
+                className="w-14 rounded border border-surface-border bg-surface-tertiary px-2 py-1 text-center text-sm text-text-primary"
+                min="0"
+                onChange={(e) => updateTome(i, "tomeEnd", e.target.value)}
+                placeholder="Fin"
+                type="number"
+                value={tome.tomeEnd}
+              />
+              <input
+                className="flex-1 rounded border border-surface-border bg-surface-tertiary px-2 py-1 text-sm text-text-primary"
+                onChange={(e) => updateTome(i, "title", e.target.value)}
+                placeholder="Titre"
+                value={tome.title}
+              />
+              <button
+                aria-label={`Supprimer tome ${tome.number}`}
+                className="shrink-0 rounded p-1 text-red-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/30"
+                onClick={() => removeTome(i)}
+                type="button"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="flex items-center gap-1">
+              <input
+                className="flex-1 rounded border border-surface-border bg-surface-tertiary px-2 py-1 text-sm text-text-primary"
+                onChange={(e) => updateTome(i, "isbn", e.target.value)}
+                placeholder="ISBN"
+                value={tome.isbn}
+              />
+              <button
+                className="shrink-0 rounded p-1 text-text-muted hover:bg-surface-tertiary hover:text-primary-600 disabled:opacity-50"
+                disabled={tome.isbn.length < 10 || tomeLookupLoading === i}
+                onClick={() => lookupTomeIsbn(i)}
+                title="Rechercher par ISBN"
+                type="button"
+              >
+                {tomeLookupLoading === i
+                  ? <Loader2 className="h-4 w-4 animate-spin" />
+                  : <Search className="h-4 w-4" />}
+              </button>
+            </div>
+            <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+              <label className="flex items-center gap-2 text-sm text-text-secondary">
+                <input
+                  checked={tome.bought}
+                  className="h-4 w-4 rounded border-surface-border text-primary-600"
+                  onChange={(e) => updateTome(i, "bought", e.target.checked)}
+                  type="checkbox"
+                />
+                Acheté
+              </label>
+              <label className="flex items-center gap-2 text-sm text-text-secondary">
+                <input
+                  checked={tome.downloaded}
+                  className="h-4 w-4 rounded border-surface-border text-primary-600"
+                  onChange={(e) => updateTome(i, "downloaded", e.target.checked)}
+                  type="checkbox"
+                />
+                DL
+              </label>
+              <label className="flex items-center gap-2 text-sm text-text-secondary">
+                <input
+                  checked={tome.read}
+                  className="h-4 w-4 rounded border-surface-border text-primary-600"
+                  onChange={(e) => updateTome(i, "read", e.target.checked)}
+                  type="checkbox"
+                />
+                Lu
+              </label>
+              <label className="flex items-center gap-2 text-sm text-text-secondary">
+                <input
+                  checked={tome.onNas}
+                  className="h-4 w-4 rounded border-surface-border text-primary-600"
+                  onChange={(e) => updateTome(i, "onNas", e.target.checked)}
+                  type="checkbox"
+                />
+                NAS
+              </label>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Desktop: table layout */}
+      <div className="hidden overflow-x-auto rounded-lg border border-surface-border sm:block" data-testid="tomes-table">
+        <table className="w-full text-sm">
+          <thead className="bg-surface-tertiary">
+            <tr>
+              <th className="px-3 py-2 text-left font-medium text-text-secondary">#</th>
+              <th className="px-3 py-2 text-left font-medium text-text-secondary">Fin</th>
+              <th className="px-3 py-2 text-left font-medium text-text-secondary">Titre</th>
+              <th className="px-3 py-2 text-left font-medium text-text-secondary">ISBN</th>
+              <th className="px-3 py-2 text-center font-medium text-text-secondary">Acheté</th>
+              <th className="px-3 py-2 text-center font-medium text-text-secondary">DL</th>
+              <th className="px-3 py-2 text-center font-medium text-text-secondary">Lu</th>
+              <th className="px-3 py-2 text-center font-medium text-text-secondary">NAS</th>
+              <th className="px-3 py-2" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-surface-border">
+            {form.tomes
+              .map((tome, i) => ({ tome, originalIndex: i }))
+              .sort((a, b) => a.tome.number - b.tome.number)
+              .map(({ tome, originalIndex: i }) => (
+              <tr className={tome.id ? "" : "bg-emerald-50 dark:bg-emerald-950/20"} key={i}>
+                <td className="px-3 py-1.5">
+                  <div className="flex items-center gap-1">
+                    <input
+                      className="w-14 rounded border border-surface-border bg-surface-primary px-2 py-1 text-center text-sm text-text-primary"
+                      min="0"
+                      onChange={(e) => updateTome(i, "number", Number(e.target.value))}
+                      type="number"
+                      value={tome.number}
+                    />
+                    {!tome.id && <span className="rounded bg-emerald-100 px-1 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300">Nouveau</span>}
+                  </div>
+                </td>
+                <td className="px-3 py-1.5">
+                  <input
+                    className="w-14 rounded border border-surface-border bg-surface-primary px-2 py-1 text-center text-sm text-text-primary"
+                    min="0"
+                    onChange={(e) => updateTome(i, "tomeEnd", e.target.value)}
+                    placeholder="Fin"
+                    type="number"
+                    value={tome.tomeEnd}
+                  />
+                </td>
+                <td className="px-3 py-1.5">
+                  <input
+                    className="w-full min-w-[100px] rounded border border-surface-border bg-surface-primary px-2 py-1 text-sm text-text-primary"
+                    onChange={(e) => updateTome(i, "title", e.target.value)}
+                    placeholder="Titre"
+                    value={tome.title}
+                  />
+                </td>
+                <td className="px-3 py-1.5">
+                  <div className="flex items-center gap-1">
+                    <input
+                      className="w-full min-w-[120px] rounded border border-surface-border bg-surface-primary px-2 py-1 text-sm text-text-primary"
+                      onChange={(e) => updateTome(i, "isbn", e.target.value)}
+                      placeholder="ISBN"
+                      value={tome.isbn}
+                    />
+                    <button
+                      className="shrink-0 rounded p-1 text-text-muted hover:bg-surface-tertiary hover:text-primary-600 disabled:opacity-50"
+                      disabled={tome.isbn.length < 10 || tomeLookupLoading === i}
+                      onClick={() => lookupTomeIsbn(i)}
+                      title="Rechercher par ISBN"
+                      type="button"
+                    >
+                      {tomeLookupLoading === i
+                        ? <Loader2 className="h-4 w-4 animate-spin" />
+                        : <Search className="h-4 w-4" />}
+                    </button>
+                  </div>
+                </td>
+                <td className="px-3 py-1.5 text-center">
+                  <input
+                    checked={tome.bought}
+                    className="h-4 w-4 rounded border-surface-border text-primary-600"
+                    onChange={(e) => updateTome(i, "bought", e.target.checked)}
+                    type="checkbox"
+                  />
+                </td>
+                <td className="px-3 py-1.5 text-center">
+                  <input
+                    checked={tome.downloaded}
+                    className="h-4 w-4 rounded border-surface-border text-primary-600"
+                    onChange={(e) => updateTome(i, "downloaded", e.target.checked)}
+                    type="checkbox"
+                  />
+                </td>
+                <td className="px-3 py-1.5 text-center">
+                  <input
+                    checked={tome.read}
+                    className="h-4 w-4 rounded border-surface-border text-primary-600"
+                    onChange={(e) => updateTome(i, "read", e.target.checked)}
+                    type="checkbox"
+                  />
+                </td>
+                <td className="px-3 py-1.5 text-center">
+                  <input
+                    checked={tome.onNas}
+                    className="h-4 w-4 rounded border-surface-border text-primary-600"
+                    onChange={(e) => updateTome(i, "onNas", e.target.checked)}
+                    type="checkbox"
+                  />
+                </td>
+                <td className="px-3 py-1.5">
+                  <button
+                    className="rounded p-1 text-red-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/30"
+                    onClick={() => removeTome(i)}
+                    type="button"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useComicForm.ts
+++ b/frontend/src/hooks/useComicForm.ts
@@ -1,0 +1,391 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
+import { useAuthors } from "./useAuthors";
+import { useOnlineStatus } from "./useOnlineStatus";
+import { useComic } from "./useComic";
+import { useCreateComic } from "./useCreateComic";
+import { fetchLookupIsbn, fetchLookupTitle, useLookupIsbn, useLookupTitle } from "./useLookup";
+import { useSyncFailures } from "./useSyncFailures";
+import { useUpdateComic } from "./useUpdateComic";
+import { apiFetch } from "../services/api";
+import type { Author, ComicSeries } from "../types/api";
+import { ComicStatus, ComicType } from "../types/enums";
+
+export interface TomeFormData {
+  bought: boolean;
+  downloaded: boolean;
+  id?: number;
+  isbn: string;
+  number: number;
+  onNas: boolean;
+  read: boolean;
+  title: string;
+  tomeEnd: string;
+}
+
+export interface FormData {
+  authors: Author[];
+  coverUrl: string;
+  defaultTomeBought: boolean;
+  defaultTomeDownloaded: boolean;
+  defaultTomeRead: boolean;
+  description: string;
+  isOneShot: boolean;
+  latestPublishedIssue: string;
+  latestPublishedIssueComplete: boolean;
+  publisher: string;
+  status: string;
+  title: string;
+  tomes: TomeFormData[];
+  type: string;
+}
+
+function emptyTome(number: number): TomeFormData {
+  return { bought: false, downloaded: false, isbn: "", number, onNas: false, read: false, title: "", tomeEnd: "" };
+}
+
+function buildInitialForm(comic?: ComicSeries): FormData {
+  if (comic) {
+    return {
+      authors: comic.authors,
+      coverUrl: comic.coverUrl ?? "",
+      defaultTomeBought: comic.defaultTomeBought,
+      defaultTomeDownloaded: comic.defaultTomeDownloaded,
+      defaultTomeRead: comic.defaultTomeRead,
+      description: comic.description ?? "",
+      isOneShot: comic.isOneShot,
+      latestPublishedIssue: comic.latestPublishedIssue?.toString() ?? "",
+      latestPublishedIssueComplete: comic.latestPublishedIssueComplete,
+      publisher: comic.publisher ?? "",
+      status: comic.status,
+      title: comic.title,
+      tomes: comic.tomes.map((t) => ({
+        bought: t.bought,
+        downloaded: t.downloaded,
+        id: t.id,
+        isbn: t.isbn ?? "",
+        number: t.number,
+        onNas: t.onNas,
+        read: t.read,
+        title: t.title ?? "",
+        tomeEnd: t.tomeEnd?.toString() ?? "",
+      })),
+      type: comic.type,
+    };
+  }
+  return {
+    authors: [],
+    coverUrl: "",
+    defaultTomeBought: false,
+    defaultTomeDownloaded: false,
+    defaultTomeRead: false,
+    description: "",
+    isOneShot: false,
+    latestPublishedIssue: "",
+    latestPublishedIssueComplete: false,
+    publisher: "",
+    status: ComicStatus.BUYING,
+    title: "",
+    tomes: [emptyTome(1)],
+    type: ComicType.BD,
+  };
+}
+
+const maxBatchSize = 100;
+
+export function useComicForm() {
+  const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const syncFailureId = searchParams.get("syncFailureId");
+  const isEdit = Boolean(id);
+  const navigate = useNavigate();
+  const isOnline = useOnlineStatus();
+  const { data: comic } = useComic(id ? Number(id) : undefined);
+  const createComic = useCreateComic();
+  const updateComic = useUpdateComic();
+  const { failures, resolveSyncFailure } = useSyncFailures();
+  const syncFailure = syncFailureId ? failures.find((f) => f.id === Number(syncFailureId)) : undefined;
+
+  const [form, setForm] = useState<FormData>(buildInitialForm());
+  const [initialized, setInitialized] = useState(!isEdit);
+
+  // Lookup state
+  const [isApplying, setIsApplying] = useState(false);
+  const [lookupIsbn, setLookupIsbn] = useState("");
+  const [lookupTitle, setLookupTitle] = useState("");
+  const [lookupMode, setLookupMode] = useState<"isbn" | "title">("title");
+  const [tomeLookupLoading, setTomeLookupLoading] = useState<number | null>(null);
+
+  // Cover search state
+  const [coverSearchOpen, setCoverSearchOpen] = useState(false);
+
+  // Batch add state
+  const [batchFrom, setBatchFrom] = useState(1);
+  const [batchTo, setBatchTo] = useState(1);
+
+  const isbnLookup = useLookupIsbn(lookupMode === "isbn" ? lookupIsbn : "", form.type);
+  const titleLookup = useLookupTitle(lookupMode === "title" ? lookupTitle : "", form.type);
+  const lookupResult = lookupMode === "isbn" ? isbnLookup : titleLookup;
+
+  // Author autocomplete
+  const [authorSearch, setAuthorSearch] = useState("");
+  const { data: authorResults } = useAuthors(authorSearch);
+  const authorOptions = authorResults?.member ?? [];
+
+  // Initialize form with comic data on edit
+  useEffect(() => {
+    if (isEdit && comic && !initialized) {
+      setForm(buildInitialForm(comic));
+      setInitialized(true);
+    }
+  }, [comic, isEdit, initialized]);
+
+  const update = <K extends keyof FormData>(key: K, value: FormData[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const applySeriesFields = (result: import("../types/api").LookupResult) => {
+    setForm((prev) => ({
+      ...prev,
+      coverUrl: result.thumbnail ?? prev.coverUrl,
+      description: result.description ?? prev.description,
+      isOneShot: result.isOneShot || prev.isOneShot,
+      latestPublishedIssue: result.latestPublishedIssue?.toString() ?? prev.latestPublishedIssue,
+      publisher: result.publisher ?? prev.publisher,
+      title: result.title || prev.title,
+    }));
+
+    if (result.authors) {
+      const authorNames = result.authors.split(",").map((n) => n.trim()).filter(Boolean);
+      update(
+        "authors",
+        authorNames.map((name, i) => ({ "@id": "", id: -(i + 1), name })),
+      );
+    }
+  };
+
+  const applyLookup = async () => {
+    const result = lookupResult.data;
+    if (!result) return;
+
+    if (lookupMode === "isbn" && result.title) {
+      setIsApplying(true);
+      try {
+        const titleResult = await fetchLookupTitle(result.title, form.type);
+        applySeriesFields(titleResult);
+        toast.success("Informations récupérées (ISBN → titre)");
+      } catch {
+        applySeriesFields(result);
+        toast.success("Informations récupérées (ISBN uniquement)");
+      } finally {
+        setIsApplying(false);
+      }
+    } else {
+      applySeriesFields(result);
+      toast.success("Informations récupérées");
+    }
+  };
+
+  const addTome = () => {
+    const nextNum = form.tomes.length > 0 ? Math.max(...form.tomes.map((t) => t.number)) + 1 : 1;
+    update("tomes", [...form.tomes, emptyTome(nextNum)]);
+  };
+
+  const batchSize = batchTo - batchFrom + 1;
+
+  const addBatchTomes = () => {
+    if (batchFrom < 1 || batchFrom > batchTo || batchSize > maxBatchSize) return;
+    const existingNumbers = new Set(form.tomes.map((t) => t.number));
+    const newTomes: TomeFormData[] = [];
+    for (let n = batchFrom; n <= batchTo; n++) {
+      if (!existingNumbers.has(n)) {
+        newTomes.push(emptyTome(n));
+      }
+    }
+    if (newTomes.length > 0) {
+      update("tomes", [...form.tomes, ...newTomes].sort((a, b) => a.number - b.number));
+    }
+  };
+
+  const removeTome = (index: number) => {
+    update(
+      "tomes",
+      form.tomes.filter((_, i) => i !== index),
+    );
+  };
+
+  const updateTome = <K extends keyof TomeFormData>(index: number, key: K, value: TomeFormData[K]) => {
+    update(
+      "tomes",
+      form.tomes.map((t, i) => (i === index ? { ...t, [key]: value } : t)),
+    );
+  };
+
+  const lookupTomeIsbn = async (index: number) => {
+    const isbn = form.tomes[index]?.isbn;
+    if (!isbn || isbn.length < 10) return;
+
+    setTomeLookupLoading(index);
+    try {
+      const result = await fetchLookupIsbn(isbn, form.type);
+      update(
+        "tomes",
+        form.tomes.map((t, i) =>
+          i === index
+            ? { ...t, isbn: result.isbn ?? t.isbn, title: result.title ?? t.title, tomeEnd: result.tomeEnd?.toString() ?? t.tomeEnd }
+            : t,
+        ),
+      );
+      toast.success(`Tome ${form.tomes[index].number} : informations récupérées`);
+    } catch {
+      toast.error("Échec de la recherche ISBN");
+    } finally {
+      setTomeLookupLoading(null);
+    }
+  };
+
+  const addAuthor = (author: Author) => {
+    if (!form.authors.some((a) => a.name === author.name)) {
+      update("authors", [...form.authors, author]);
+    }
+    setAuthorSearch("");
+  };
+
+  const removeAuthor = (index: number) => {
+    update(
+      "authors",
+      form.authors.filter((_, i) => i !== index),
+    );
+  };
+
+  const handleSubmit = async (e?: React.FormEvent) => {
+    e?.preventDefault();
+
+    const authorIris: string[] = [];
+    const pendingAuthors: string[] = [];
+    for (const a of form.authors) {
+      if (a.id > 0) {
+        authorIris.push(a["@id"]);
+      } else if (!navigator.onLine) {
+        pendingAuthors.push(a.name);
+      } else {
+        try {
+          const created = await apiFetch<Author>("/authors", {
+            body: JSON.stringify({ name: a.name }),
+            method: "POST",
+          });
+          authorIris.push(created["@id"]);
+        } catch {
+          toast.error(`Erreur lors de la création de l'auteur « ${a.name} »`);
+          return;
+        }
+      }
+    }
+
+    const payload: Record<string, unknown> = {
+      ...(pendingAuthors.length > 0 ? { _pendingAuthors: pendingAuthors } : {}),
+      authors: authorIris,
+      coverUrl: form.coverUrl || null,
+      defaultTomeBought: form.defaultTomeBought,
+      defaultTomeDownloaded: form.defaultTomeDownloaded,
+      defaultTomeRead: form.defaultTomeRead,
+      description: form.description || null,
+      isOneShot: form.isOneShot,
+      latestPublishedIssue: form.latestPublishedIssue ? Number(form.latestPublishedIssue) : null,
+      latestPublishedIssueComplete: form.latestPublishedIssueComplete,
+      publisher: form.publisher || null,
+      status: form.status,
+      title: form.title,
+      type: form.type,
+    };
+
+    if (!form.isOneShot) {
+      payload.tomes = [...form.tomes]
+        .sort((a, b) => a.number - b.number)
+        .map((t) => ({
+          ...(t.id ? { "@id": `/api/tomes/${t.id}` } : {}),
+          bought: t.bought,
+          downloaded: t.downloaded,
+          isbn: t.isbn || null,
+          number: t.number,
+          onNas: t.onNas,
+          read: t.read,
+          title: t.title || null,
+          tomeEnd: t.tomeEnd ? Number(t.tomeEnd) : null,
+        }));
+    }
+
+    if (isEdit && id) {
+      updateComic.mutate(
+        { id: Number(id), ...payload } as Partial<ComicSeries> & { id: number },
+        {
+          onSuccess: (data) => {
+            if (!data) return;
+            if (syncFailure?.id) void resolveSyncFailure(syncFailure.id);
+            toast.success("Série mise à jour");
+            navigate(`/comic/${id}`, { viewTransition: true });
+          },
+          onError: (err) => toast.error(err.message),
+        },
+      );
+    } else {
+      createComic.mutate(payload as Partial<ComicSeries>, {
+        onSuccess: (created) => {
+          if (!created) return;
+          if (syncFailure?.id) void resolveSyncFailure(syncFailure.id);
+          toast.success("Série créée");
+          navigate(`/comic/${created.id}`, { viewTransition: true });
+        },
+        onError: (err) => toast.error(err.message),
+      });
+    }
+
+    if (!navigator.onLine) {
+      navigate("/", { viewTransition: true });
+    }
+  };
+
+  const isSaving = createComic.isPending || updateComic.isPending;
+
+  return {
+    addAuthor,
+    addBatchTomes,
+    addTome,
+    applyLookup,
+    authorOptions,
+    authorSearch,
+    batchFrom,
+    batchSize,
+    batchTo,
+    coverSearchOpen,
+    form,
+    handleSubmit,
+    initialized,
+    isApplying,
+    isEdit,
+    isOnline,
+    isSaving,
+    lookupIsbn,
+    lookupMode,
+    lookupResult,
+    lookupTitle,
+    lookupTomeIsbn,
+    maxBatchSize,
+    navigate,
+    removeAuthor,
+    removeTome,
+    resolveSyncFailure,
+    setAuthorSearch,
+    setBatchFrom,
+    setBatchTo,
+    setCoverSearchOpen,
+    setLookupIsbn,
+    setLookupMode,
+    setLookupTitle,
+    syncFailure,
+    tomeLookupLoading,
+    update,
+    updateTome,
+  };
+}

--- a/frontend/src/pages/ComicDetail.tsx
+++ b/frontend/src/pages/ComicDetail.tsx
@@ -11,6 +11,7 @@ import { useComic } from "../hooks/useComic";
 import { useDeleteComic } from "../hooks/useDeleteComic";
 import { useUpdateTome } from "../hooks/useUpdateTome";
 import { ComicStatusLabel, ComicTypeLabel, ComicTypePlaceholder } from "../types/enums";
+import { getCoverSrc } from "../utils/coverUtils";
 import { countCoveredTomes } from "../utils/tomeUtils";
 
 function formatRelativeDate(isoDate: string): string {
@@ -114,7 +115,7 @@ export default function ComicDetail() {
     return <div className="py-12 text-center text-text-muted">Série introuvable</div>;
   }
 
-  const coverSrc = comic.coverImage ? `/uploads/covers/${comic.coverImage}` : comic.coverUrl;
+  const coverSrc = getCoverSrc(comic);
   const showProgress = !comic.isOneShot && optimisticTomes.length > 0;
   const progressTotal = comic.latestPublishedIssue ?? countCoveredTomes(optimisticTomes);
   const boughtCount = countCoveredTomes(optimisticTomes, (t) => t.bought);

--- a/frontend/src/pages/ComicForm.tsx
+++ b/frontend/src/pages/ComicForm.tsx
@@ -1,194 +1,14 @@
-import {
-  Combobox,
-  ComboboxInput,
-  ComboboxOption,
-  ComboboxOptions,
-  Listbox,
-  ListboxButton,
-  ListboxOption,
-  ListboxOptions,
-} from "@headlessui/react";
-import { AlertTriangle, ArrowLeft, Check, ChevronDown, Image, Layers, Loader2, Plus, Search, Trash2, X } from "lucide-react";
-import { useEffect, useState } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { toast } from "sonner";
-import BarcodeScanner from "../components/BarcodeScanner";
+import { AlertTriangle, ArrowLeft, Image, Loader2, X } from "lucide-react";
+import AuthorAutocomplete from "../components/AuthorAutocomplete";
 import CoverSearchModal from "../components/CoverSearchModal";
+import LookupSection from "../components/LookupSection";
+import SelectListbox from "../components/SelectListbox";
 import SkeletonBox from "../components/SkeletonBox";
-import { useAuthors } from "../hooks/useAuthors";
-import { useOnlineStatus } from "../hooks/useOnlineStatus";
-import { apiFetch } from "../services/api";
-import { useComic } from "../hooks/useComic";
-import { useCreateComic } from "../hooks/useCreateComic";
-import { fetchLookupIsbn, fetchLookupTitle, useLookupIsbn, useLookupTitle } from "../hooks/useLookup";
-import { useSyncFailures } from "../hooks/useSyncFailures";
-import { useUpdateComic } from "../hooks/useUpdateComic";
-import type { Author, ComicSeries } from "../types/api";
+import TomeTable from "../components/TomeTable";
+import { useComicForm } from "../hooks/useComicForm";
 import type { SyncFailure } from "../services/offlineQueue";
-import {
-  ComicStatus,
-  ComicStatusLabel,
-  ComicType,
-  ComicTypeLabel,
-} from "../types/enums";
-
-interface TomeFormData {
-  bought: boolean;
-  downloaded: boolean;
-  id?: number;
-  isbn: string;
-  number: number;
-  onNas: boolean;
-  read: boolean;
-  title: string;
-  tomeEnd: string;
-}
-
-interface FormData {
-  authors: Author[];
-  coverUrl: string;
-  defaultTomeBought: boolean;
-  defaultTomeDownloaded: boolean;
-  defaultTomeRead: boolean;
-  description: string;
-  isOneShot: boolean;
-  latestPublishedIssue: string;
-  latestPublishedIssueComplete: boolean;
-  publisher: string;
-  status: string;
-  title: string;
-  tomes: TomeFormData[];
-  type: string;
-}
-
-function emptyTome(number: number): TomeFormData {
-  return { bought: false, downloaded: false, isbn: "", number, onNas: false, read: false, title: "", tomeEnd: "" };
-}
-
-function buildInitialForm(comic?: ComicSeries): FormData {
-  if (comic) {
-    return {
-      authors: comic.authors,
-      coverUrl: comic.coverUrl ?? "",
-      defaultTomeBought: comic.defaultTomeBought,
-      defaultTomeDownloaded: comic.defaultTomeDownloaded,
-      defaultTomeRead: comic.defaultTomeRead,
-      description: comic.description ?? "",
-      isOneShot: comic.isOneShot,
-      latestPublishedIssue: comic.latestPublishedIssue?.toString() ?? "",
-      latestPublishedIssueComplete: comic.latestPublishedIssueComplete,
-      publisher: comic.publisher ?? "",
-      status: comic.status,
-      title: comic.title,
-      tomes: comic.tomes.map((t) => ({
-        bought: t.bought,
-        downloaded: t.downloaded,
-        id: t.id,
-        isbn: t.isbn ?? "",
-        number: t.number,
-        onNas: t.onNas,
-        read: t.read,
-        title: t.title ?? "",
-        tomeEnd: t.tomeEnd?.toString() ?? "",
-      })),
-      type: comic.type,
-    };
-  }
-  return {
-    authors: [],
-    coverUrl: "",
-    defaultTomeBought: false,
-    defaultTomeDownloaded: false,
-    defaultTomeRead: false,
-    description: "",
-    isOneShot: false,
-    latestPublishedIssue: "",
-    latestPublishedIssueComplete: false,
-    publisher: "",
-    status: ComicStatus.BUYING,
-    title: "",
-    tomes: [emptyTome(1)],
-    type: ComicType.BD,
-  };
-}
-
-function FormListbox({
-  label,
-  onChange,
-  options,
-  value,
-}: {
-  label: string;
-  onChange: (v: string) => void;
-  options: { label: string; value: string }[];
-  value: string;
-}) {
-  const selected = options.find((o) => o.value === value) ?? options[0];
-
-  return (
-    <div>
-      <span className="mb-1 block text-sm font-medium text-text-secondary">{label}</span>
-      <Listbox onChange={onChange} value={value}>
-        <div className="relative">
-          <ListboxButton className="flex w-full items-center justify-between gap-2 rounded-lg border border-surface-border bg-surface-primary px-3 py-2 text-sm text-text-primary transition hover:border-primary-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
-            <span>{selected.label}</span>
-            <ChevronDown className="h-4 w-4 text-text-muted" />
-          </ListboxButton>
-          <ListboxOptions className="absolute z-20 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-surface-border bg-surface-primary py-1 shadow-lg focus:outline-none">
-            {options.map((option) => (
-              <ListboxOption
-                className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm text-text-primary data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-950/30"
-                key={option.value}
-                value={option.value}
-              >
-                <Check
-                  className={`h-4 w-4 shrink-0 ${option.value === value ? "text-primary-600" : "invisible"}`}
-                />
-                {option.label}
-              </ListboxOption>
-            ))}
-          </ListboxOptions>
-        </div>
-      </Listbox>
-    </div>
-  );
-}
-
-const typeOptions = Object.entries(ComicType).map(([, value]) => ({
-  label: ComicTypeLabel[value],
-  value,
-}));
-
-const statusOptions = Object.entries(ComicStatus).map(([, value]) => ({
-  label: ComicStatusLabel[value],
-  value,
-}));
-
-const syncFieldLabels: Record<string, string> = {
-  authors: "Auteurs",
-  coverUrl: "Couverture",
-  description: "Description",
-  isOneShot: "One-shot",
-  latestPublishedIssue: "Dernier tome paru",
-  publisher: "Éditeur",
-  status: "Statut",
-  title: "Titre",
-  tomes: "Tomes",
-  type: "Type",
-};
-
-const syncOperationLabels: Record<string, string> = {
-  create: "Création",
-  delete: "Suppression",
-  update: "Mise à jour",
-};
-
-function formatSyncValue(value: unknown): string {
-  if (value === null || value === undefined) return "—";
-  if (typeof value === "boolean") return value ? "Oui" : "Non";
-  if (Array.isArray(value)) return `${value.length} élément(s)`;
-  return String(value);
-}
+import { statusOptions, typeOptions } from "../types/enums";
+import { fieldLabels, formatSyncValue, operationLabels } from "../utils/syncLabels";
 
 function SyncFailureSection({ failure, onDismiss }: { failure: SyncFailure; onDismiss: () => void }) {
   const entries = Object.entries(failure.payload)
@@ -201,7 +21,7 @@ function SyncFailureSection({ failure, onDismiss }: { failure: SyncFailure; onDi
         <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
         <div className="min-w-0 flex-1">
           <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
-            {syncOperationLabels[failure.operation] ?? failure.operation} échouée — {failure.error}
+            {operationLabels[failure.operation] ?? failure.operation} échouée — {failure.error}
           </p>
           <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
             Modifications tentées hors ligne :
@@ -210,7 +30,7 @@ function SyncFailureSection({ failure, onDismiss }: { failure: SyncFailure; onDi
             {entries.map(([key, value]) => (
               <div className="contents" key={key}>
                 <dt className="font-medium text-amber-800 dark:text-amber-300">
-                  {syncFieldLabels[key] ?? key}
+                  {fieldLabels[key] ?? key}
                 </dt>
                 <dd className="truncate text-amber-700 dark:text-amber-400">
                   {formatSyncValue(value)}
@@ -235,52 +55,49 @@ function SyncFailureSection({ failure, onDismiss }: { failure: SyncFailure; onDi
   );
 }
 
+const formListboxClassName = "flex w-full items-center justify-between gap-2 rounded-lg border border-surface-border bg-surface-primary px-3 py-2 text-sm text-text-primary transition hover:border-primary-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500";
+
 export default function ComicForm() {
-  const { id } = useParams<{ id: string }>();
-  const [searchParams] = useSearchParams();
-  const syncFailureId = searchParams.get("syncFailureId");
-  const isEdit = Boolean(id);
-  const navigate = useNavigate();
-  const isOnline = useOnlineStatus();
-  const { data: comic } = useComic(id ? Number(id) : undefined);
-  const createComic = useCreateComic();
-  const updateComic = useUpdateComic();
-  const { failures, resolveSyncFailure } = useSyncFailures();
-  const syncFailure = syncFailureId ? failures.find((f) => f.id === Number(syncFailureId)) : undefined;
-
-  const [form, setForm] = useState<FormData>(buildInitialForm());
-  const [initialized, setInitialized] = useState(!isEdit);
-
-  // Lookup state
-  const [isApplying, setIsApplying] = useState(false);
-  const [lookupIsbn, setLookupIsbn] = useState("");
-  const [lookupTitle, setLookupTitle] = useState("");
-  const [lookupMode, setLookupMode] = useState<"isbn" | "title">("title");
-  const [tomeLookupLoading, setTomeLookupLoading] = useState<number | null>(null);
-
-  // Cover search state
-  const [coverSearchOpen, setCoverSearchOpen] = useState(false);
-
-  // Batch add state
-  const [batchFrom, setBatchFrom] = useState(1);
-  const [batchTo, setBatchTo] = useState(1);
-
-  const isbnLookup = useLookupIsbn(lookupMode === "isbn" ? lookupIsbn : "", form.type);
-  const titleLookup = useLookupTitle(lookupMode === "title" ? lookupTitle : "", form.type);
-  const lookupResult = lookupMode === "isbn" ? isbnLookup : titleLookup;
-
-  // Author autocomplete
-  const [authorSearch, setAuthorSearch] = useState("");
-  const { data: authorResults } = useAuthors(authorSearch);
-  const authorOptions = authorResults?.member ?? [];
-
-  // Initialize form with comic data on edit
-  useEffect(() => {
-    if (isEdit && comic && !initialized) {
-      setForm(buildInitialForm(comic));
-      setInitialized(true);
-    }
-  }, [comic, isEdit, initialized]);
+  const {
+    addAuthor,
+    addBatchTomes,
+    addTome,
+    applyLookup,
+    authorOptions,
+    authorSearch,
+    batchFrom,
+    batchSize,
+    batchTo,
+    coverSearchOpen,
+    form,
+    handleSubmit,
+    initialized,
+    isApplying,
+    isEdit,
+    isOnline,
+    isSaving,
+    lookupIsbn,
+    lookupMode,
+    lookupResult,
+    lookupTitle,
+    lookupTomeIsbn,
+    maxBatchSize,
+    navigate,
+    removeAuthor,
+    removeTome,
+    resolveSyncFailure,
+    setAuthorSearch,
+    setBatchFrom,
+    setBatchTo,
+    setCoverSearchOpen,
+    setLookupIsbn,
+    setLookupMode,
+    setLookupTitle,
+    syncFailure,
+    tomeLookupLoading,
+    update,
+    updateTome,
+  } = useComicForm();
 
   if (isEdit && !initialized) {
     return (
@@ -325,218 +142,6 @@ export default function ComicForm() {
     );
   }
 
-  const update = <K extends keyof FormData>(key: K, value: FormData[K]) => {
-    setForm((prev) => ({ ...prev, [key]: value }));
-  };
-
-  const applySeriesFields = (result: import("../types/api").LookupResult) => {
-    setForm((prev) => ({
-      ...prev,
-      coverUrl: result.thumbnail ?? prev.coverUrl,
-      description: result.description ?? prev.description,
-      isOneShot: result.isOneShot || prev.isOneShot,
-      latestPublishedIssue: result.latestPublishedIssue?.toString() ?? prev.latestPublishedIssue,
-      publisher: result.publisher ?? prev.publisher,
-      title: result.title || prev.title,
-    }));
-
-    if (result.authors) {
-      const authorNames = result.authors.split(",").map((n) => n.trim()).filter(Boolean);
-      update(
-        "authors",
-        authorNames.map((name, i) => ({ "@id": "", id: -(i + 1), name })),
-      );
-    }
-  };
-
-  const applyLookup = async () => {
-    const result = lookupResult.data;
-    if (!result) return;
-
-    if (lookupMode === "isbn" && result.title) {
-      // Chaînage ISBN → titre : l'ISBN donne le titre de la série, puis le lookup titre remplit les champs
-      setIsApplying(true);
-      try {
-        const titleResult = await fetchLookupTitle(result.title, form.type);
-        applySeriesFields(titleResult);
-        toast.success("Informations récupérées (ISBN → titre)");
-      } catch {
-        // Fallback : appliquer directement le résultat ISBN
-        applySeriesFields(result);
-        toast.success("Informations récupérées (ISBN uniquement)");
-      } finally {
-        setIsApplying(false);
-      }
-    } else {
-      applySeriesFields(result);
-      toast.success("Informations récupérées");
-    }
-  };
-
-  const addTome = () => {
-    const nextNum = form.tomes.length > 0 ? Math.max(...form.tomes.map((t) => t.number)) + 1 : 1;
-    update("tomes", [...form.tomes, emptyTome(nextNum)]);
-  };
-
-  const maxBatchSize = 100;
-  const batchSize = batchTo - batchFrom + 1;
-
-  const addBatchTomes = () => {
-    if (batchFrom < 1 || batchFrom > batchTo || batchSize > maxBatchSize) return;
-    const existingNumbers = new Set(form.tomes.map((t) => t.number));
-    const newTomes: TomeFormData[] = [];
-    for (let n = batchFrom; n <= batchTo; n++) {
-      if (!existingNumbers.has(n)) {
-        newTomes.push(emptyTome(n));
-      }
-    }
-    if (newTomes.length > 0) {
-      update("tomes", [...form.tomes, ...newTomes].sort((a, b) => a.number - b.number));
-    }
-  };
-
-  const removeTome = (index: number) => {
-    update(
-      "tomes",
-      form.tomes.filter((_, i) => i !== index),
-    );
-  };
-
-  const updateTome = <K extends keyof TomeFormData>(index: number, key: K, value: TomeFormData[K]) => {
-    update(
-      "tomes",
-      form.tomes.map((t, i) => (i === index ? { ...t, [key]: value } : t)),
-    );
-  };
-
-  const lookupTomeIsbn = async (index: number) => {
-    const isbn = form.tomes[index]?.isbn;
-    if (!isbn || isbn.length < 10) return;
-
-    setTomeLookupLoading(index);
-    try {
-      const result = await fetchLookupIsbn(isbn, form.type);
-      update(
-        "tomes",
-        form.tomes.map((t, i) =>
-          i === index
-            ? { ...t, isbn: result.isbn ?? t.isbn, title: result.title ?? t.title, tomeEnd: result.tomeEnd?.toString() ?? t.tomeEnd }
-            : t,
-        ),
-      );
-      toast.success(`Tome ${form.tomes[index].number} : informations récupérées`);
-    } catch {
-      toast.error("Échec de la recherche ISBN");
-    } finally {
-      setTomeLookupLoading(null);
-    }
-  };
-
-  const addAuthor = (author: Author) => {
-    if (!form.authors.some((a) => a.name === author.name)) {
-      update("authors", [...form.authors, author]);
-    }
-    setAuthorSearch("");
-  };
-
-  const removeAuthor = (index: number) => {
-    update(
-      "authors",
-      form.authors.filter((_, i) => i !== index),
-    );
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    // Créer les nouveaux auteurs via l'API et récupérer leurs IRI
-    const authorIris: string[] = [];
-    const pendingAuthors: string[] = [];
-    for (const a of form.authors) {
-      if (a.id > 0) {
-        authorIris.push(a["@id"]);
-      } else if (!navigator.onLine) {
-        // Hors ligne : stocker les noms pour création au retour en ligne
-        pendingAuthors.push(a.name);
-      } else {
-        try {
-          const created = await apiFetch<Author>("/authors", {
-            body: JSON.stringify({ name: a.name }),
-            method: "POST",
-          });
-          authorIris.push(created["@id"]);
-        } catch {
-          toast.error(`Erreur lors de la création de l'auteur « ${a.name} »`);
-          return;
-        }
-      }
-    }
-
-    const payload: Record<string, unknown> = {
-      ...(pendingAuthors.length > 0 ? { _pendingAuthors: pendingAuthors } : {}),
-      authors: authorIris,
-      coverUrl: form.coverUrl || null,
-      defaultTomeBought: form.defaultTomeBought,
-      defaultTomeDownloaded: form.defaultTomeDownloaded,
-      defaultTomeRead: form.defaultTomeRead,
-      description: form.description || null,
-      isOneShot: form.isOneShot,
-      latestPublishedIssue: form.latestPublishedIssue ? Number(form.latestPublishedIssue) : null,
-      latestPublishedIssueComplete: form.latestPublishedIssueComplete,
-      publisher: form.publisher || null,
-      status: form.status,
-      title: form.title,
-      type: form.type,
-    };
-
-    if (!form.isOneShot) {
-      payload.tomes = [...form.tomes]
-        .sort((a, b) => a.number - b.number)
-        .map((t) => ({
-          ...(t.id ? { "@id": `/api/tomes/${t.id}` } : {}),
-          bought: t.bought,
-          downloaded: t.downloaded,
-          isbn: t.isbn || null,
-          number: t.number,
-          onNas: t.onNas,
-          read: t.read,
-          title: t.title || null,
-          tomeEnd: t.tomeEnd ? Number(t.tomeEnd) : null,
-        }));
-    }
-
-    if (isEdit && id) {
-      updateComic.mutate(
-        { id: Number(id), ...payload } as Partial<ComicSeries> & { id: number },
-        {
-          onSuccess: (data) => {
-            if (!data) return; // offline: déjà géré par useOfflineMutation
-            if (syncFailure?.id) void resolveSyncFailure(syncFailure.id);
-            toast.success("Série mise à jour");
-            navigate(`/comic/${id}`, { viewTransition: true });
-          },
-          onError: (err) => toast.error(err.message),
-        },
-      );
-    } else {
-      createComic.mutate(payload as Partial<ComicSeries>, {
-        onSuccess: (created) => {
-          if (!created) return; // offline: déjà géré par useOfflineMutation
-          if (syncFailure?.id) void resolveSyncFailure(syncFailure.id);
-          toast.success("Série créée");
-          navigate(`/comic/${created.id}`, { viewTransition: true });
-        },
-        onError: (err) => toast.error(err.message),
-      });
-    }
-
-    if (!navigator.onLine) {
-      navigate("/", { viewTransition: true });
-    }
-  };
-
-  const isSaving = createComic.isPending || updateComic.isPending;
-
   return (
     <div className="mx-auto max-w-3xl space-y-6">
       {/* Header */}
@@ -557,107 +162,20 @@ export default function ComicForm() {
         />
       )}
 
-      {/* Lookup section — visible on create AND edit */}
-      {isOnline ? (
-        <div className="rounded-lg border border-surface-border bg-surface-tertiary p-4 space-y-3">
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-semibold text-text-secondary">Recherche automatique</h2>
-            <div className="flex rounded-lg bg-surface-primary p-0.5 border border-surface-border">
-              <button
-                className={`rounded-md px-3 py-1 text-sm font-medium transition ${lookupMode === "isbn" ? "bg-primary-600 text-white shadow-sm" : "text-text-muted hover:text-text-secondary"}`}
-                onClick={() => setLookupMode("isbn")}
-                type="button"
-              >
-                ISBN
-              </button>
-              <button
-                className={`rounded-md px-3 py-1 text-sm font-medium transition ${lookupMode === "title" ? "bg-primary-600 text-white shadow-sm" : "text-text-muted hover:text-text-secondary"}`}
-                onClick={() => setLookupMode("title")}
-                type="button"
-              >
-                Titre
-              </button>
-            </div>
-          </div>
-
-          {lookupMode === "isbn" ? (
-            <div className="flex gap-2">
-              <input
-                className="flex-1 rounded-lg border border-surface-border bg-surface-primary px-3 py-2 text-sm text-text-primary"
-                onChange={(e) => setLookupIsbn(e.target.value)}
-                placeholder="ISBN (10 ou 13 chiffres)"
-                value={lookupIsbn}
-              />
-              <BarcodeScanner onScan={setLookupIsbn} />
-            </div>
-          ) : (
-            <div className="flex gap-2">
-              <input
-                className="flex-1 rounded-lg border border-surface-border bg-surface-primary px-3 py-2 text-sm text-text-primary"
-                onChange={(e) => setLookupTitle(e.target.value)}
-                placeholder="Titre de la série"
-                value={lookupTitle}
-              />
-              {form.title && form.title !== lookupTitle && (
-                <button
-                  className="flex shrink-0 items-center gap-1.5 rounded-lg border border-surface-border bg-surface-primary px-3 py-1.5 text-sm text-text-muted hover:border-primary-400 hover:text-primary-600 transition"
-                  onClick={() => setLookupTitle(form.title)}
-                  title="Utiliser le titre de la série"
-                  type="button"
-                >
-                  <Layers className="h-4 w-4" />
-                </button>
-              )}
-            </div>
-          )}
-
-          {lookupResult.isFetching && (
-            <div className="flex items-center gap-2 text-sm text-text-muted">
-              <Loader2 className="h-4 w-4 animate-spin" /> Recherche en cours…
-            </div>
-          )}
-
-          {lookupResult.data && !lookupResult.isFetching && (
-            <div className="rounded-lg bg-surface-primary p-3 border border-surface-border space-y-2">
-              <div className="flex items-center justify-between gap-3">
-                <div className="min-w-0 text-sm">
-                  <p className="truncate font-medium text-text-primary">{lookupResult.data.title}</p>
-                  <p className="truncate text-text-muted">
-                    {lookupResult.data.authors ?? ""}
-                    {lookupResult.data.publisher && ` — ${lookupResult.data.publisher}`}
-                  </p>
-                </div>
-                <button
-                  className="flex shrink-0 items-center gap-1.5 rounded-lg bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
-                  disabled={isApplying}
-                  onClick={applyLookup}
-                  type="button"
-                >
-                  {isApplying && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-                  Appliquer
-                </button>
-              </div>
-              {lookupResult.data.sources.length > 0 && (
-                <p className="text-xs text-text-muted">
-                  Sources : {lookupResult.data.sources.join(", ")}
-                </p>
-              )}
-              {Object.entries(lookupResult.data.apiMessages).filter(([, m]) => m.status !== "success").length > 0 && (
-                <p className="text-xs text-text-muted">
-                  {Object.entries(lookupResult.data.apiMessages)
-                    .filter(([, m]) => m.status !== "success")
-                    .map(([provider, m]) => `${provider}: ${m.message}`)
-                    .join(" · ")}
-                </p>
-              )}
-            </div>
-          )}
-        </div>
-      ) : (
-        <div className="rounded-lg border border-surface-border bg-surface-tertiary p-4">
-          <p className="text-sm text-text-muted">Recherche indisponible hors ligne</p>
-        </div>
-      )}
+      {/* Lookup section */}
+      <LookupSection
+        applyLookup={applyLookup}
+        formTitle={form.title}
+        isApplying={isApplying}
+        isOnline={isOnline}
+        lookupIsbn={lookupIsbn}
+        lookupMode={lookupMode}
+        lookupResult={lookupResult}
+        lookupTitle={lookupTitle}
+        setLookupIsbn={setLookupIsbn}
+        setLookupMode={setLookupMode}
+        setLookupTitle={setLookupTitle}
+      />
 
       {/* Form */}
       <form className="space-y-5" onSubmit={handleSubmit}>
@@ -677,13 +195,15 @@ export default function ComicForm() {
 
         {/* Type + Status */}
         <div className="grid grid-cols-2 gap-4">
-          <FormListbox
+          <SelectListbox
+            buttonClassName={formListboxClassName}
             label="Type *"
             onChange={(v) => update("type", v)}
             options={typeOptions}
             value={form.type}
           />
-          <FormListbox
+          <SelectListbox
+            buttonClassName={formListboxClassName}
             label="Statut *"
             onChange={(v) => update("status", v)}
             options={statusOptions}
@@ -755,62 +275,14 @@ export default function ComicForm() {
         />
 
         {/* Authors */}
-        <div>
-          <label className="mb-1 block text-sm font-medium text-text-secondary">Auteurs</label>
-          <div className="flex flex-wrap gap-2 mb-2">
-            {form.authors.map((author, i) => (
-              <span
-                className="flex items-center gap-1 rounded-full bg-primary-100 px-3 py-1 text-sm font-medium text-primary-700 dark:bg-primary-950/30 dark:text-primary-400"
-                key={author.id}
-              >
-                {author.name}
-                <button
-                  className="ml-1 rounded-full p-0.5 hover:bg-primary-200 dark:hover:bg-primary-900/40"
-                  onClick={() => removeAuthor(i)}
-                  type="button"
-                >
-                  <X className="h-3 w-3" />
-                </button>
-              </span>
-            ))}
-          </div>
-          <Combobox
-            onChange={(author: Author | null) => {
-              if (author) addAuthor(author);
-            }}
-            value={null}
-          >
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" />
-              <ComboboxInput
-                className="w-full rounded-lg border border-surface-border bg-surface-primary py-2 pl-10 pr-3 text-sm text-text-primary"
-                displayValue={() => authorSearch}
-                onChange={(e) => setAuthorSearch(e.target.value)}
-                placeholder="Rechercher ou créer un auteur…"
-              />
-              <ComboboxOptions className="absolute z-10 mt-1 max-h-48 w-full overflow-auto rounded-lg border border-surface-border bg-surface-primary shadow-lg">
-                {authorOptions.map((author) => (
-                  <ComboboxOption
-                    className="cursor-pointer px-3 py-2 text-sm text-text-primary data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-950/30"
-                    key={author.id}
-                    value={author}
-                  >
-                    {author.name}
-                  </ComboboxOption>
-                ))}
-                {authorSearch.length >= 2 && !authorOptions.some((a) => a.name.toLowerCase() === authorSearch.toLowerCase()) && (
-                  <ComboboxOption
-                    className="cursor-pointer px-3 py-2 text-sm text-primary-700 dark:text-primary-400 data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-950/30"
-                    value={{ "@id": "", id: -Date.now(), name: authorSearch } as Author}
-                  >
-                    <Plus className="mr-1 inline h-3 w-3" />
-                    Créer « {authorSearch} »
-                  </ComboboxOption>
-                )}
-              </ComboboxOptions>
-            </div>
-          </Combobox>
-        </div>
+        <AuthorAutocomplete
+          addAuthor={addAuthor}
+          authorOptions={authorOptions}
+          authorSearch={authorSearch}
+          authors={form.authors}
+          removeAuthor={removeAuthor}
+          setAuthorSearch={setAuthorSearch}
+        />
 
         {/* Description */}
         <div>
@@ -884,274 +356,21 @@ export default function ComicForm() {
 
         {/* Tomes */}
         {!form.isOneShot && (
-          <div>
-            <div className="mb-2 flex items-center justify-between">
-              <h2 className="text-sm font-semibold text-text-secondary">
-                Tomes ({form.tomes.length})
-              </h2>
-              <button
-                className="flex items-center gap-1 rounded-lg bg-primary-100 px-3 py-1.5 text-sm font-medium text-primary-700 hover:bg-primary-200 dark:bg-primary-950/30 dark:text-primary-400 dark:hover:bg-primary-900/40"
-                onClick={addTome}
-                type="button"
-              >
-                <Plus className="h-4 w-4" /> Ajouter
-              </button>
-            </div>
-            <div className="mb-3 flex flex-wrap items-end gap-2 rounded-lg border border-surface-border bg-surface-tertiary p-3">
-              <div>
-                <label className="mb-1 block text-xs font-medium text-text-muted" htmlFor="batch-from">Du tome</label>
-                <input
-                  className="w-16 rounded border border-surface-border bg-surface-primary px-2 py-1 text-center text-sm text-text-primary"
-                  id="batch-from"
-                  min="1"
-                  onChange={(e) => setBatchFrom(Number(e.target.value))}
-                  type="number"
-                  value={batchFrom}
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-xs font-medium text-text-muted" htmlFor="batch-to">au tome</label>
-                <input
-                  className="w-16 rounded border border-surface-border bg-surface-primary px-2 py-1 text-center text-sm text-text-primary"
-                  id="batch-to"
-                  min="1"
-                  onChange={(e) => setBatchTo(Number(e.target.value))}
-                  type="number"
-                  value={batchTo}
-                />
-              </div>
-              <button
-                className="flex items-center gap-1 rounded-lg bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
-                disabled={batchFrom < 1 || batchFrom > batchTo || batchSize > maxBatchSize}
-                onClick={addBatchTomes}
-                type="button"
-              >
-                <Layers className="h-4 w-4" /> Générer
-              </button>
-              {batchSize > maxBatchSize && (
-                <span className="text-xs text-red-500">Max {maxBatchSize} tomes</span>
-              )}
-            </div>
-            {/* Mobile: card layout */}
-            <div className="space-y-3 sm:hidden" data-testid="tomes-cards">
-              {form.tomes
-                .map((tome, i) => ({ tome, originalIndex: i }))
-                .sort((a, b) => a.tome.number - b.tome.number)
-                .map(({ tome, originalIndex: i }) => (
-                <div className={`rounded-lg border p-3 space-y-2 ${tome.id ? "border-surface-border bg-surface-primary" : "border-emerald-300 bg-emerald-50 dark:border-emerald-700 dark:bg-emerald-950/30"}`} key={i}>
-                  <div className="flex items-center gap-2">
-                    {!tome.id && <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300">Nouveau</span>}
-                    <input
-                      className="w-14 rounded border border-surface-border bg-surface-tertiary px-2 py-1 text-center text-sm font-medium text-text-primary"
-                      min="0"
-                      onChange={(e) => updateTome(i, "number", Number(e.target.value))}
-                      type="number"
-                      value={tome.number}
-                    />
-                    <input
-                      className="w-14 rounded border border-surface-border bg-surface-tertiary px-2 py-1 text-center text-sm text-text-primary"
-                      min="0"
-                      onChange={(e) => updateTome(i, "tomeEnd", e.target.value)}
-                      placeholder="Fin"
-                      type="number"
-                      value={tome.tomeEnd}
-                    />
-                    <input
-                      className="flex-1 rounded border border-surface-border bg-surface-tertiary px-2 py-1 text-sm text-text-primary"
-                      onChange={(e) => updateTome(i, "title", e.target.value)}
-                      placeholder="Titre"
-                      value={tome.title}
-                    />
-                    <button
-                      aria-label={`Supprimer tome ${tome.number}`}
-                      className="shrink-0 rounded p-1 text-red-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/30"
-                      onClick={() => removeTome(i)}
-                      type="button"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <input
-                      className="flex-1 rounded border border-surface-border bg-surface-tertiary px-2 py-1 text-sm text-text-primary"
-                      onChange={(e) => updateTome(i, "isbn", e.target.value)}
-                      placeholder="ISBN"
-                      value={tome.isbn}
-                    />
-                    <button
-                      className="shrink-0 rounded p-1 text-text-muted hover:bg-surface-tertiary hover:text-primary-600 disabled:opacity-50"
-                      disabled={tome.isbn.length < 10 || tomeLookupLoading === i}
-                      onClick={() => lookupTomeIsbn(i)}
-                      title="Rechercher par ISBN"
-                      type="button"
-                    >
-                      {tomeLookupLoading === i
-                        ? <Loader2 className="h-4 w-4 animate-spin" />
-                        : <Search className="h-4 w-4" />}
-                    </button>
-                  </div>
-                  <div className="grid grid-cols-2 gap-x-4 gap-y-1">
-                    <label className="flex items-center gap-2 text-sm text-text-secondary">
-                      <input
-                        checked={tome.bought}
-                        className="h-4 w-4 rounded border-surface-border text-primary-600"
-                        onChange={(e) => updateTome(i, "bought", e.target.checked)}
-                        type="checkbox"
-                      />
-                      Acheté
-                    </label>
-                    <label className="flex items-center gap-2 text-sm text-text-secondary">
-                      <input
-                        checked={tome.downloaded}
-                        className="h-4 w-4 rounded border-surface-border text-primary-600"
-                        onChange={(e) => updateTome(i, "downloaded", e.target.checked)}
-                        type="checkbox"
-                      />
-                      DL
-                    </label>
-                    <label className="flex items-center gap-2 text-sm text-text-secondary">
-                      <input
-                        checked={tome.read}
-                        className="h-4 w-4 rounded border-surface-border text-primary-600"
-                        onChange={(e) => updateTome(i, "read", e.target.checked)}
-                        type="checkbox"
-                      />
-                      Lu
-                    </label>
-                    <label className="flex items-center gap-2 text-sm text-text-secondary">
-                      <input
-                        checked={tome.onNas}
-                        className="h-4 w-4 rounded border-surface-border text-primary-600"
-                        onChange={(e) => updateTome(i, "onNas", e.target.checked)}
-                        type="checkbox"
-                      />
-                      NAS
-                    </label>
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            {/* Desktop: table layout */}
-            <div className="hidden overflow-x-auto rounded-lg border border-surface-border sm:block" data-testid="tomes-table">
-              <table className="w-full text-sm">
-                <thead className="bg-surface-tertiary">
-                  <tr>
-                    <th className="px-3 py-2 text-left font-medium text-text-secondary">#</th>
-                    <th className="px-3 py-2 text-left font-medium text-text-secondary">Fin</th>
-                    <th className="px-3 py-2 text-left font-medium text-text-secondary">Titre</th>
-                    <th className="px-3 py-2 text-left font-medium text-text-secondary">ISBN</th>
-                    <th className="px-3 py-2 text-center font-medium text-text-secondary">Acheté</th>
-                    <th className="px-3 py-2 text-center font-medium text-text-secondary">DL</th>
-                    <th className="px-3 py-2 text-center font-medium text-text-secondary">Lu</th>
-                    <th className="px-3 py-2 text-center font-medium text-text-secondary">NAS</th>
-                    <th className="px-3 py-2" />
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-surface-border">
-                  {form.tomes
-                    .map((tome, i) => ({ tome, originalIndex: i }))
-                    .sort((a, b) => a.tome.number - b.tome.number)
-                    .map(({ tome, originalIndex: i }) => (
-                    <tr className={tome.id ? "" : "bg-emerald-50 dark:bg-emerald-950/20"} key={i}>
-                      <td className="px-3 py-1.5">
-                        <div className="flex items-center gap-1">
-                          <input
-                            className="w-14 rounded border border-surface-border bg-surface-primary px-2 py-1 text-center text-sm text-text-primary"
-                            min="0"
-                            onChange={(e) => updateTome(i, "number", Number(e.target.value))}
-                            type="number"
-                            value={tome.number}
-                          />
-                          {!tome.id && <span className="rounded bg-emerald-100 px-1 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300">Nouveau</span>}
-                        </div>
-                      </td>
-                      <td className="px-3 py-1.5">
-                        <input
-                          className="w-14 rounded border border-surface-border bg-surface-primary px-2 py-1 text-center text-sm text-text-primary"
-                          min="0"
-                          onChange={(e) => updateTome(i, "tomeEnd", e.target.value)}
-                          placeholder="Fin"
-                          type="number"
-                          value={tome.tomeEnd}
-                        />
-                      </td>
-                      <td className="px-3 py-1.5">
-                        <input
-                          className="w-full min-w-[100px] rounded border border-surface-border bg-surface-primary px-2 py-1 text-sm text-text-primary"
-                          onChange={(e) => updateTome(i, "title", e.target.value)}
-                          placeholder="Titre"
-                          value={tome.title}
-                        />
-                      </td>
-                      <td className="px-3 py-1.5">
-                        <div className="flex items-center gap-1">
-                          <input
-                            className="w-full min-w-[120px] rounded border border-surface-border bg-surface-primary px-2 py-1 text-sm text-text-primary"
-                            onChange={(e) => updateTome(i, "isbn", e.target.value)}
-                            placeholder="ISBN"
-                            value={tome.isbn}
-                          />
-                          <button
-                            className="shrink-0 rounded p-1 text-text-muted hover:bg-surface-tertiary hover:text-primary-600 disabled:opacity-50"
-                            disabled={tome.isbn.length < 10 || tomeLookupLoading === i}
-                            onClick={() => lookupTomeIsbn(i)}
-                            title="Rechercher par ISBN"
-                            type="button"
-                          >
-                            {tomeLookupLoading === i
-                              ? <Loader2 className="h-4 w-4 animate-spin" />
-                              : <Search className="h-4 w-4" />}
-                          </button>
-                        </div>
-                      </td>
-                      <td className="px-3 py-1.5 text-center">
-                        <input
-                          checked={tome.bought}
-                          className="h-4 w-4 rounded border-surface-border text-primary-600"
-                          onChange={(e) => updateTome(i, "bought", e.target.checked)}
-                          type="checkbox"
-                        />
-                      </td>
-                      <td className="px-3 py-1.5 text-center">
-                        <input
-                          checked={tome.downloaded}
-                          className="h-4 w-4 rounded border-surface-border text-primary-600"
-                          onChange={(e) => updateTome(i, "downloaded", e.target.checked)}
-                          type="checkbox"
-                        />
-                      </td>
-                      <td className="px-3 py-1.5 text-center">
-                        <input
-                          checked={tome.read}
-                          className="h-4 w-4 rounded border-surface-border text-primary-600"
-                          onChange={(e) => updateTome(i, "read", e.target.checked)}
-                          type="checkbox"
-                        />
-                      </td>
-                      <td className="px-3 py-1.5 text-center">
-                        <input
-                          checked={tome.onNas}
-                          className="h-4 w-4 rounded border-surface-border text-primary-600"
-                          onChange={(e) => updateTome(i, "onNas", e.target.checked)}
-                          type="checkbox"
-                        />
-                      </td>
-                      <td className="px-3 py-1.5">
-                        <button
-                          className="rounded p-1 text-red-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/30"
-                          onClick={() => removeTome(i)}
-                          type="button"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
+          <TomeTable
+            addBatchTomes={addBatchTomes}
+            addTome={addTome}
+            batchFrom={batchFrom}
+            batchSize={batchSize}
+            batchTo={batchTo}
+            form={form}
+            lookupTomeIsbn={lookupTomeIsbn}
+            maxBatchSize={maxBatchSize}
+            removeTome={removeTome}
+            setBatchFrom={setBatchFrom}
+            setBatchTo={setBatchTo}
+            tomeLookupLoading={tomeLookupLoading}
+            updateTome={updateTome}
+          />
         )}
       </form>
 

--- a/frontend/src/pages/LookupTool.tsx
+++ b/frontend/src/pages/LookupTool.tsx
@@ -6,15 +6,7 @@ import {
   useBatchLookup,
   useBatchLookupPreview,
 } from "../hooks/useBatchLookup";
-import { ComicTypeLabel } from "../types/enums";
-
-const typeOptions = [
-  { label: "Tous les types", value: "" },
-  ...Object.entries(ComicTypeLabel).map(([value, label]) => ({
-    label,
-    value,
-  })),
-];
+import { typeOptionsAll } from "../types/enums";
 
 export default function LookupTool() {
   const [type, setType] = useState("");
@@ -56,7 +48,7 @@ export default function LookupTool() {
             onChange={(e) => setType(e.target.value)}
             value={type}
           >
-            {typeOptions.map((opt) => (
+            {typeOptionsAll.map((opt) => (
               <option key={opt.value} value={opt.value}>
                 {opt.label}
               </option>

--- a/frontend/src/pages/MergeSeries.tsx
+++ b/frontend/src/pages/MergeSeries.tsx
@@ -1,8 +1,4 @@
 import {
-  Listbox,
-  ListboxButton,
-  ListboxOption,
-  ListboxOptions,
   Switch,
   Tab,
   TabGroup,
@@ -10,11 +6,12 @@ import {
   TabPanel,
   TabPanels,
 } from "@headlessui/react";
-import { Check, ChevronDown, Loader2, Merge, Search as SearchIcon } from "lucide-react";
+import { Loader2, Merge, Search as SearchIcon } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
 import EmptyState from "../components/EmptyState";
+import SelectListbox from "../components/SelectListbox";
 import MergeGroupCard from "../components/MergeGroupCard";
 import MergePreviewModal from "../components/MergePreviewModal";
 import MergeSeriesConfirmModal, { type MergeSeriesEntry } from "../components/MergeSeriesConfirmModal";
@@ -25,19 +22,7 @@ import {
   useMergePreview,
 } from "../hooks/useMergeSeries";
 import type { ComicSeries, HydraCollection, MergeGroup, MergePreview } from "../types/api";
-import { ComicType, ComicTypeLabel } from "../types/enums";
-
-interface SelectOption {
-  label: string;
-  value: string;
-}
-
-const typeOptions: SelectOption[] = Object.entries(ComicType).map(
-  ([, value]) => ({
-    label: ComicTypeLabel[value],
-    value,
-  }),
-);
+import { type SelectOption, typeOptions } from "../types/enums";
 
 const letterOptions: SelectOption[] = [
   { label: "0-9", value: "0-9" },
@@ -148,11 +133,6 @@ export default function MergeSeries() {
     });
   };
 
-  const selectedTypeOption = typeOptions.find((o) => o.value === selectedType);
-  const selectedLetterOption = letterOptions.find(
-    (o) => o.value === selectedLetter,
-  );
-
   return (
     <div className="mx-auto max-w-4xl px-4 py-6">
       <h1 className="text-xl font-bold text-text-primary">
@@ -176,65 +156,21 @@ export default function MergeSeries() {
               {/* Filters row */}
               <div className="flex flex-wrap items-center gap-3">
                 <div className="min-w-0 flex-1">
-                  <Listbox onChange={setSelectedType} value={selectedType}>
-                    <div className="relative">
-                      <ListboxButton className="flex w-full items-center justify-between gap-2 rounded-lg border border-surface-border bg-surface-primary px-3 py-1.5 text-sm text-text-primary transition hover:border-primary-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
-                        <span className={`truncate ${!selectedTypeOption ? "text-text-muted" : ""}`}>
-                          {selectedTypeOption?.label ?? "Type"}
-                        </span>
-                        <ChevronDown className="h-4 w-4 text-text-muted" />
-                      </ListboxButton>
-                      <ListboxOptions className="absolute z-20 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-surface-border bg-surface-primary py-1 shadow-lg transition focus:outline-none">
-                        {typeOptions.map((option) => (
-                          <ListboxOption
-                            className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm text-text-primary data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-950/30"
-                            key={option.value}
-                            value={option.value}
-                          >
-                            <Check
-                              className={`h-4 w-4 shrink-0 ${
-                                option.value === selectedType
-                                  ? "text-primary-600"
-                                  : "invisible"
-                              }`}
-                            />
-                            {option.label}
-                          </ListboxOption>
-                        ))}
-                      </ListboxOptions>
-                    </div>
-                  </Listbox>
+                  <SelectListbox
+                    onChange={setSelectedType}
+                    options={typeOptions}
+                    placeholder="Type"
+                    value={selectedType}
+                  />
                 </div>
 
                 <div className="min-w-0 flex-1">
-                  <Listbox onChange={setSelectedLetter} value={selectedLetter}>
-                    <div className="relative">
-                      <ListboxButton className="flex w-full items-center justify-between gap-2 rounded-lg border border-surface-border bg-surface-primary px-3 py-1.5 text-sm text-text-primary transition hover:border-primary-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
-                        <span className={`truncate ${!selectedLetterOption ? "text-text-muted" : ""}`}>
-                          {selectedLetterOption?.label ?? "Lettre"}
-                        </span>
-                        <ChevronDown className="h-4 w-4 text-text-muted" />
-                      </ListboxButton>
-                      <ListboxOptions className="absolute z-20 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-surface-border bg-surface-primary py-1 shadow-lg transition focus:outline-none">
-                        {letterOptions.map((option) => (
-                          <ListboxOption
-                            className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm text-text-primary data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-950/30"
-                            key={option.value}
-                            value={option.value}
-                          >
-                            <Check
-                              className={`h-4 w-4 shrink-0 ${
-                                option.value === selectedLetter
-                                  ? "text-primary-600"
-                                  : "invisible"
-                              }`}
-                            />
-                            {option.label}
-                          </ListboxOption>
-                        ))}
-                      </ListboxOptions>
-                    </div>
-                  </Listbox>
+                  <SelectListbox
+                    onChange={setSelectedLetter}
+                    options={letterOptions}
+                    placeholder="Lettre"
+                    value={selectedLetter}
+                  />
                 </div>
 
                 <label className="flex items-center gap-2 text-sm text-text-secondary">

--- a/frontend/src/pages/Trash.tsx
+++ b/frontend/src/pages/Trash.tsx
@@ -7,6 +7,7 @@ import SkeletonBox from "../components/SkeletonBox";
 import { usePermanentDelete, useRestoreComic, useTrash } from "../hooks/useTrash";
 import type { ComicSeries } from "../types/api";
 import { ComicTypePlaceholder } from "../types/enums";
+import { getCoverSrc } from "../utils/coverUtils";
 
 export default function Trash() {
   const { data, isLoading } = useTrash();
@@ -47,7 +48,7 @@ export default function Trash() {
               <img
                 alt={comic.title}
                 className="h-12 w-9 rounded object-cover"
-                src={comic.coverImage ? `/uploads/covers/${comic.coverImage}` : (comic.coverUrl ?? ComicTypePlaceholder[comic.type])}
+                src={getCoverSrc(comic) ?? ComicTypePlaceholder[comic.type]}
               />
               <span className="flex-1 font-medium text-text-primary">{comic.title}</span>
               <button

--- a/frontend/src/types/enums.ts
+++ b/frontend/src/types/enums.ts
@@ -36,3 +36,32 @@ export const ComicTypePlaceholder: Record<ComicType, string> = {
   [ComicType.LIVRE]: "/placeholder-livre.jpg",
   [ComicType.MANGA]: "/placeholder-manga.jpg",
 };
+
+export interface SelectOption {
+  label: string;
+  value: string;
+}
+
+export const typeOptions: SelectOption[] = Object.entries(ComicType).map(
+  ([, value]) => ({
+    label: ComicTypeLabel[value],
+    value,
+  }),
+);
+
+export const typeOptionsAll: SelectOption[] = [
+  { label: "Tous les types", value: "" },
+  ...typeOptions,
+];
+
+export const statusOptions: SelectOption[] = Object.entries(ComicStatus)
+  .map(([, value]) => ({
+    label: ComicStatusLabel[value],
+    value,
+  }))
+  .sort((a, b) => a.label.localeCompare(b.label));
+
+export const statusOptionsAll: SelectOption[] = [
+  { label: "Tous les statuts", value: "" },
+  ...statusOptions,
+];

--- a/frontend/src/utils/coverUtils.ts
+++ b/frontend/src/utils/coverUtils.ts
@@ -1,0 +1,6 @@
+export function getCoverSrc(comic: { coverImage: string | null; coverUrl?: string | null }): string | null {
+  if (comic.coverImage) {
+    return `/uploads/covers/${comic.coverImage}`;
+  }
+  return comic.coverUrl ?? null;
+}

--- a/frontend/src/utils/syncLabels.ts
+++ b/frontend/src/utils/syncLabels.ts
@@ -1,0 +1,37 @@
+export const operationLabels: Record<string, string> = {
+  create: "Création",
+  delete: "Suppression",
+  update: "Mise à jour",
+};
+
+export const resourceLabels: Record<string, string> = {
+  comic_series: "série",
+  tome: "tome",
+};
+
+export const fieldLabels: Record<string, string> = {
+  authors: "Auteurs",
+  bought: "Acheté",
+  coverUrl: "Couverture",
+  description: "Description",
+  downloaded: "Téléchargé",
+  isbn: "ISBN",
+  isOneShot: "One-shot",
+  latestPublishedIssue: "Dernier tome paru",
+  number: "Numéro",
+  onNas: "NAS",
+  publisher: "Éditeur",
+  read: "Lu",
+  status: "Statut",
+  title: "Titre",
+  tomeEnd: "Fin",
+  tomes: "Tomes",
+  type: "Type",
+};
+
+export function formatSyncValue(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "boolean") return value ? "Oui" : "Non";
+  if (Array.isArray(value)) return `${value.length} élément(s)`;
+  return String(value);
+}


### PR DESCRIPTION
## Summary

- Centralise `typeOptions`/`statusOptions` dans `enums.ts` (utilisés par Filters, ComicForm, MergeSeries, LookupTool)
- Extrait `getCoverSrc()` dans `utils/coverUtils.ts` (ComicCard, ComicDetail, Trash)
- Extrait les labels de sync dans `utils/syncLabels.ts` (ComicForm, SyncErrorBanner)
- Crée `SelectListbox` réutilisable remplaçant 4 Listbox inline (Filters, ComicForm, MergeSeries)
- Découpe `ComicForm.tsx` (1180 → 398 lignes) en `useComicForm`, `TomeTable`, `LookupSection`, `AuthorAutocomplete`
- Ajoute tests unitaires pour `typeOptions`, `statusOptions`, `getCoverSrc`, `syncLabels` et `SelectListbox`

## Test plan

- [x] 613 tests Vitest passent (68 fichiers)
- [x] `tsc --noEmit` sans erreur
- [x] Aucun changement de comportement — refactoring pur

fixes #169