### PR TITLE
chore(claude): impose le skill /implement pour toute issue GitHub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Location: `docs/plans/` (gitignored). Concise only: what to do (files, logic, or
 
 ## Workflow
 
+- **GitHub issues → `/implement` skill**: ALL work on a GitHub issue (bug, feature, chore) MUST go through the `/implement` skill. No exceptions.
 - **Complex tasks**: Plan mode → approval → implementation
 - **Splitting**: divide large changes into verifiable chunks
 


### PR DESCRIPTION
## Summary
- Ajout règle CLAUDE.md : toute issue GitHub doit passer par le skill `/implement`
- Évite d'oublier les étapes de vérification (lint, tests, review) avant commit