### PR TITLE
chore(deploy): déploie par tag SemVer au lieu de suivre main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,11 +134,10 @@ Run CS-Fixer and tests afterwards.
 
 ### Tags/Releases (SemVer)
 
-Format: `vMAJOR.MINOR.PATCH`. Tags on `main` only.
+Format: `vMAJOR.MINOR.PATCH`. Tags on `main` only. **Pushing a tag triggers production deployment** (NAS pulls latest tag nightly via `nas-update.sh`).
 1. CHANGELOG: `[Unreleased]` → `[vX.Y.Z] - YYYY-MM-DD`
 2. Commit: `chore(release): vX.Y.Z`
-3. `git tag -a vX.Y.Z -m "vX.Y.Z"` + push
-4. `gh release create vX.Y.Z`
+3. `git tag -a vX.Y.Z -m "vX.Y.Z"` + push tag + push commit
 
 ## Issue Workflow
 

--- a/scripts/nas-update.sh
+++ b/scripts/nas-update.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # Script de mise à jour automatique — lancé par le planificateur DSM (root)
+# Déploie le dernier tag SemVer (vX.Y.Z) depuis le dépôt distant.
 
 APP_DIR="/volume1/docker/bibliotheque"
 BACKEND_DIR="${APP_DIR}/backend"
 ENV_FILE="${BACKEND_DIR}/.env.nas"
 LOG_DIR="/var/log/bibliotheque"
 LOG_FILE="${LOG_DIR}/update-$(date '+%Y-%m-%d').log"
-MAX_ROLLBACKS=5
 
 mkdir -p "$LOG_DIR"
 
@@ -14,19 +14,29 @@ log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
 }
 
+# Retourne le dernier tag SemVer (vX.Y.Z) trié par version.
+latest_tag() {
+    git -C "$APP_DIR" tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1
+}
+
+# Retourne le tag actuellement déployé (celui qui pointe sur HEAD, ou vide).
+current_tag() {
+    git -C "$APP_DIR" describe --tags --exact-match HEAD 2>/dev/null
+}
+
 # Tente un build et vérifie que les conteneurs démarrent correctement.
 # Retourne 0 si succès, 1 si échec.
 try_build() {
-    local commit_sha
-    commit_sha=$(git -C "$APP_DIR" rev-parse --short HEAD)
-    log "Tentative de build pour le commit ${commit_sha}..."
+    local tag
+    tag=$(current_tag)
+    log "Tentative de build pour le tag ${tag:-$(git -C "$APP_DIR" rev-parse --short HEAD)}..."
 
     cd "$BACKEND_DIR" || { log "ERREUR: impossible d'accéder à ${BACKEND_DIR}"; return 1; }
 
     docker compose --env-file "$ENV_FILE" down >> "$LOG_FILE" 2>&1
 
     if ! docker compose --env-file "$ENV_FILE" up --build -d >> "$LOG_FILE" 2>&1; then
-        log "ERREUR: docker compose up --build a échoué pour le commit ${commit_sha}."
+        log "ERREUR: docker compose up --build a échoué."
         return 1
     fi
 
@@ -36,35 +46,43 @@ try_build() {
     not_running=$(docker compose --env-file "$ENV_FILE" ps --format '{{.State}}' 2>/dev/null | grep -civ "running")
 
     if [ "$not_running" -gt 0 ]; then
-        log "ERREUR: des conteneurs ne sont pas running pour le commit ${commit_sha}."
+        log "ERREUR: des conteneurs ne sont pas running."
         return 1
     fi
 
-    log "Build réussi pour le commit ${commit_sha}."
+    log "Build réussi."
     return 0
 }
 
 log "=== Début de la mise à jour ==="
 
-# Pull les dernières modifications
 cd "$APP_DIR" || { log "ERREUR: impossible d'accéder à ${APP_DIR}"; exit 1; }
-GIT_OUTPUT=$(git pull origin main 2>&1)
-GIT_EXIT_CODE=$?
-log "git pull: ${GIT_OUTPUT}"
 
-# Si git pull a échoué, on s'arrête et on notifie
-if [ "$GIT_EXIT_CODE" -ne 0 ]; then
-    log "ERREUR: git pull a échoué (exit code ${GIT_EXIT_CODE})."
+# Récupérer les tags distants
+if ! git fetch --tags origin >> "$LOG_FILE" 2>&1; then
+    log "ERREUR: git fetch --tags a échoué."
     exit 1
 fi
 
-# Si rien n'a changé, on s'arrête
-if echo "$GIT_OUTPUT" | grep -q "Already up to date"; then
-    log "Aucune modification, arrêt."
+TARGET_TAG=$(latest_tag)
+CURRENT_TAG=$(current_tag)
+
+if [ -z "$TARGET_TAG" ]; then
+    log "ERREUR: aucun tag SemVer trouvé."
+    exit 1
+fi
+
+if [ "$TARGET_TAG" = "$CURRENT_TAG" ]; then
+    log "Déjà sur le tag ${TARGET_TAG}, aucune mise à jour nécessaire."
     exit 0
 fi
 
-# Tentative de build avec le dernier code
+log "Mise à jour : ${CURRENT_TAG:-aucun tag} → ${TARGET_TAG}"
+
+# Checkout du tag cible
+git checkout "$TARGET_TAG" >> "$LOG_FILE" 2>&1
+
+# Tentative de build avec le nouveau tag
 if try_build; then
     # Attendre que la DB soit healthy
     sleep 15
@@ -72,42 +90,30 @@ if try_build; then
     # Migrations
     docker compose --env-file "$ENV_FILE" exec -T php php bin/console doctrine:migrations:migrate -n --env=prod >> "$LOG_FILE" 2>&1
     log "Migrations exécutées."
-    log "=== Mise à jour terminée ==="
+    log "=== Mise à jour terminée (${TARGET_TAG}) ==="
     exit 0
 fi
 
-# Échec du build : rollback commit par commit (first-parent = une PR entière)
-log "Le build a échoué, début du rollback automatique..."
+# Échec du build : rollback vers les tags précédents
+log "Le build a échoué pour ${TARGET_TAG}, début du rollback..."
 
-rollback_count=0
-while [ "$rollback_count" -lt "$MAX_ROLLBACKS" ]; do
-    rollback_count=$((rollback_count + 1))
-    log "Rollback ${rollback_count}/${MAX_ROLLBACKS}..."
+# Lister les tags SemVer par version décroissante, en excluant le tag qui vient d'échouer
+PREVIOUS_TAGS=$(git -C "$APP_DIR" tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${TARGET_TAG}$" | head -5)
 
-    # Remonter au merge commit précédent (first-parent)
-    cd "$APP_DIR" || { log "ERREUR: impossible d'accéder à ${APP_DIR}"; exit 1; }
-    previous_commit=$(git log --first-parent --format='%H' -n 2 | tail -1)
-
-    if [ -z "$previous_commit" ]; then
-        log "ERREUR: impossible de trouver un commit précédent pour le rollback."
-        break
-    fi
-
-    git reset --hard "$previous_commit" >> "$LOG_FILE" 2>&1
-    log "Rollback vers ${previous_commit}."
+for tag in $PREVIOUS_TAGS; do
+    log "Rollback vers ${tag}..."
+    git checkout "$tag" >> "$LOG_FILE" 2>&1
 
     if try_build; then
         sleep 15
-        # Les migrations du commit rollbacké peuvent diverger du schéma actuel.
-        # doctrine:migrations:migrate applique l'état attendu par ce commit.
-        log "ATTENTION: rollback effectué — vérifier manuellement la cohérence des migrations si le commit annulé contenait des changements de schéma."
+        log "ATTENTION: rollback effectué — vérifier manuellement la cohérence des migrations si le tag annulé contenait des changements de schéma."
         docker compose --env-file "$ENV_FILE" exec -T php php bin/console doctrine:migrations:migrate -n --env=prod >> "$LOG_FILE" 2>&1
         log "Migrations exécutées après rollback."
-        log "=== Mise à jour terminée (rollback vers $(git -C "$APP_DIR" rev-parse --short HEAD)) ==="
+        log "=== Mise à jour terminée (rollback vers ${tag}) ==="
         exit 0
     fi
 done
 
-log "ERREUR CRITIQUE: rollback échoué après ${MAX_ROLLBACKS} tentatives. Intervention manuelle requise."
+log "ERREUR CRITIQUE: rollback échoué après avoir essayé les tags précédents. Intervention manuelle requise."
 log "=== Mise à jour échouée ==="
 exit 1


### PR DESCRIPTION
## Summary

- `nas-update.sh` déploie le dernier tag `vX.Y.Z` au lieu de `git pull origin main`
- Rollback par tags précédents au lieu de remonter les commits
- CLAUDE.md mis à jour pour refléter le nouveau workflow

Fixes #197 (contexte)