### PR TITLE
fix(deploy): arrête le script de mise à jour si git pull échoue

### DIFF
--- a/scripts/nas-update.sh
+++ b/scripts/nas-update.sh
@@ -49,7 +49,14 @@ log "=== Début de la mise à jour ==="
 # Pull les dernières modifications
 cd "$APP_DIR" || { log "ERREUR: impossible d'accéder à ${APP_DIR}"; exit 1; }
 GIT_OUTPUT=$(git pull origin main 2>&1)
+GIT_EXIT_CODE=$?
 log "git pull: ${GIT_OUTPUT}"
+
+# Si git pull a échoué, on s'arrête et on notifie
+if [ "$GIT_EXIT_CODE" -ne 0 ]; then
+    log "ERREUR: git pull a échoué (exit code ${GIT_EXIT_CODE})."
+    exit 1
+fi
 
 # Si rien n'a changé, on s'arrête
 if echo "$GIT_OUTPUT" | grep -q "Already up to date"; then


### PR DESCRIPTION
## Summary
- **Corrige un bug silencieux** : le script `nas-update.sh` ignorait les erreurs de `git pull` (ex: clé SSH inaccessible par root) et continuait le build avec le vieux code, sans notification
- Vérifie maintenant le code de retour de `git pull` et sort avec `exit 1`, ce qui déclenche l'alerte DSM « script terminé de manière anormale »

## Test plan
- [ ] Vérifier que le script s'arrête bien si `git pull` échoue (simuler avec une mauvaise clé SSH)
- [ ] Vérifier que DSM envoie la notification quand le script sort en erreur