### PR TITLE
feat(frontend): ajoute la page « À acheter »

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Page « À acheter »** : Nouvelle page `/to-buy` listant les séries en cours d'achat avec tomes manquants, remplacement du tab Wishlist par « À acheter » dans la navigation (#191)
 - **CI GitHub Actions** : Workflow lint (PHPStan, CS Fixer, TypeScript) + tests (PHPUnit, Vitest) sur chaque PR, avec protection de la branche `main` (#166)
 - **Couvertures locales** : Téléchargement automatique des couvertures externes en WebP local via `CoverDownloader`, intégré au lookup et commande batch `app:download-covers` (#180)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,6 +58,7 @@ const Login = lazyWithRetry(() => import("./pages/Login"));
 const LookupTool = lazyWithRetry(() => import("./pages/LookupTool"));
 const MergeSeries = lazyWithRetry(() => import("./pages/MergeSeries"));
 const NotFound = lazyWithRetry(() => import("./pages/NotFound"));
+const ToBuy = lazyWithRetry(() => import("./pages/ToBuy"));
 const PurgeTool = lazyWithRetry(() => import("./pages/PurgeTool"));
 const Tools = lazyWithRetry(() => import("./pages/Tools"));
 const Trash = lazyWithRetry(() => import("./pages/Trash"));
@@ -101,6 +102,7 @@ const router = createBrowserRouter(
         <Route element={<LookupTool />} path="tools/lookup" />
         <Route element={<MergeSeries />} path="tools/merge-series" />
         <Route element={<PurgeTool />} path="tools/purge" />
+        <Route element={<ToBuy />} path="to-buy" />
         <Route element={<Trash />} path="trash" />
         <Route element={<NotFound />} path="*" />
       </Route>

--- a/frontend/src/__tests__/integration/components/BottomNav.test.tsx
+++ b/frontend/src/__tests__/integration/components/BottomNav.test.tsx
@@ -7,7 +7,7 @@ describe("BottomNav", () => {
     renderWithProviders(<BottomNav />);
 
     expect(screen.getByText("Accueil")).toBeInTheDocument();
-    expect(screen.getByText("Wishlist")).toBeInTheDocument();
+    expect(screen.getByText("À acheter")).toBeInTheDocument();
     expect(screen.getByText("Ajouter")).toBeInTheDocument();
     expect(screen.getByText("Corbeille")).toBeInTheDocument();
   });
@@ -16,38 +16,30 @@ describe("BottomNav", () => {
     renderWithProviders(<BottomNav />);
 
     expect(screen.getByText("Accueil").closest("a")).toHaveAttribute("href", "/");
-    expect(screen.getByText("Wishlist").closest("a")).toHaveAttribute("href", "/?status=wishlist");
+    expect(screen.getByText("À acheter").closest("a")).toHaveAttribute("href", "/to-buy");
     expect(screen.getByText("Ajouter").closest("a")).toHaveAttribute("href", "/comic/new");
     expect(screen.getByText("Corbeille").closest("a")).toHaveAttribute("href", "/trash");
   });
 
-  it("highlights Wishlist tab when status=wishlist in URL", () => {
-    renderWithProviders(<BottomNav />, { initialEntries: ["/?status=wishlist"] });
+  it("highlights À acheter tab on /to-buy", () => {
+    renderWithProviders(<BottomNav />, { initialEntries: ["/to-buy"] });
 
-    const wishlistLink = screen.getByText("Wishlist").closest("a");
-    expect(wishlistLink?.className).toContain("border-pink-500");
+    const toBuyLink = screen.getByText("À acheter").closest("a");
+    expect(toBuyLink?.className).toContain("border-emerald-500");
   });
 
-  it("does not highlight Home tab when status=wishlist", () => {
-    renderWithProviders(<BottomNav />, { initialEntries: ["/?status=wishlist"] });
-
-    const homeLink = screen.getByText("Accueil").closest("a");
-    expect(homeLink?.className).toContain("text-text-secondary");
-    expect(homeLink?.className).not.toContain("border-primary-500");
-  });
-
-  it("highlights Home tab on root without status param", () => {
+  it("highlights Home tab on root", () => {
     renderWithProviders(<BottomNav />, { initialEntries: ["/"] });
 
     const homeLink = screen.getByText("Accueil").closest("a");
     expect(homeLink?.className).toContain("border-primary-500");
   });
 
-  it("does not highlight Wishlist tab on root without status param", () => {
-    renderWithProviders(<BottomNav />, { initialEntries: ["/"] });
+  it("does not highlight Home tab on /to-buy", () => {
+    renderWithProviders(<BottomNav />, { initialEntries: ["/to-buy"] });
 
-    const wishlistLink = screen.getByText("Wishlist").closest("a");
-    expect(wishlistLink?.className).toContain("text-text-secondary");
-    expect(wishlistLink?.className).not.toContain("border-pink-500");
+    const homeLink = screen.getByText("Accueil").closest("a");
+    expect(homeLink?.className).toContain("text-text-secondary");
+    expect(homeLink?.className).not.toContain("border-primary-500");
   });
 });

--- a/frontend/src/__tests__/integration/components/Layout.test.tsx
+++ b/frontend/src/__tests__/integration/components/Layout.test.tsx
@@ -77,7 +77,7 @@ describe("Layout", () => {
     );
 
     expect(screen.getByText("Accueil")).toBeInTheDocument();
-    expect(screen.getByText("Wishlist")).toBeInTheDocument();
+    expect(screen.getByText("À acheter")).toBeInTheDocument();
     expect(screen.getByText("Corbeille")).toBeInTheDocument();
   });
 

--- a/frontend/src/__tests__/integration/pages/ToBuy.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ToBuy.test.tsx
@@ -1,0 +1,122 @@
+import { screen } from "@testing-library/react";
+import type { ComicSeries } from "../../../types/api";
+import { createTestQueryClient, renderWithProviders } from "../../helpers/test-utils";
+import ToBuy from "../../../pages/ToBuy";
+
+function makeTome(number: number, bought: boolean) {
+  return {
+    "@id": `/api/tomes/${number}`,
+    bought,
+    createdAt: "",
+    downloaded: false,
+    id: number,
+    isbn: null,
+    number,
+    onNas: false,
+    read: false,
+    title: null,
+    tomeEnd: null,
+    updatedAt: "",
+  };
+}
+
+function makeSeries(id: number, title: string, overrides: Partial<ComicSeries> = {}): ComicSeries {
+  return {
+    "@id": `/api/comics/${id}`,
+    authors: [],
+    coverImage: null,
+    coverUrl: null,
+    createdAt: "2024-01-01T00:00:00+00:00",
+    defaultTomeBought: true,
+    defaultTomeDownloaded: false,
+    defaultTomeRead: false,
+    description: null,
+    id,
+    isOneShot: false,
+    latestPublishedIssue: null,
+    latestPublishedIssueComplete: false,
+    latestPublishedIssueUpdatedAt: null,
+    publishedDate: null,
+    publisher: null,
+    status: "buying",
+    title,
+    tomes: [],
+    type: "manga",
+    updatedAt: "2024-01-01T00:00:00+00:00",
+    ...overrides,
+  };
+}
+
+function renderWithComics(comics: ComicSeries[]) {
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryData(["comics"], {
+    "@context": "/api/contexts/ComicSeries",
+    "@id": "/api/comics",
+    "@type": "Collection",
+    member: comics,
+    totalItems: comics.length,
+  });
+  return renderWithProviders(<ToBuy />, { initialEntries: ["/to-buy"], queryClient });
+}
+
+describe("ToBuy", () => {
+  it("shows empty state when no series to buy", () => {
+    renderWithComics([]);
+    expect(screen.getByText("Rien à acheter")).toBeInTheDocument();
+  });
+
+  it("shows buying series with unbought tomes", () => {
+    const series = makeSeries(1, "One Piece", {
+      tomes: [makeTome(1, true), makeTome(2, false), makeTome(3, false)],
+    });
+    renderWithComics([series]);
+    expect(screen.getByText("One Piece")).toBeInTheDocument();
+    expect(screen.getByText("Prochain : T.2, T.3")).toBeInTheDocument();
+  });
+
+  it("excludes finished series", () => {
+    const series = makeSeries(1, "Naruto", {
+      status: "finished",
+      tomes: [makeTome(1, false)],
+    });
+    renderWithComics([series]);
+    expect(screen.queryByText("Naruto")).not.toBeInTheDocument();
+    expect(screen.getByText("Rien à acheter")).toBeInTheDocument();
+  });
+
+  it("excludes one-shots", () => {
+    const series = makeSeries(1, "Akira", {
+      isOneShot: true,
+      tomes: [makeTome(1, false)],
+    });
+    renderWithComics([series]);
+    expect(screen.queryByText("Akira")).not.toBeInTheDocument();
+  });
+
+  it("excludes series with all tomes bought", () => {
+    const series = makeSeries(1, "Bleach", {
+      tomes: [makeTome(1, true), makeTome(2, true)],
+    });
+    renderWithComics([series]);
+    expect(screen.queryByText("Bleach")).not.toBeInTheDocument();
+  });
+
+  it("sorts series by title", () => {
+    const series = [
+      makeSeries(1, "Zetman", { tomes: [makeTome(1, false)] }),
+      makeSeries(2, "Akira Toriyama", { tomes: [makeTome(1, false)] }),
+    ];
+    renderWithComics(series);
+    const cards = screen.getAllByRole("link");
+    expect(cards[0]).toHaveTextContent("Akira Toriyama");
+    expect(cards[1]).toHaveTextContent("Zetman");
+  });
+
+  it("shows single tome as 'Prochain : T.X'", () => {
+    const series = makeSeries(1, "Solo", {
+      tomes: [makeTome(1, true), makeTome(2, false)],
+    });
+    renderWithComics([series]);
+    expect(screen.getByText("Prochain : T.2")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/unit/utils/toBuyUtils.test.tsx
+++ b/frontend/src/__tests__/unit/utils/toBuyUtils.test.tsx
@@ -1,0 +1,103 @@
+import type { ComicSeries } from "../../../types/api";
+import { filterSeriesToBuy, getNextTomesToBuy } from "../../../utils/toBuyUtils";
+
+function makeSeries(overrides: Partial<ComicSeries> = {}): ComicSeries {
+  return {
+    "@id": "/api/comics/1",
+    authors: [],
+    coverImage: null,
+    coverUrl: null,
+    createdAt: "2024-01-01T00:00:00+00:00",
+    defaultTomeBought: true,
+    defaultTomeDownloaded: false,
+    defaultTomeRead: false,
+    description: null,
+    id: 1,
+    isOneShot: false,
+    latestPublishedIssue: null,
+    latestPublishedIssueComplete: false,
+    latestPublishedIssueUpdatedAt: null,
+    publishedDate: null,
+    publisher: null,
+    status: "buying",
+    title: "Test Series",
+    tomes: [],
+    type: "manga",
+    updatedAt: "2024-01-01T00:00:00+00:00",
+    ...overrides,
+  };
+}
+
+describe("getNextTomesToBuy", () => {
+  it("returns empty array when all tomes are bought", () => {
+    const series = makeSeries({
+      tomes: [
+        { "@id": "/api/tomes/1", bought: true, createdAt: "", downloaded: false, id: 1, isbn: null, number: 1, onNas: false, read: false, title: null, tomeEnd: null, updatedAt: "" },
+        { "@id": "/api/tomes/2", bought: true, createdAt: "", downloaded: false, id: 2, isbn: null, number: 2, onNas: false, read: false, title: null, tomeEnd: null, updatedAt: "" },
+      ],
+    });
+    expect(getNextTomesToBuy(series)).toEqual([]);
+  });
+
+  it("returns unbought tome numbers sorted", () => {
+    const series = makeSeries({
+      tomes: [
+        { "@id": "/api/tomes/1", bought: true, createdAt: "", downloaded: false, id: 1, isbn: null, number: 1, onNas: false, read: false, title: null, tomeEnd: null, updatedAt: "" },
+        { "@id": "/api/tomes/2", bought: false, createdAt: "", downloaded: false, id: 2, isbn: null, number: 3, onNas: false, read: false, title: null, tomeEnd: null, updatedAt: "" },
+        { "@id": "/api/tomes/3", bought: false, createdAt: "", downloaded: false, id: 3, isbn: null, number: 2, onNas: false, read: false, title: null, tomeEnd: null, updatedAt: "" },
+      ],
+    });
+    expect(getNextTomesToBuy(series)).toEqual([2, 3]);
+  });
+
+  it("returns empty array when series has no tomes", () => {
+    const series = makeSeries({ tomes: [] });
+    expect(getNextTomesToBuy(series)).toEqual([]);
+  });
+});
+
+describe("filterSeriesToBuy", () => {
+  it("includes buying series with unbought tomes", () => {
+    const series = makeSeries({
+      status: "buying",
+      tomes: [
+        { "@id": "/api/tomes/1", bought: false, createdAt: "", downloaded: false, id: 1, isbn: null, number: 1, onNas: false, read: false, title: null, tomeEnd: null, updatedAt: "" },
+      ],
+    });
+    expect(filterSeriesToBuy([series])).toEqual([series]);
+  });
+
+  it("excludes non-buying series", () => {
+    const series = makeSeries({
+      status: "finished",
+      tomes: [
+        { "@id": "/api/tomes/1", bought: false, createdAt: "", downloaded: false, id: 1, isbn: null, number: 1, onNas: false, read: false, title: null, tomeEnd: null, updatedAt: "" },
+      ],
+    });
+    expect(filterSeriesToBuy([series])).toEqual([]);
+  });
+
+  it("excludes one-shots", () => {
+    const series = makeSeries({
+      isOneShot: true,
+      tomes: [
+        { "@id": "/api/tomes/1", bought: false, createdAt: "", downloaded: false, id: 1, isbn: null, number: 1, onNas: false, read: false, title: null, tomeEnd: null, updatedAt: "" },
+      ],
+    });
+    expect(filterSeriesToBuy([series])).toEqual([]);
+  });
+
+  it("excludes series with all tomes bought", () => {
+    const series = makeSeries({
+      tomes: [
+        { "@id": "/api/tomes/1", bought: true, createdAt: "", downloaded: false, id: 1, isbn: null, number: 1, onNas: false, read: false, title: null, tomeEnd: null, updatedAt: "" },
+      ],
+    });
+    expect(filterSeriesToBuy([series])).toEqual([]);
+  });
+
+  it("excludes series with no tomes", () => {
+    const series = makeSeries({ tomes: [] });
+    expect(filterSeriesToBuy([series])).toEqual([]);
+  });
+});

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,11 +1,11 @@
-import { Heart, Home, Plus, Trash2 } from "lucide-react";
+import { Home, Plus, ShoppingCart, Trash2 } from "lucide-react";
 import type { ComponentType } from "react";
-import { Link, useLocation, useSearchParams } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 
 interface Tab {
   activeColor: string;
   icon: ComponentType<{ className?: string }>;
-  isActive: (pathname: string, status: string) => boolean;
+  isActive: (pathname: string) => boolean;
   label: string;
   to: string;
 }
@@ -14,19 +14,19 @@ const tabs: Tab[] = [
   {
     activeColor: "border-primary-500 text-primary-600",
     icon: Home,
-    isActive: (pathname, status) => pathname === "/" && status !== "wishlist",
+    isActive: (pathname) => pathname === "/",
     label: "Accueil",
     to: "/",
   },
   {
-    activeColor: "border-pink-500 text-pink-600",
-    icon: Heart,
-    isActive: (pathname, status) => pathname === "/" && status === "wishlist",
-    label: "Wishlist",
-    to: "/?status=wishlist",
+    activeColor: "border-emerald-500 text-emerald-600",
+    icon: ShoppingCart,
+    isActive: (pathname) => pathname === "/to-buy",
+    label: "À acheter",
+    to: "/to-buy",
   },
   {
-    activeColor: "border-emerald-500 text-emerald-600",
+    activeColor: "border-sky-500 text-sky-600",
     icon: Plus,
     isActive: (pathname) => pathname === "/comic/new",
     label: "Ajouter",
@@ -43,14 +43,12 @@ const tabs: Tab[] = [
 
 export default function BottomNav() {
   const { pathname } = useLocation();
-  const [searchParams] = useSearchParams();
-  const status = searchParams.get("status") ?? "";
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-50 mx-auto h-[var(--bottom-nav-h)] border-t border-surface-border bg-surface-primary pb-safe lg:max-w-4xl lg:left-1/2 lg:-translate-x-1/2 lg:rounded-t-xl lg:border-x">
       <div className="flex h-full items-center justify-around">
         {tabs.map(({ activeColor, icon: Icon, isActive, label, to }) => {
-          const active = isActive(pathname, status);
+          const active = isActive(pathname);
           return (
             <Link
               className={`flex flex-col items-center justify-center gap-0.5 px-3 text-xs font-medium transition-colors ${

--- a/frontend/src/pages/ToBuy.tsx
+++ b/frontend/src/pages/ToBuy.tsx
@@ -1,0 +1,88 @@
+import { Loader2, Search, ShoppingCart } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import ComicCard from "../components/ComicCard";
+import ComicCardSkeleton from "../components/ComicCardSkeleton";
+import EmptyState from "../components/EmptyState";
+import { useComics } from "../hooks/useComics";
+import { searchComics } from "../utils/searchComics";
+import { filterSeriesToBuy, getNextTomesToBuy } from "../utils/toBuyUtils";
+
+export default function ToBuy() {
+  const { data, isFetching, isLoading } = useComics();
+  const allComics = data?.member ?? [];
+
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const handleSearchChange = useCallback((v: string) => {
+    setSearch(v);
+    clearTimeout(searchTimerRef.current);
+    searchTimerRef.current = setTimeout(() => setDebouncedSearch(v), 300);
+  }, []);
+
+  useEffect(() => {
+    return () => clearTimeout(searchTimerRef.current);
+  }, []);
+
+  const filtered = useMemo(() => {
+    const toBuy = filterSeriesToBuy(allComics);
+    const searched = searchComics(toBuy, debouncedSearch);
+    return [...searched].sort((a, b) => a.title.localeCompare(b.title, "fr"));
+  }, [allComics, debouncedSearch]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <div className="relative min-w-0 flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" />
+          <input
+            className="w-full rounded-lg border border-surface-border bg-surface-primary py-2 pl-10 pr-4 text-sm text-text-primary placeholder:text-text-muted focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+            onChange={(e) => handleSearchChange(e.target.value)}
+            placeholder="Rechercher…"
+            type="search"
+            value={search}
+          />
+        </div>
+        <span className="flex shrink-0 items-center gap-1.5 text-sm text-text-muted">
+          {isFetching && !isLoading && (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          )}
+          {filtered.length}
+        </span>
+      </div>
+
+      {isLoading ? (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+          {Array.from({ length: 8 }, (_, i) => (
+            <ComicCardSkeleton key={i} />
+          ))}
+        </div>
+      ) : filtered.length === 0 ? (
+        debouncedSearch ? (
+          <EmptyState
+            icon={Search}
+            title={`Aucun résultat pour « ${debouncedSearch} »`}
+          />
+        ) : (
+          <EmptyState
+            description="Toutes vos séries en cours sont complètes"
+            icon={ShoppingCart}
+            title="Rien à acheter"
+          />
+        )
+      ) : (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+          {filtered.map((comic) => (
+            <div key={comic.id}>
+              <ComicCard comic={comic} />
+              <p className="mt-1 truncate px-1 text-xs text-emerald-600 dark:text-emerald-400">
+                Prochain : {getNextTomesToBuy(comic).map((n) => `T.${n}`).join(", ")}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/utils/toBuyUtils.ts
+++ b/frontend/src/utils/toBuyUtils.ts
@@ -1,0 +1,14 @@
+import type { ComicSeries } from "../types/api";
+
+export function getNextTomesToBuy(series: ComicSeries): number[] {
+  return series.tomes
+    .filter((t) => !t.bought)
+    .map((t) => t.number)
+    .sort((a, b) => a - b);
+}
+
+export function filterSeriesToBuy(series: ComicSeries[]): ComicSeries[] {
+  return series.filter(
+    (s) => s.status === "buying" && !s.isOneShot && s.tomes.some((t) => !t.bought),
+  );
+}


### PR DESCRIPTION
## Summary
- Nouvelle page `/to-buy` affichant les séries `buying` non one-shot avec au moins un tome non acheté, triées par titre
- Remplacement du tab Wishlist par « À acheter » (icône ShoppingCart, couleur emerald) dans BottomNav
- Utilitaires `getNextTomesToBuy()` et `filterSeriesToBuy()` avec tests unitaires
- Sous chaque card, affichage "Prochain : T.X, T.Y" des tomes manquants

## Test Plan
- [x] 8 tests unitaires `toBuyUtils` passent
- [x] 7 tests intégration `ToBuy` page passent
- [x] 5 tests intégration `BottomNav` mis à jour et passent
- [x] Test Layout mis à jour (Wishlist → À acheter)
- [x] 628/628 tests passent, lint clean

fixes #191