### PR TITLE
feat(lookup): affiche plusieurs séries candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Added
+
+- **Lookup multi-candidats** : Le lookup par titre affiche plusieurs séries candidates regroupées par titre, permettant de choisir avant d'appliquer. Paramètre `limit` sur `/api/lookup/title` (défaut 1, max 10). Tous les providers contribuent aux candidats (#200)
+
+### Fixed
+
+- **Priorité Bedetheque thumbnail BD** : La priorité du champ thumbnail est maintenant 150 (comme les autres champs) pour le type BD, au lieu de 50 (#200)
+
 ## [v2.6.0] - 2026-03-14
 
 ### Added

--- a/backend/phpstan-baseline.neon
+++ b/backend/phpstan-baseline.neon
@@ -63,13 +63,13 @@ parameters:
 		-
 			message: '#^Cannot call method getStatusCode\(\) on ApiPlatform\\Symfony\\Bundle\\Test\\Response\|null\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 4
 			path: tests/Functional/Api/LookupApiTest.php
 
 		-
 			message: '#^Cannot call method toArray\(\) on ApiPlatform\\Symfony\\Bundle\\Test\\Response\|null\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 5
 			path: tests/Functional/Api/LookupApiTest.php
 
 		-
@@ -367,9 +367,15 @@ parameters:
 			path: tests/Unit/Service/Lookup/BedethequeLookupTest.php
 
 		-
-			message: '#^Parameter \#1 \$attributes of static method Gemini\\Responses\\GenerativeModel\\GenerateContentResponse\:\:from\(\) expects .+$#'
+			message: '#^Parameter \#1 \$attributes of static method Gemini\\Responses\\GenerativeModel\\GenerateContentResponse\:\:from\(\) expects array\{candidates\: array\<array\{content\: array\{parts\: array\{array\{text\: string\|null, inlineData\: array\{mimeType\: string, data\: string\}\|null, fileData\: array\{fileUri\: string, mimeType\: string\}\|null, functionCall\: array\{name\: string, args\: array\<string, mixed\>\|null\}\|null, functionResponse\: array\{name\: string, response\: array\<string, mixed\>\}\|null\}\}, role\: string\}\|null, finishReason\: string\|null, safetyRatings\: array\{array\{category\: string, probability\: string, blocked\: bool\|null\}\}\|null, citationMetadata\: array\{citationSources\: array\{array\{startIndex\: int, endIndex\: int, uri\: string\|null, license\: string\|null\}\}\}\|null, index\: int\|null, tokenCount\: int\|null, avgLogprobs\: float\|null, groundingAttributions\: array\<array\{sourceId\: array\{groundingPassage\?\: array\{passageId\: string, partIndex\: int\}, semanticRetrieverChunk\?\: array\{source\: string, chunk\: string\}\}, content\: array\{parts\: array\{array\{text\: string\|null, inlineData\: array\{mimeType\: string, data\: string\}\|null, fileData\: array\{fileUri\: string, mimeType\: string\}\|null, functionCall\: array\{name\: string, args\: array\<string, mixed\>\|null\}\|null, functionResponse\: array\{name\: string, response\: array\<string, mixed\>\}\|null\}\}, role\: string\}\}\>\|null, \.\.\.\}\>\|null, promptFeedback\: array\{safetyRatings\: array\{array\{category\: string, probability\: string, blocked\: bool\|null\}\}, blockReason\: string\|null\}\|null, usageMetadata\: array\{promptTokenCount\: int, totalTokenCount\: int, candidatesTokenCount\: int\|null, cachedContentTokenCount\: int\|null, toolUsePromptTokenCount\: int\|null, thoughtsTokenCount\: int\|null, promptTokensDetails\: list\<array\{modality\: string, tokenCount\: int\}\>\|null, cacheTokensDetails\: list\<array\{modality\: string, tokenCount\: int\}\>\|null, \.\.\.\}, modelVersion\: string\|null\}, array\{candidates\: array\{\}, promptFeedback\: array\{blockReason\: ''SAFETY'', safetyRatings\: array\{array\{category\: ''HARM_CATEGORY…'', probability\: ''HIGH'', blocked\: true\}\}\}, usageMetadata\: array\{candidatesTokenCount\: 0, promptTokenCount\: 10, totalTokenCount\: 10\}\} given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
+			path: tests/Unit/Service/Lookup/BedethequeLookupTest.php
+
+		-
+			message: '#^Parameter \#1 \$attributes of static method Gemini\\Responses\\GenerativeModel\\GenerateContentResponse\:\:from\(\) expects array\{candidates\: array\<array\{content\: array\{parts\: array\{array\{text\: string\|null, inlineData\: array\{mimeType\: string, data\: string\}\|null, fileData\: array\{fileUri\: string, mimeType\: string\}\|null, functionCall\: array\{name\: string, args\: array\<string, mixed\>\|null\}\|null, functionResponse\: array\{name\: string, response\: array\<string, mixed\>\}\|null\}\}, role\: string\}\|null, finishReason\: string\|null, safetyRatings\: array\{array\{category\: string, probability\: string, blocked\: bool\|null\}\}\|null, citationMetadata\: array\{citationSources\: array\{array\{startIndex\: int, endIndex\: int, uri\: string\|null, license\: string\|null\}\}\}\|null, index\: int\|null, tokenCount\: int\|null, avgLogprobs\: float\|null, groundingAttributions\: array\<array\{sourceId\: array\{groundingPassage\?\: array\{passageId\: string, partIndex\: int\}, semanticRetrieverChunk\?\: array\{source\: string, chunk\: string\}\}, content\: array\{parts\: array\{array\{text\: string\|null, inlineData\: array\{mimeType\: string, data\: string\}\|null, fileData\: array\{fileUri\: string, mimeType\: string\}\|null, functionCall\: array\{name\: string, args\: array\<string, mixed\>\|null\}\|null, functionResponse\: array\{name\: string, response\: array\<string, mixed\>\}\|null\}\}, role\: string\}\}\>\|null, \.\.\.\}\>\|null, promptFeedback\: array\{safetyRatings\: array\{array\{category\: string, probability\: string, blocked\: bool\|null\}\}, blockReason\: string\|null\}\|null, usageMetadata\: array\{promptTokenCount\: int, totalTokenCount\: int, candidatesTokenCount\: int\|null, cachedContentTokenCount\: int\|null, toolUsePromptTokenCount\: int\|null, thoughtsTokenCount\: int\|null, promptTokensDetails\: list\<array\{modality\: string, tokenCount\: int\}\>\|null, cacheTokensDetails\: list\<array\{modality\: string, tokenCount\: int\}\>\|null, \.\.\.\}, modelVersion\: string\|null\}, array\{candidates\: array\{\}, promptFeedback\: null, usageMetadata\: array\{candidatesTokenCount\: 0, promptTokenCount\: 10, totalTokenCount\: 10\}\} given\.$#'
+			identifier: argument.type
+			count: 1
 			path: tests/Unit/Service/Lookup/BedethequeLookupTest.php
 
 		-
@@ -423,7 +429,7 @@ parameters:
 		-
 			message: '#^Cannot access property \$status on App\\Service\\Lookup\\ApiMessage\|null\.$#'
 			identifier: property.nonObject
-			count: 5
+			count: 6
 			path: tests/Unit/Service/Lookup/GoogleBooksLookupTest.php
 
 		-
@@ -451,25 +457,25 @@ parameters:
 			path: tests/Unit/Service/Lookup/LookupApplierTest.php
 
 		-
-			message: '#^Method App\\Service\\Lookup\\AbstractLookupProvider@anonymous/tests/Unit/Service/Lookup/LookupOrchestratorTest\.php\:299\:\:resolveLookup\(\) never returns null so it can be removed from the return type\.$#'
+			message: '#^Method App\\Service\\Lookup\\AbstractLookupProvider@anonymous/tests/Unit/Service/Lookup/LookupOrchestratorTest\.php\:300\:\:resolveLookup\(\) never returns null so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1
 			path: tests/Unit/Service/Lookup/LookupOrchestratorTest.php
 
 		-
-			message: '#^Method App\\Service\\Lookup\\LookupProviderInterface@anonymous/tests/Unit/Service/Lookup/LookupOrchestratorTest\.php\:574\:\:resolveLookup\(\) never returns null so it can be removed from the return type\.$#'
+			message: '#^Method App\\Service\\Lookup\\LookupProviderInterface@anonymous/tests/Unit/Service/Lookup/LookupOrchestratorTest\.php\:575\:\:resolveLookup\(\) never returns null so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1
 			path: tests/Unit/Service/Lookup/LookupOrchestratorTest.php
 
 		-
-			message: '#^Property App\\Service\\Lookup\\LookupProviderInterface@anonymous/tests/Unit/Service/Lookup/LookupOrchestratorTest\.php\:574\:\:\$calledSupportsType is never read, only written\.$#'
+			message: '#^Property App\\Service\\Lookup\\LookupProviderInterface@anonymous/tests/Unit/Service/Lookup/LookupOrchestratorTest\.php\:575\:\:\$calledSupportsType is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: tests/Unit/Service/Lookup/LookupOrchestratorTest.php
 
 		-
-			message: '#^Property App\\Service\\Lookup\\LookupProviderInterface@anonymous/tests/Unit/Service/Lookup/LookupOrchestratorTest\.php\:574\:\:\$calledWithType is never read, only written\.$#'
+			message: '#^Property App\\Service\\Lookup\\LookupProviderInterface@anonymous/tests/Unit/Service/Lookup/LookupOrchestratorTest\.php\:575\:\:\$calledWithType is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: tests/Unit/Service/Lookup/LookupOrchestratorTest.php

--- a/backend/src/Controller/ApiController.php
+++ b/backend/src/Controller/ApiController.php
@@ -55,6 +55,8 @@ final class ApiController
 
     /**
      * Recherche les informations par titre.
+     *
+     * Paramètre `limit` : 1 = résultat unique fusionné (défaut), 2-10 = multi-candidats.
      */
     #[Route('/title', name: 'api_lookup_title', methods: ['GET'])]
     public function titleLookup(Request $request, LookupOrchestrator $lookupOrchestrator): JsonResponse
@@ -66,9 +68,18 @@ final class ApiController
 
         $title = $request->query->get('title', '');
         $type = $this->resolveComicType($request);
+        $limit = \max(0, (int) $request->query->get('limit', '1'));
 
         if (empty($title)) {
             return new JsonResponse(['error' => 'Titre requis'], Response::HTTP_BAD_REQUEST);
+        }
+
+        if ($limit < 1 || $limit > 10) {
+            return new JsonResponse(['error' => 'Le paramètre limit doit être entre 1 et 10'], Response::HTTP_BAD_REQUEST);
+        }
+
+        if ($limit > 1) {
+            return $this->buildMultiLookupResponse($lookupOrchestrator, $title, $type, $limit);
         }
 
         $result = $lookupOrchestrator->lookupByTitle($title, $type);
@@ -97,6 +108,20 @@ final class ApiController
         $results = $coverSearchService->search($query, $type);
 
         return new JsonResponse($results);
+    }
+
+    /**
+     * Construit la réponse JSON pour un lookup multi-candidats.
+     */
+    private function buildMultiLookupResponse(LookupOrchestrator $lookupOrchestrator, string $title, ?ComicType $type, int $limit): JsonResponse
+    {
+        $results = $lookupOrchestrator->lookupByTitleMultiple($title, $type, $limit);
+
+        return new JsonResponse([
+            'apiMessages' => $lookupOrchestrator->getLastApiMessages(),
+            'results' => \array_map(static fn (LookupResult $r) => $r->jsonSerialize(), $results),
+            'sources' => $lookupOrchestrator->getLastSources(),
+        ]);
     }
 
     /**

--- a/backend/src/Service/Lookup/AniListLookup.php
+++ b/backend/src/Service/Lookup/AniListLookup.php
@@ -20,7 +20,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * Provider de recherche via l'API AniList (manga uniquement, par titre).
  */
 #[AutoconfigureTag('app.lookup_provider', ['priority' => 60])]
-final class AniListLookup extends AbstractLookupProvider
+final class AniListLookup extends AbstractLookupProvider implements MultiResultLookupProviderInterface
 {
     private const string API_URL = 'https://graphql.anilist.co';
 
@@ -59,6 +59,43 @@ final class AniListLookup extends AbstractLookupProvider
         }
         GRAPHQL;
 
+    private const string GRAPHQL_QUERY_PAGE = <<<'GRAPHQL'
+        query ($search: String, $perPage: Int) {
+            Page(perPage: $perPage) {
+                media(search: $search, type: MANGA) {
+                    title {
+                        english
+                        native
+                        romaji
+                    }
+                    format
+                    volumes
+                    status
+                    description(asHtml: false)
+                    coverImage {
+                        extraLarge
+                        large
+                    }
+                    startDate {
+                        day
+                        month
+                        year
+                    }
+                    staff(sort: RELEVANCE, perPage: 10) {
+                        edges {
+                            role
+                            node {
+                                name {
+                                    full
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        GRAPHQL;
+
     /** @var list<string> */
     private const array AUTHOR_ROLES = ['Art', 'Original Creator', 'Original Story', 'Story', 'Story & Art'];
 
@@ -80,6 +117,25 @@ final class AniListLookup extends AbstractLookupProvider
     public function getName(): string
     {
         return 'anilist';
+    }
+
+    public function prepareMultipleLookup(string $query, ?ComicType $type, int $limit): mixed
+    {
+        $this->resetApiMessage();
+
+        $searchTitle = $this->cleanTitle($query);
+
+        return $this->httpClient->request('POST', self::API_URL, [
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+            ],
+            'json' => [
+                'query' => self::GRAPHQL_QUERY_PAGE,
+                'variables' => ['perPage' => $limit, 'search' => $searchTitle],
+            ],
+            'timeout' => 10,
+        ]);
     }
 
     public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed
@@ -114,42 +170,10 @@ final class AniListLookup extends AbstractLookupProvider
                 return null;
             }
 
-            $authors = $this->extractAuthors($media['staff']['edges'] ?? []);
-
-            $title = $media['title']['english']
-                ?? $media['title']['romaji']
-                ?? $media['title']['native']
-                ?? null;
-
-            $thumbnail = $media['coverImage']['extraLarge']
-                ?? $media['coverImage']['large']
-                ?? null;
-
-            $publishedDate = $this->formatDate($media['startDate'] ?? []);
-
-            $description = $media['description'] ?? null;
-            if (null !== $description) {
-                $description = \strip_tags($description);
-                $description = \html_entity_decode($description, \ENT_QUOTES | \ENT_HTML5, 'UTF-8');
-            }
-
-            $format = $media['format'] ?? null;
-            $volumes = $media['volumes'] ?? null;
-            $status = $media['status'] ?? null;
-            $isOneShot = 'ONE_SHOT' === $format || (1 === $volumes && 'FINISHED' === $status);
-
+            $result = $this->buildResultFromMedia($media);
             $this->recordApiMessage(ApiLookupStatus::SUCCESS, 'Données trouvées');
 
-            return new LookupResult(
-                authors: $authors,
-                description: $description,
-                isOneShot: $isOneShot,
-                latestPublishedIssue: \is_int($volumes) ? $volumes : null,
-                publishedDate: $publishedDate,
-                source: 'anilist',
-                thumbnail: $thumbnail,
-                title: $title,
-            );
+            return $result;
         } catch (TransportExceptionInterface $e) {
             $this->logger->error('Erreur réseau AniList : {error}', [
                 'error' => $e->getMessage(),
@@ -179,9 +203,109 @@ final class AniListLookup extends AbstractLookupProvider
         }
     }
 
+    public function resolveMultipleLookup(mixed $state): array
+    {
+        \assert($state instanceof ResponseInterface);
+        try {
+            $data = $state->toArray();
+            $mediaList = $data['data']['Page']['media'] ?? [];
+
+            if (0 === \count($mediaList)) {
+                $this->recordApiMessage(ApiLookupStatus::NOT_FOUND, 'Aucun résultat');
+
+                return [];
+            }
+
+            $results = [];
+            foreach ($mediaList as $media) {
+                $results[] = $this->buildResultFromMedia($media);
+            }
+
+            $this->recordApiMessage(ApiLookupStatus::SUCCESS, \sprintf('%d résultat(s) trouvé(s)', \count($results)));
+
+            return $results;
+        } catch (TransportExceptionInterface $e) {
+            $this->logger->error('Erreur réseau AniList : {error}', [
+                'error' => $e->getMessage(),
+            ]);
+            $this->recordApiMessage(ApiLookupStatus::ERROR, 'Erreur de connexion');
+
+            return [];
+        } catch (ClientExceptionInterface|ServerExceptionInterface|RedirectionExceptionInterface $e) {
+            $code = $e->getResponse()->getStatusCode();
+            if (429 === $code) {
+                $this->recordApiMessage(ApiLookupStatus::RATE_LIMITED, 'Quota dépassé (429)');
+            } else {
+                $this->recordApiMessage(ApiLookupStatus::ERROR, \sprintf('Erreur HTTP (%d)', $code));
+            }
+            $this->logger->warning('Erreur HTTP AniList : {error}', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        } catch (DecodingExceptionInterface $e) {
+            $this->logger->error('Réponse JSON invalide de AniList : {error}', [
+                'error' => $e->getMessage(),
+            ]);
+            $this->recordApiMessage(ApiLookupStatus::ERROR, 'Réponse invalide');
+
+            return [];
+        }
+    }
+
     public function supports(string $mode, ?ComicType $type): bool
     {
         return 'title' === $mode && ComicType::MANGA === $type;
+    }
+
+    /**
+     * Construit un LookupResult à partir d'un objet media AniList.
+     *
+     * @param array<string, mixed> $media
+     */
+    private function buildResultFromMedia(array $media): LookupResult
+    {
+        /** @var array<string, mixed> $staffData */
+        $staffData = \is_array($media['staff'] ?? null) ? $media['staff'] : [];
+        /** @var list<array<string, mixed>> $staffEdges */
+        $staffEdges = \is_array($staffData['edges'] ?? null) ? $staffData['edges'] : [];
+        $authors = $this->extractAuthors($staffEdges);
+
+        /** @var array<string, string|null> $titleData */
+        $titleData = \is_array($media['title'] ?? null) ? $media['title'] : [];
+        $title = $titleData['english'] ?? $titleData['romaji'] ?? $titleData['native'] ?? null;
+
+        /** @var array<string, string|null> $coverData */
+        $coverData = \is_array($media['coverImage'] ?? null) ? $media['coverImage'] : [];
+        $thumbnail = $coverData['extraLarge'] ?? $coverData['large'] ?? null;
+
+        /** @var array{year?: int|null, month?: int|null, day?: int|null} $startDate */
+        $startDate = \is_array($media['startDate'] ?? null) ? $media['startDate'] : [];
+        $publishedDate = $this->formatDate($startDate);
+
+        $description = $media['description'] ?? null;
+        if (\is_string($description)) {
+            $description = \strip_tags($description);
+            $description = \html_entity_decode($description, \ENT_QUOTES | \ENT_HTML5, 'UTF-8');
+        } else {
+            $description = null;
+        }
+
+        $format = $media['format'] ?? null;
+        $volumes = $media['volumes'] ?? null;
+        $status = $media['status'] ?? null;
+        $isOneShot = 'ONE_SHOT' === $format || (1 === $volumes && 'FINISHED' === $status);
+
+        return new LookupResult(
+            authors: $authors,
+            description: $description,
+            isOneShot: $isOneShot,
+            latestPublishedIssue: \is_int($volumes) ? $volumes : null,
+            publishedDate: $publishedDate,
+            source: 'anilist',
+            thumbnail: \is_string($thumbnail) ? $thumbnail : null,
+            title: \is_string($title) ? $title : null,
+        );
     }
 
     /**

--- a/backend/src/Service/Lookup/BedethequeLookup.php
+++ b/backend/src/Service/Lookup/BedethequeLookup.php
@@ -48,12 +48,12 @@ final class BedethequeLookup extends AbstractGeminiLookupProvider
 
     public function getFieldPriority(string $field, ?ComicType $type = null): int
     {
-        if ('thumbnail' === $field) {
-            return 50;
-        }
-
         if (ComicType::BD === $type) {
             return 150;
+        }
+
+        if ('thumbnail' === $field) {
+            return 50;
         }
 
         return 110;

--- a/backend/src/Service/Lookup/GoogleBooksLookup.php
+++ b/backend/src/Service/Lookup/GoogleBooksLookup.php
@@ -21,7 +21,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * Provider de recherche via l'API Google Books.
  */
 #[AutoconfigureTag('app.lookup_provider', ['priority' => 100])]
-final class GoogleBooksLookup extends AbstractLookupProvider
+final class GoogleBooksLookup extends AbstractLookupProvider implements MultiResultLookupProviderInterface
 {
     private const string API_URL = 'https://www.googleapis.com/books/v1/volumes';
 
@@ -43,6 +43,25 @@ final class GoogleBooksLookup extends AbstractLookupProvider
         return 'google_books';
     }
 
+    public function prepareMultipleLookup(string $query, ?ComicType $type, int $limit): mixed
+    {
+        $this->resetApiMessage();
+
+        $queryParams = [
+            'maxResults' => \min($limit * 8, 40),
+            'q' => $query,
+        ];
+
+        if ('' !== $this->apiKey) {
+            $queryParams['key'] = $this->apiKey;
+        }
+
+        return $this->httpClient->request('GET', self::API_URL, [
+            'query' => $queryParams,
+            'timeout' => 10,
+        ]);
+    }
+
     public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed
     {
         $this->resetApiMessage();
@@ -62,6 +81,51 @@ final class GoogleBooksLookup extends AbstractLookupProvider
             'query' => $query,
             'timeout' => 10,
         ]);
+    }
+
+    public function resolveMultipleLookup(mixed $state): array
+    {
+        \assert($state instanceof ResponseInterface);
+        try {
+            $data = $state->toArray();
+
+            if (empty($data['items'])) {
+                $this->recordApiMessage(ApiLookupStatus::NOT_FOUND, 'Aucun résultat');
+
+                return [];
+            }
+
+            $results = $this->groupItemsByTitle($data['items']);
+            $this->recordApiMessage(ApiLookupStatus::SUCCESS, \sprintf('%d résultat(s) trouvé(s)', \count($results)));
+
+            return $results;
+        } catch (TransportExceptionInterface $e) {
+            $this->logger->error('Erreur réseau Google Books : {error}', [
+                'error' => $e->getMessage(),
+            ]);
+            $this->recordApiMessage(ApiLookupStatus::ERROR, 'Erreur de connexion');
+
+            return [];
+        } catch (ClientExceptionInterface|ServerExceptionInterface|RedirectionExceptionInterface $e) {
+            $code = $e->getResponse()->getStatusCode();
+            if (429 === $code) {
+                $this->recordApiMessage(ApiLookupStatus::RATE_LIMITED, 'Quota dépassé (429)');
+            } else {
+                $this->recordApiMessage(ApiLookupStatus::ERROR, \sprintf('Erreur HTTP (%d)', $code));
+            }
+            $this->logger->warning('Erreur HTTP Google Books : {error}', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        } catch (DecodingExceptionInterface $e) {
+            $this->logger->error('Réponse JSON invalide de Google Books : {error}', [
+                'error' => $e->getMessage(),
+            ]);
+            $this->recordApiMessage(ApiLookupStatus::ERROR, 'Réponse invalide');
+
+            return [];
+        }
     }
 
     public function resolveLookup(mixed $state): ?LookupResult
@@ -144,6 +208,41 @@ final class GoogleBooksLookup extends AbstractLookupProvider
     }
 
     /**
+     * Regroupe les items par titre distinct et fusionne chaque groupe.
+     *
+     * @param array<int, array<string, mixed>> $items
+     *
+     * @return list<LookupResult>
+     */
+    private function groupItemsByTitle(array $items): array
+    {
+        /** @var array<string, list<array<string, mixed>>> $groups */
+        $groups = [];
+
+        foreach ($items as $item) {
+            $volumeInfo = $item['volumeInfo'] ?? [];
+            if (!\is_array($volumeInfo)) {
+                continue;
+            }
+
+            $title = \is_string($volumeInfo['title'] ?? null) ? $volumeInfo['title'] : null;
+            if (null === $title) {
+                continue;
+            }
+
+            $normalizedTitle = $this->normalizeTitle($title);
+            $groups[$normalizedTitle][] = $item;
+        }
+
+        $results = [];
+        foreach ($groups as $groupItems) {
+            $results[] = $this->mergeItems($groupItems);
+        }
+
+        return $results;
+    }
+
+    /**
      * Fusionne les données de plusieurs résultats Google Books.
      *
      * @param array<int, array<string, mixed>> $items
@@ -221,5 +320,26 @@ final class GoogleBooksLookup extends AbstractLookupProvider
             thumbnail: $thumbnail,
             title: $title,
         );
+    }
+
+    /**
+     * Normalise un titre pour le regroupement (supprime suffixes de tome/volume, casse).
+     */
+    private function normalizeTitle(string $title): string
+    {
+        $patterns = [
+            '/\s*[-–—]\s*(?:T(?:ome)?|Vol(?:ume)?|V)\.?\s*\d+.*$/iu',
+            '/\s+(?:T(?:ome)?|Vol(?:ume)?|V)\.?\s*\d+.*$/iu',
+            '/\s*#\d+.*$/u',
+            '/\s*\(\d+\)\s*$/u',
+            '/\s+\d+\s*$/u',
+        ];
+
+        $normalized = $title;
+        foreach ($patterns as $pattern) {
+            $normalized = \preg_replace($pattern, '', $normalized) ?? $normalized;
+        }
+
+        return \mb_strtolower(\trim($normalized));
     }
 }

--- a/backend/src/Service/Lookup/LookupOrchestrator.php
+++ b/backend/src/Service/Lookup/LookupOrchestrator.php
@@ -72,6 +72,116 @@ class LookupOrchestrator
     }
 
     /**
+     * Recherche par titre avec plusieurs résultats candidats.
+     *
+     * @return list<LookupResult>
+     */
+    public function lookupByTitleMultiple(string $title, ?ComicType $type, int $limit): array
+    {
+        $title = \trim($title);
+
+        if ('' === $title) {
+            return [];
+        }
+
+        $this->apiMessages = [];
+        $this->sources = [];
+
+        $startTime = \microtime(true);
+
+        // Phase 1 : lancer toutes les requêtes (non bloquant)
+        /** @var list<array{multi: bool, provider: LookupProviderInterface, state: mixed}> $prepared */
+        $prepared = [];
+
+        foreach ($this->providers as $provider) {
+            if (!$provider->supports('title', $type)) {
+                continue;
+            }
+
+            try {
+                if ($provider instanceof MultiResultLookupProviderInterface) {
+                    $state = $provider->prepareMultipleLookup($title, $type, $limit);
+                    $prepared[] = ['multi' => true, 'provider' => $provider, 'state' => $state];
+                } else {
+                    $state = $provider->prepareLookup($title, $type, 'title');
+                    $prepared[] = ['multi' => false, 'provider' => $provider, 'state' => $state];
+                }
+            } catch (\Throwable $e) {
+                $this->logger->error('Erreur prepareLookup {provider} : {error}', [
+                    'error' => $e->getMessage(),
+                    'provider' => $provider->getName(),
+                ]);
+                $this->apiMessages[$provider->getName()] = new ApiMessage(
+                    message: $e->getMessage(),
+                    status: ApiLookupStatus::ERROR->value,
+                );
+            }
+        }
+
+        // Phase 2 : résoudre les réponses
+        /** @var list<LookupResult> $allResults */
+        $allResults = [];
+
+        foreach ($prepared as ['multi' => $isMulti, 'provider' => $provider, 'state' => $state]) {
+            $elapsed = \microtime(true) - $startTime;
+
+            if ($elapsed >= $this->globalTimeout) {
+                $this->apiMessages[$provider->getName()] = new ApiMessage(
+                    message: 'Timeout global dépassé',
+                    status: ApiLookupStatus::TIMEOUT->value,
+                );
+
+                continue;
+            }
+
+            try {
+                if ($isMulti) {
+                    \assert($provider instanceof MultiResultLookupProviderInterface);
+                    $results = $provider->resolveMultipleLookup($state);
+                } else {
+                    $single = $provider->resolveLookup($state);
+                    $results = null !== $single ? [$single] : [];
+                }
+
+                $apiMessage = $provider->getLastApiMessage();
+
+                if (null !== $apiMessage) {
+                    $this->apiMessages[$provider->getName()] = $apiMessage;
+                }
+
+                if (\count($results) > 0) {
+                    \array_push($allResults, ...$results);
+                    $this->sources[] = $provider->getName();
+                }
+            } catch (\Throwable $e) {
+                $this->logger->error('Erreur resolveLookup {provider} : {error}', [
+                    'error' => $e->getMessage(),
+                    'provider' => $provider->getName(),
+                ]);
+                $this->apiMessages[$provider->getName()] = new ApiMessage(
+                    message: $e->getMessage(),
+                    status: ApiLookupStatus::ERROR->value,
+                );
+            }
+        }
+
+        // Dédupliquer par titre normalisé, garder le premier trouvé
+        $seen = [];
+        $deduplicated = [];
+
+        foreach ($allResults as $result) {
+            $key = \mb_strtolower(\trim($result->title ?? ''));
+            if ('' === $key || isset($seen[$key])) {
+                continue;
+            }
+            $seen[$key] = true;
+            $deduplicated[] = $result;
+        }
+
+        return \array_slice($deduplicated, 0, $limit);
+    }
+
+    /**
      * Recherche par titre.
      */
     public function lookupByTitle(string $title, ?ComicType $type = null): ?LookupResult

--- a/backend/src/Service/Lookup/MultiResultLookupProviderInterface.php
+++ b/backend/src/Service/Lookup/MultiResultLookupProviderInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Lookup;
+
+use App\Enum\ComicType;
+
+/**
+ * Interface pour les providers capables de retourner plusieurs résultats distincts.
+ *
+ * Utilisée pour le lookup par titre multi-candidats.
+ */
+interface MultiResultLookupProviderInterface extends LookupProviderInterface
+{
+    /**
+     * Phase 1 : lance la requête HTTP pour la recherche multi-résultats.
+     *
+     * @param string         $query Titre de recherche
+     * @param ComicType|null $type  Le type de série
+     * @param int            $limit Nombre maximum de résultats
+     *
+     * @return mixed État intermédiaire
+     */
+    public function prepareMultipleLookup(string $query, ?ComicType $type, int $limit): mixed;
+
+    /**
+     * Phase 2 : traite la réponse et retourne plusieurs résultats.
+     *
+     * @param mixed $state État retourné par prepareMultipleLookup()
+     *
+     * @return list<LookupResult>
+     */
+    public function resolveMultipleLookup(mixed $state): array;
+}

--- a/backend/tests/Functional/Api/LookupApiTest.php
+++ b/backend/tests/Functional/Api/LookupApiTest.php
@@ -119,6 +119,56 @@ final class LookupApiTest extends ApiTestCase
         self::assertResponseStatusCodeSame(401);
     }
 
+    /**
+     * Teste que le parametre limit invalide (> 10) est clamp a 10.
+     */
+    public function testTitleLookupWithLimitParameterProcesses(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/lookup/title', [
+            'query' => ['limit' => '5', 'title' => 'One Piece', 'type' => 'manga'],
+        ]);
+
+        $statusCode = $client->getResponse()->getStatusCode();
+        self::assertContains($statusCode, [200, 404], 'Doit être 200 ou 404, pas une erreur serveur');
+    }
+
+    /**
+     * Teste que limit>1 retourne une reponse avec un tableau results.
+     */
+    public function testTitleLookupWithLimitMultiReturnsResultsArray(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/lookup/title', [
+            'query' => ['limit' => '5', 'title' => 'Naruto', 'type' => 'manga'],
+        ]);
+
+        $statusCode = $client->getResponse()->getStatusCode();
+        self::assertSame(200, $statusCode);
+
+        $data = $client->getResponse()->toArray(false);
+        self::assertArrayHasKey('results', $data);
+        self::assertArrayHasKey('apiMessages', $data);
+        self::assertArrayHasKey('sources', $data);
+        self::assertIsArray($data['results']);
+    }
+
+    /**
+     * Teste que limit=0 retourne une erreur 400.
+     */
+    public function testTitleLookupWithLimitZeroReturns400(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/lookup/title', [
+            'query' => ['limit' => '0', 'title' => 'One Piece'],
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
     // ---------------------------------------------------------------
     // Rate limiting
     // ---------------------------------------------------------------

--- a/backend/tests/Unit/Service/Lookup/AniListLookupTest.php
+++ b/backend/tests/Unit/Service/Lookup/AniListLookupTest.php
@@ -882,6 +882,109 @@ final class AniListLookupTest extends TestCase
     }
 
     /**
+     * Teste que prepareMultipleLookup utilise la query Page avec perPage.
+     */
+    public function testPrepareMultipleLookupUsesPageQuery(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $httpClient = $this->createHttpClientMock();
+
+        $httpClient->expects(self::once())
+            ->method('request')
+            ->with(
+                'POST',
+                'https://graphql.anilist.co',
+                self::callback(static function (array $options): bool {
+                    return \str_contains($options['json']['query'], 'Page')
+                        && 'Naruto' === $options['json']['variables']['search']
+                        && 5 === $options['json']['variables']['perPage'];
+                }),
+            )
+            ->willReturn($response);
+
+        $this->provider->prepareMultipleLookup('Naruto', ComicType::MANGA, 5);
+    }
+
+    /**
+     * Teste resolveMultipleLookup retourne un resultat par media.
+     */
+    public function testResolveMultipleLookupReturnsMultipleResults(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'data' => [
+                'Page' => [
+                    'media' => [
+                        [
+                            'coverImage' => ['extraLarge' => 'https://img1.jpg', 'large' => null],
+                            'description' => 'Ninja story',
+                            'format' => 'MANGA',
+                            'staff' => ['edges' => [['node' => ['name' => ['full' => 'Kishimoto']], 'role' => 'Story & Art']]],
+                            'startDate' => ['day' => null, 'month' => null, 'year' => 1999],
+                            'status' => 'FINISHED',
+                            'title' => ['english' => 'Naruto', 'native' => null, 'romaji' => null],
+                            'volumes' => 72,
+                        ],
+                        [
+                            'coverImage' => ['extraLarge' => 'https://img2.jpg', 'large' => null],
+                            'description' => 'Boruto story',
+                            'format' => 'MANGA',
+                            'staff' => ['edges' => []],
+                            'startDate' => ['day' => null, 'month' => null, 'year' => 2016],
+                            'status' => 'RELEASING',
+                            'title' => ['english' => 'Boruto', 'native' => null, 'romaji' => null],
+                            'volumes' => null,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $results = $this->provider->resolveMultipleLookup($response);
+
+        self::assertCount(2, $results);
+        self::assertSame('Naruto', $results[0]->title);
+        self::assertSame('Kishimoto', $results[0]->authors);
+        self::assertSame(72, $results[0]->latestPublishedIssue);
+        self::assertSame('Boruto', $results[1]->title);
+    }
+
+    /**
+     * Teste resolveMultipleLookup retourne un tableau vide quand pas de media.
+     */
+    public function testResolveMultipleLookupNoMedia(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'data' => [
+                'Page' => [
+                    'media' => [],
+                ],
+            ],
+        ]);
+
+        $results = $this->provider->resolveMultipleLookup($response);
+
+        self::assertSame([], $results);
+    }
+
+    /**
+     * Teste resolveMultipleLookup gere les erreurs de transport.
+     */
+    public function testResolveMultipleLookupTransportException(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $exception = new class('Timeout') extends \RuntimeException implements TransportExceptionInterface {};
+        $response->method('toArray')->willThrowException($exception);
+
+        $this->createLoggerMock();
+
+        $results = $this->provider->resolveMultipleLookup($response);
+
+        self::assertSame([], $results);
+    }
+
+    /**
      * Recree le provider avec un mock httpClient pour les tests d'attente.
      */
     private function createHttpClientMock(): HttpClientInterface&MockObject

--- a/backend/tests/Unit/Service/Lookup/BedethequeLookupTest.php
+++ b/backend/tests/Unit/Service/Lookup/BedethequeLookupTest.php
@@ -74,6 +74,7 @@ final class BedethequeLookupTest extends TestCase
         self::assertSame(150, $provider->getFieldPriority('publisher', ComicType::BD));
         self::assertSame(150, $provider->getFieldPriority('latestPublishedIssue', ComicType::BD));
         self::assertSame(150, $provider->getFieldPriority('isOneShot', ComicType::BD));
+        self::assertSame(150, $provider->getFieldPriority('thumbnail', ComicType::BD));
     }
 
     /**
@@ -89,13 +90,12 @@ final class BedethequeLookupTest extends TestCase
     }
 
     /**
-     * Teste que thumbnail a une priorite basse (extraction non fiable via grounding).
+     * Teste que thumbnail a une priorite basse pour les types non-BD.
      */
-    public function testGetFieldPriorityThumbnailIsLow(): void
+    public function testGetFieldPriorityThumbnailIsLowForNonBd(): void
     {
         $provider = $this->createProvider();
 
-        self::assertSame(50, $provider->getFieldPriority('thumbnail', ComicType::BD));
         self::assertSame(50, $provider->getFieldPriority('thumbnail', ComicType::MANGA));
         self::assertSame(50, $provider->getFieldPriority('thumbnail', null));
     }

--- a/backend/tests/Unit/Service/Lookup/GoogleBooksLookupTest.php
+++ b/backend/tests/Unit/Service/Lookup/GoogleBooksLookupTest.php
@@ -646,6 +646,106 @@ final class GoogleBooksLookupTest extends TestCase
     }
 
     /**
+     * Teste que prepareMultipleLookup envoie la meme requete que prepareLookup.
+     */
+    public function testPrepareMultipleLookupSendsRequest(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $httpClient = $this->createHttpClientMock();
+
+        $httpClient->expects(self::once())
+            ->method('request')
+            ->with(
+                'GET',
+                'https://www.googleapis.com/books/v1/volumes',
+                self::callback(static function (array $options): bool {
+                    return 'Naruto' === $options['query']['q']
+                        && 40 === $options['query']['maxResults'];
+                }),
+            )
+            ->willReturn($response);
+
+        $result = $this->provider->prepareMultipleLookup('Naruto', ComicType::MANGA, 5);
+
+        self::assertSame($response, $result);
+    }
+
+    /**
+     * Teste resolveMultipleLookup regroupe les items par titre distinct.
+     */
+    public function testResolveMultipleLookupGroupsByTitle(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'items' => [
+                [
+                    'volumeInfo' => [
+                        'authors' => ['Oda'],
+                        'description' => 'Pirates',
+                        'title' => 'One Piece',
+                    ],
+                ],
+                [
+                    'volumeInfo' => [
+                        'authors' => ['Oda'],
+                        'publishedDate' => '1997',
+                        'title' => 'One Piece',
+                    ],
+                ],
+                [
+                    'volumeInfo' => [
+                        'authors' => ['Kishimoto'],
+                        'description' => 'Ninjas',
+                        'title' => 'Naruto',
+                    ],
+                ],
+            ],
+        ]);
+
+        $results = $this->provider->resolveMultipleLookup($response);
+
+        self::assertCount(2, $results);
+        self::assertSame('One Piece', $results[0]->title);
+        self::assertSame('Oda', $results[0]->authors);
+        self::assertSame('Pirates', $results[0]->description);
+        self::assertSame('1997', $results[0]->publishedDate);
+        self::assertSame('Naruto', $results[1]->title);
+        self::assertSame('Kishimoto', $results[1]->authors);
+    }
+
+    /**
+     * Teste resolveMultipleLookup retourne un tableau vide quand pas d'items.
+     */
+    public function testResolveMultipleLookupNoItems(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn(['items' => []]);
+
+        $results = $this->provider->resolveMultipleLookup($response);
+
+        self::assertSame([], $results);
+    }
+
+    /**
+     * Teste resolveMultipleLookup gere les erreurs de transport.
+     */
+    public function testResolveMultipleLookupTransportException(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $exception = new class('Timeout') extends \RuntimeException implements TransportExceptionInterface {};
+        $response->method('toArray')->willThrowException($exception);
+
+        $this->createLoggerMock();
+
+        $results = $this->provider->resolveMultipleLookup($response);
+
+        self::assertSame([], $results);
+
+        $apiMessage = $this->provider->getLastApiMessage();
+        self::assertSame('error', $apiMessage->status);
+    }
+
+    /**
      * Recree le provider avec un mock httpClient pour les tests d'attente.
      */
     private function createHttpClientMock(): HttpClientInterface&MockObject

--- a/backend/tests/Unit/Service/Lookup/LookupOrchestratorTest.php
+++ b/backend/tests/Unit/Service/Lookup/LookupOrchestratorTest.php
@@ -12,6 +12,7 @@ use App\Service\Lookup\EnrichableLookupProviderInterface;
 use App\Service\Lookup\LookupOrchestrator;
 use App\Service\Lookup\LookupProviderInterface;
 use App\Service\Lookup\LookupResult;
+use App\Service\Lookup\MultiResultLookupProviderInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -783,6 +784,228 @@ final class LookupOrchestratorTest extends TestCase
         self::assertSame('9782723489003', $lookupResult->isbn);
         // Le resultat original n'avait pas d'ISBN
         self::assertNull($result->isbn);
+    }
+
+    /**
+     * Teste lookupByTitleMultiple avec un titre vide retourne un tableau vide.
+     */
+    public function testLookupByTitleMultipleWithEmptyTitleReturnsEmpty(): void
+    {
+        $orchestrator = new LookupOrchestrator(30.0, new NullLogger(), []);
+
+        self::assertSame([], $orchestrator->lookupByTitleMultiple('', null, 5));
+        self::assertSame([], $orchestrator->lookupByTitleMultiple('   ', null, 5));
+    }
+
+    /**
+     * Teste lookupByTitleMultiple retourne les resultats de plusieurs providers.
+     */
+    public function testLookupByTitleMultipleReturnsResults(): void
+    {
+        $provider = $this->createStubMultiResultProvider(
+            fieldPriority: 100,
+            name: 'multi_provider',
+            results: [
+                new LookupResult(authors: 'Oda', source: 'multi_provider', title: 'One Piece'),
+                new LookupResult(authors: 'Kishimoto', source: 'multi_provider', title: 'Naruto'),
+            ],
+            supports: true,
+        );
+
+        $orchestrator = new LookupOrchestrator(30.0, new NullLogger(), [$provider]);
+
+        $results = $orchestrator->lookupByTitleMultiple('One Piece', ComicType::MANGA, 5);
+
+        self::assertCount(2, $results);
+        self::assertSame('One Piece', $results[0]->title);
+        self::assertSame('Naruto', $results[1]->title);
+    }
+
+    /**
+     * Teste lookupByTitleMultiple deduplique par titre normalise.
+     */
+    public function testLookupByTitleMultipleDeduplicatesByTitle(): void
+    {
+        $provider1 = $this->createStubMultiResultProvider(
+            fieldPriority: 100,
+            name: 'provider1',
+            results: [
+                new LookupResult(source: 'provider1', title: 'One Piece'),
+                new LookupResult(source: 'provider1', title: 'Naruto'),
+            ],
+            supports: true,
+        );
+
+        $provider2 = $this->createStubMultiResultProvider(
+            fieldPriority: 80,
+            name: 'provider2',
+            results: [
+                new LookupResult(source: 'provider2', thumbnail: 'https://img.jpg', title: 'one piece'),
+                new LookupResult(source: 'provider2', title: 'Bleach'),
+            ],
+            supports: true,
+        );
+
+        $orchestrator = new LookupOrchestrator(30.0, new NullLogger(), [$provider1, $provider2]);
+
+        $results = $orchestrator->lookupByTitleMultiple('test', null, 10);
+
+        // 3 titres distincts: one piece, naruto, bleach
+        self::assertCount(3, $results);
+        $titles = \array_map(static fn (LookupResult $r) => $r->title, $results);
+        self::assertContains('One Piece', $titles);
+        self::assertContains('Naruto', $titles);
+        self::assertContains('Bleach', $titles);
+    }
+
+    /**
+     * Teste lookupByTitleMultiple inclut les providers single-result comme candidats.
+     */
+    public function testLookupByTitleMultipleIncludesSingleResultProviders(): void
+    {
+        $regularProvider = $this->createStubProvider(
+            fieldPriority: 200,
+            name: 'regular',
+            result: new LookupResult(source: 'regular', title: 'Single Result'),
+            supports: true,
+        );
+
+        $multiProvider = $this->createStubMultiResultProvider(
+            fieldPriority: 100,
+            name: 'multi',
+            results: [new LookupResult(source: 'multi', title: 'Multi Result')],
+            supports: true,
+        );
+
+        $orchestrator = new LookupOrchestrator(30.0, new NullLogger(), [$regularProvider, $multiProvider]);
+
+        $results = $orchestrator->lookupByTitleMultiple('test', null, 5);
+
+        self::assertCount(2, $results);
+        $titles = \array_map(static fn (LookupResult $r) => $r->title, $results);
+        self::assertContains('Single Result', $titles);
+        self::assertContains('Multi Result', $titles);
+    }
+
+    /**
+     * Teste lookupByTitleMultiple tronque au limit demande.
+     */
+    public function testLookupByTitleMultipleTruncatesToLimit(): void
+    {
+        $results = [];
+        for ($i = 1; $i <= 10; ++$i) {
+            $results[] = new LookupResult(source: 'provider', title: "Title {$i}");
+        }
+
+        $provider = $this->createStubMultiResultProvider(
+            fieldPriority: 100,
+            name: 'provider',
+            results: $results,
+            supports: true,
+        );
+
+        $orchestrator = new LookupOrchestrator(30.0, new NullLogger(), [$provider]);
+
+        $lookupResults = $orchestrator->lookupByTitleMultiple('test', null, 3);
+
+        self::assertCount(3, $lookupResults);
+    }
+
+    /**
+     * Teste lookupByTitleMultiple gere les exceptions dans prepareMultipleLookup.
+     */
+    public function testLookupByTitleMultiplePrepareException(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('error');
+
+        $provider = $this->createStubMultiResultProvider(
+            fieldPriority: 100,
+            name: 'failing',
+            results: [],
+            supports: true,
+            throwOnPrepare: new \RuntimeException('Prepare failed'),
+        );
+
+        $orchestrator = new LookupOrchestrator(30.0, $logger, [$provider]);
+
+        $results = $orchestrator->lookupByTitleMultiple('test', null, 5);
+
+        self::assertSame([], $results);
+        $messages = $orchestrator->getLastApiMessages();
+        self::assertArrayHasKey('failing', $messages);
+        self::assertSame('error', $messages['failing']->status);
+    }
+
+    /**
+     * Cree un stub MultiResultLookupProviderInterface.
+     *
+     * @param list<LookupResult> $results
+     */
+    private function createStubMultiResultProvider(
+        int $fieldPriority,
+        string $name,
+        array $results,
+        bool $supports,
+        ?\Throwable $throwOnPrepare = null,
+    ): MultiResultLookupProviderInterface {
+        return new class($fieldPriority, $name, $results, $supports, $throwOnPrepare) implements MultiResultLookupProviderInterface {
+            /**
+             * @param list<LookupResult> $results
+             */
+            public function __construct(
+                private readonly int $fieldPriority,
+                private readonly string $name,
+                private readonly array $results,
+                private readonly bool $supports,
+                private readonly ?\Throwable $throwOnPrepare,
+            ) {
+            }
+
+            public function getFieldPriority(string $field, ?ComicType $type = null): int
+            {
+                return $this->fieldPriority;
+            }
+
+            public function getLastApiMessage(): ?ApiMessage
+            {
+                return null;
+            }
+
+            public function getName(): string
+            {
+                return $this->name;
+            }
+
+            public function prepareMultipleLookup(string $query, ?ComicType $type, int $limit): mixed
+            {
+                if (null !== $this->throwOnPrepare) {
+                    throw $this->throwOnPrepare;
+                }
+
+                return 'multi_state';
+            }
+
+            public function prepareLookup(string $query, ?ComicType $type, string $mode = 'title'): mixed
+            {
+                return 'state';
+            }
+
+            public function resolveMultipleLookup(mixed $state): array
+            {
+                return $this->results;
+            }
+
+            public function resolveLookup(mixed $state): ?LookupResult
+            {
+                return $this->results[0] ?? null;
+            }
+
+            public function supports(string $mode, ?ComicType $type): bool
+            {
+                return $this->supports;
+            }
+        };
     }
 
     /**

--- a/frontend/src/__tests__/helpers/factories.ts
+++ b/frontend/src/__tests__/helpers/factories.ts
@@ -1,4 +1,4 @@
-import type { Author, ComicSeries, Tome, LookupResult } from "../../types/api";
+import type { Author, ComicSeries, LookupCandidatesResponse, Tome, LookupResult } from "../../types/api";
 import { ComicStatus, ComicType } from "../../types/enums";
 
 let nextId = 1;
@@ -80,6 +80,15 @@ export function createMockLookupResult(
     tomeEnd: null,
     tomeNumber: null,
     ...overrides,
+  };
+}
+
+export function wrapAsCandidatesResponse(result: LookupResult): LookupCandidatesResponse {
+  const { apiMessages, sources, ...candidate } = result;
+  return {
+    apiMessages,
+    results: [candidate],
+    sources,
   };
 }
 

--- a/frontend/src/__tests__/integration/hooks/useLookup.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useLookup.test.tsx
@@ -8,6 +8,7 @@ import {
   fetchLookupTitle,
   useLookupIsbn,
   useLookupTitle,
+  useLookupTitleCandidates,
 } from "../../../hooks/useLookup";
 import { createTestQueryClient } from "../../helpers/test-utils";
 import { createMockLookupResult } from "../../helpers/factories";
@@ -210,6 +211,71 @@ describe("useLookupTitle", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
+    expect(capturedUrl).toContain("type=manga");
+  });
+});
+
+describe("useLookupTitleCandidates", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("is disabled when title is shorter than 2 characters", () => {
+    const { result } = renderHook(() => useLookupTitleCandidates("A"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("returns multiple candidates", async () => {
+    const candidatesResponse = {
+      apiMessages: {},
+      results: [
+        { authors: "Oda", description: null, isbn: null, isOneShot: false, latestPublishedIssue: null, publishedDate: null, publisher: "Glenat", thumbnail: null, title: "One Piece", tomeEnd: null, tomeNumber: null },
+        { authors: "Oda", description: null, isbn: null, isOneShot: null, latestPublishedIssue: null, publishedDate: null, publisher: null, thumbnail: null, title: "One Piece Party", tomeEnd: null, tomeNumber: null },
+      ],
+      sources: ["google_books"],
+    };
+
+    server.use(
+      http.get("/api/lookup/title", ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get("limit")) {
+          return HttpResponse.json(candidatesResponse);
+        }
+        return HttpResponse.json(createMockLookupResult({ title: "One Piece" }));
+      }),
+    );
+
+    const { result } = renderHook(() => useLookupTitleCandidates("One Piece"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.results).toHaveLength(2);
+    expect(result.current.data?.results[0].title).toBe("One Piece");
+    expect(result.current.data?.results[1].title).toBe("One Piece Party");
+  });
+
+  it("includes limit parameter in URL", async () => {
+    let capturedUrl = "";
+
+    server.use(
+      http.get("/api/lookup/title", ({ request }) => {
+        capturedUrl = new URL(request.url).search;
+        return HttpResponse.json({ apiMessages: {}, results: [], sources: [] });
+      }),
+    );
+
+    const { result } = renderHook(() => useLookupTitleCandidates("Test", "manga", 3), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(capturedUrl).toContain("limit=3");
     expect(capturedUrl).toContain("type=manga");
   });
 });

--- a/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
@@ -10,10 +10,23 @@ import {
   createMockHydraCollection,
   createMockLookupResult,
   createMockTome,
+  wrapAsCandidatesResponse,
 } from "../../helpers/factories";
+import type { LookupResult } from "../../../types/api";
 import { server } from "../../helpers/server";
 import { renderWithProviders } from "../../helpers/test-utils";
 import { ComicStatus, ComicType } from "../../../types/enums";
+
+/** Crée un handler MSW pour /api/lookup/title qui gère les deux formats (candidats et ciblé). */
+function mockTitleLookup(result: LookupResult) {
+  return http.get("/api/lookup/title", ({ request }) => {
+    const url = new URL(request.url);
+    if (url.searchParams.get("limit")) {
+      return HttpResponse.json(wrapAsCandidatesResponse(result));
+    }
+    return HttpResponse.json(result);
+  });
+}
 
 // Mock html5-qrcode for BarcodeScanner component
 vi.mock("html5-qrcode", () => ({
@@ -334,9 +347,7 @@ describe("ComicForm", () => {
         title: "Lookup Title",
       });
 
-      server.use(
-        http.get("/api/lookup/title", () => HttpResponse.json(lookupResult)),
-      );
+      server.use(mockTitleLookup(lookupResult));
 
       renderCreateForm();
 
@@ -344,7 +355,13 @@ describe("ComicForm", () => {
       const lookupInput = screen.getByPlaceholderText("Titre de la série");
       await user.type(lookupInput, "Lookup Title");
 
-      // Wait for lookup result to appear
+      // Wait for candidate to appear and select it
+      await waitFor(() => {
+        expect(screen.getByText("Lookup Title")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Lookup Title"));
+
+      // Wait for targeted lookup result to appear
       await waitFor(() => {
         expect(screen.getByText("Appliquer")).toBeInTheDocument();
       });
@@ -392,7 +409,7 @@ describe("ComicForm", () => {
 
       server.use(
         http.get("/api/lookup/isbn", () => HttpResponse.json(isbnResult)),
-        http.get("/api/lookup/title", () => HttpResponse.json(titleResult)),
+        mockTitleLookup(titleResult),
       );
 
       renderCreateForm();
@@ -432,11 +449,18 @@ describe("ComicForm", () => {
       });
 
       let titleLookupCalled = false;
+      const mockResult = createMockLookupResult({ title: "Should Not Be Called" });
       server.use(
         http.get("/api/lookup/isbn", () => HttpResponse.json(isbnResult)),
-        http.get("/api/lookup/title", () => {
-          titleLookupCalled = true;
-          return HttpResponse.json(createMockLookupResult({ title: "Should Not Be Called" }));
+        http.get("/api/lookup/title", ({ request }) => {
+          const url = new URL(request.url);
+          if (!url.searchParams.get("limit")) {
+            titleLookupCalled = true;
+          }
+          if (url.searchParams.get("limit")) {
+            return HttpResponse.json(wrapAsCandidatesResponse(mockResult));
+          }
+          return HttpResponse.json(mockResult);
         }),
       );
 
@@ -478,9 +502,13 @@ describe("ComicForm", () => {
 
       server.use(
         http.get("/api/lookup/isbn", () => HttpResponse.json(isbnResult)),
-        http.get("/api/lookup/title", () =>
-          HttpResponse.json({ error: "Not found" }, { status: 404 }),
-        ),
+        http.get("/api/lookup/title", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("limit")) {
+            return HttpResponse.json({ apiMessages: {}, results: [], sources: [] });
+          }
+          return HttpResponse.json({ error: "Not found" }, { status: 404 });
+        }),
       );
 
       renderCreateForm();
@@ -513,14 +541,18 @@ describe("ComicForm", () => {
         title: "One Shot Series",
       });
 
-      server.use(
-        http.get("/api/lookup/title", () => HttpResponse.json(lookupResult)),
-      );
+      server.use(mockTitleLookup(lookupResult));
 
       renderCreateForm();
 
       const lookupInput = screen.getByPlaceholderText("Titre de la série");
       await user.type(lookupInput, "One Shot Series");
+
+      // Select candidate
+      await waitFor(() => {
+        expect(screen.getByText("One Shot Series")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("One Shot Series"));
 
       await waitFor(() => {
         expect(screen.getByText("Appliquer")).toBeInTheDocument();
@@ -541,10 +573,15 @@ describe("ComicForm", () => {
     it("shows loading indicator during lookup", async () => {
       const user = userEvent.setup();
 
+      const result = createMockLookupResult({ title: "Test" });
       server.use(
-        http.get("/api/lookup/title", async () => {
+        http.get("/api/lookup/title", async ({ request }) => {
           await new Promise((resolve) => setTimeout(resolve, 200));
-          return HttpResponse.json(createMockLookupResult({ title: "Test" }));
+          const url = new URL(request.url);
+          if (url.searchParams.get("limit")) {
+            return HttpResponse.json(wrapAsCandidatesResponse(result));
+          }
+          return HttpResponse.json(result);
         }),
       );
 
@@ -560,26 +597,23 @@ describe("ComicForm", () => {
     it("displays lookup result card with title, authors, and publisher", async () => {
       const user = userEvent.setup();
 
-      server.use(
-        http.get("/api/lookup/title", () =>
-          HttpResponse.json(
-            createMockLookupResult({
-              authors: "John Doe",
-              publisher: "BigPub",
-              title: "Result Title",
-            }),
-          ),
-        ),
-      );
+      const result = createMockLookupResult({
+        authors: "John Doe",
+        publisher: "BigPub",
+        title: "Result Title",
+      });
+
+      server.use(mockTitleLookup(result));
 
       renderCreateForm();
 
       await user.type(screen.getByPlaceholderText("Titre de la série"), "Result Title");
 
+      // Candidates are shown first
       await waitFor(() => {
         expect(screen.getByText("Result Title")).toBeInTheDocument();
       });
-      // Authors and publisher shown in the result card
+      // Authors and publisher shown in the candidate card
       expect(screen.getByText(/John Doe/)).toBeInTheDocument();
       expect(screen.getByText(/BigPub/)).toBeInTheDocument();
     });

--- a/frontend/src/components/LookupSection.tsx
+++ b/frontend/src/components/LookupSection.tsx
@@ -1,10 +1,11 @@
-import { Layers, Loader2 } from "lucide-react";
+import { ArrowLeft, Layers, Loader2 } from "lucide-react";
 import type { UseQueryResult } from "@tanstack/react-query";
 import BarcodeScanner from "./BarcodeScanner";
-import type { LookupResult } from "../types/api";
+import type { LookupCandidatesResponse, LookupResult } from "../types/api";
 
 interface LookupSectionProps {
   applyLookup: () => void;
+  clearCandidate: () => void;
   formTitle: string;
   isApplying: boolean;
   isOnline: boolean;
@@ -12,13 +13,17 @@ interface LookupSectionProps {
   lookupMode: "isbn" | "title";
   lookupResult: UseQueryResult<LookupResult>;
   lookupTitle: string;
+  selectCandidate: (title: string) => void;
+  selectedCandidateTitle: string | null;
   setLookupIsbn: (v: string) => void;
   setLookupMode: (v: "isbn" | "title") => void;
   setLookupTitle: (v: string) => void;
+  titleCandidates: UseQueryResult<LookupCandidatesResponse>;
 }
 
 export default function LookupSection({
   applyLookup,
+  clearCandidate,
   formTitle,
   isApplying,
   isOnline,
@@ -26,9 +31,12 @@ export default function LookupSection({
   lookupMode,
   lookupResult,
   lookupTitle,
+  selectCandidate,
+  selectedCandidateTitle,
   setLookupIsbn,
   setLookupMode,
   setLookupTitle,
+  titleCandidates,
 }: LookupSectionProps) {
   if (!isOnline) {
     return (
@@ -37,6 +45,11 @@ export default function LookupSection({
       </div>
     );
   }
+
+  const isTitleMode = lookupMode === "title";
+  const showCandidates = isTitleMode && !selectedCandidateTitle;
+  const showTargeted = isTitleMode && selectedCandidateTitle !== null;
+  const isSearching = showCandidates ? titleCandidates.isFetching : lookupResult.isFetching;
 
   return (
     <div className="rounded-lg border border-surface-border bg-surface-tertiary p-4 space-y-3">
@@ -74,14 +87,20 @@ export default function LookupSection({
         <div className="flex gap-2">
           <input
             className="flex-1 rounded-lg border border-surface-border bg-surface-primary px-3 py-2 text-sm text-text-primary"
-            onChange={(e) => setLookupTitle(e.target.value)}
+            onChange={(e) => {
+              setLookupTitle(e.target.value);
+              clearCandidate();
+            }}
             placeholder="Titre de la série"
             value={lookupTitle}
           />
           {formTitle && formTitle !== lookupTitle && (
             <button
               className="flex shrink-0 items-center gap-1.5 rounded-lg border border-surface-border bg-surface-primary px-3 py-1.5 text-sm text-text-muted hover:border-primary-400 hover:text-primary-600 transition"
-              onClick={() => setLookupTitle(formTitle)}
+              onClick={() => {
+                setLookupTitle(formTitle);
+                clearCandidate();
+              }}
               title="Utiliser le titre de la série"
               type="button"
             >
@@ -91,46 +110,140 @@ export default function LookupSection({
         </div>
       )}
 
-      {lookupResult.isFetching && (
+      {isSearching && (
         <div className="flex items-center gap-2 text-sm text-text-muted">
           <Loader2 className="h-4 w-4 animate-spin" /> Recherche en cours…
         </div>
       )}
 
-      {lookupResult.data && !lookupResult.isFetching && (
-        <div className="rounded-lg bg-surface-primary p-3 border border-surface-border space-y-2">
-          <div className="flex items-center justify-between gap-3">
-            <div className="min-w-0 text-sm">
-              <p className="truncate font-medium text-text-primary">{lookupResult.data.title}</p>
-              <p className="truncate text-text-muted">
-                {lookupResult.data.authors ?? ""}
-                {lookupResult.data.publisher && ` — ${lookupResult.data.publisher}`}
+      {/* Candidates list (title mode, no selection yet) */}
+      {showCandidates && titleCandidates.data && !titleCandidates.isFetching && (
+        <div className="space-y-2">
+          {titleCandidates.data.results.length === 0 ? (
+            <p className="text-sm text-text-muted">Aucun résultat trouvé</p>
+          ) : (
+            <>
+              <p className="text-xs text-text-muted">
+                {titleCandidates.data.results.length} résultat(s) — sélectionnez une série :
               </p>
-            </div>
-            <button
-              className="flex shrink-0 items-center gap-1.5 rounded-lg bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
-              disabled={isApplying}
-              onClick={applyLookup}
-              type="button"
-            >
-              {isApplying && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-              Appliquer
-            </button>
-          </div>
-          {lookupResult.data.sources.length > 0 && (
-            <p className="text-xs text-text-muted">
-              Sources : {lookupResult.data.sources.join(", ")}
-            </p>
+              <div className="space-y-1.5">
+                {titleCandidates.data.results.map((candidate, index) => (
+                  <button
+                    className="flex w-full items-center gap-3 rounded-lg bg-surface-primary p-2.5 border border-surface-border text-left hover:border-primary-400 transition"
+                    key={index}
+                    onClick={() => candidate.title && selectCandidate(candidate.title)}
+                    type="button"
+                  >
+                    {candidate.thumbnail ? (
+                      <img
+                        alt=""
+                        className="h-12 w-9 shrink-0 rounded object-cover"
+                        src={candidate.thumbnail}
+                      />
+                    ) : (
+                      <div className="flex h-12 w-9 shrink-0 items-center justify-center rounded bg-surface-tertiary text-text-muted">
+                        <Layers className="h-4 w-4" />
+                      </div>
+                    )}
+                    <div className="min-w-0 text-sm">
+                      <p className="truncate font-medium text-text-primary">{candidate.title}</p>
+                      <p className="truncate text-text-muted">
+                        {candidate.authors ?? ""}
+                        {candidate.publisher && ` — ${candidate.publisher}`}
+                      </p>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </>
           )}
-          {Object.entries(lookupResult.data.apiMessages).filter(([, m]) => m.status !== "success").length > 0 && (
+          {titleCandidates.data.sources.length > 0 && (
             <p className="text-xs text-text-muted">
-              {Object.entries(lookupResult.data.apiMessages)
-                .filter(([, m]) => m.status !== "success")
-                .map(([provider, m]) => `${provider}: ${m.message}`)
-                .join(" · ")}
+              Sources : {titleCandidates.data.sources.join(", ")}
             </p>
           )}
         </div>
+      )}
+
+      {/* Targeted result (title mode, candidate selected) */}
+      {showTargeted && (
+        <div className="space-y-2">
+          <button
+            className="flex items-center gap-1 text-xs text-text-muted hover:text-primary-600 transition"
+            onClick={clearCandidate}
+            type="button"
+          >
+            <ArrowLeft className="h-3 w-3" />
+            Retour aux résultats
+          </button>
+          {lookupResult.isFetching && (
+            <div className="flex items-center gap-2 text-sm text-text-muted">
+              <Loader2 className="h-4 w-4 animate-spin" /> Chargement des détails…
+            </div>
+          )}
+          {lookupResult.data && !lookupResult.isFetching && (
+            <LookupResultCard
+              applyLookup={applyLookup}
+              isApplying={isApplying}
+              result={lookupResult.data}
+            />
+          )}
+        </div>
+      )}
+
+      {/* ISBN result (isbn mode) */}
+      {lookupMode === "isbn" && lookupResult.data && !lookupResult.isFetching && (
+        <LookupResultCard
+          applyLookup={applyLookup}
+          isApplying={isApplying}
+          result={lookupResult.data}
+        />
+      )}
+    </div>
+  );
+}
+
+function LookupResultCard({
+  applyLookup,
+  isApplying,
+  result,
+}: {
+  applyLookup: () => void;
+  isApplying: boolean;
+  result: LookupResult;
+}) {
+  return (
+    <div className="rounded-lg bg-surface-primary p-3 border border-surface-border space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0 text-sm">
+          <p className="truncate font-medium text-text-primary">{result.title}</p>
+          <p className="truncate text-text-muted">
+            {result.authors ?? ""}
+            {result.publisher && ` — ${result.publisher}`}
+          </p>
+        </div>
+        <button
+          className="flex shrink-0 items-center gap-1.5 rounded-lg bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
+          disabled={isApplying}
+          onClick={applyLookup}
+          type="button"
+        >
+          {isApplying && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+          Appliquer
+        </button>
+      </div>
+      {result.sources.length > 0 && (
+        <p className="text-xs text-text-muted">
+          Sources : {result.sources.join(", ")}
+        </p>
+      )}
+      {Object.entries(result.apiMessages).filter(([, m]) => m.status !== "success").length > 0 && (
+        <p className="text-xs text-text-muted">
+          {Object.entries(result.apiMessages)
+            .filter(([, m]) => m.status !== "success")
+            .map(([provider, m]) => `${provider}: ${m.message}`)
+            .join(" · ")}
+        </p>
       )}
     </div>
   );

--- a/frontend/src/hooks/useComicForm.ts
+++ b/frontend/src/hooks/useComicForm.ts
@@ -5,7 +5,7 @@ import { useAuthors } from "./useAuthors";
 import { useOnlineStatus } from "./useOnlineStatus";
 import { useComic } from "./useComic";
 import { useCreateComic } from "./useCreateComic";
-import { fetchLookupIsbn, fetchLookupTitle, useLookupIsbn, useLookupTitle } from "./useLookup";
+import { fetchLookupIsbn, fetchLookupTitle, useLookupIsbn, useLookupTitle, useLookupTitleCandidates } from "./useLookup";
 import { useSyncFailures } from "./useSyncFailures";
 import { useUpdateComic } from "./useUpdateComic";
 import { apiFetch } from "../services/api";
@@ -115,6 +115,7 @@ export function useComicForm() {
   const [lookupIsbn, setLookupIsbn] = useState("");
   const [lookupTitle, setLookupTitle] = useState("");
   const [lookupMode, setLookupMode] = useState<"isbn" | "title">("title");
+  const [selectedCandidateTitle, setSelectedCandidateTitle] = useState<string | null>(null);
   const [tomeLookupLoading, setTomeLookupLoading] = useState<number | null>(null);
 
   // Cover search state
@@ -125,8 +126,9 @@ export function useComicForm() {
   const [batchTo, setBatchTo] = useState(1);
 
   const isbnLookup = useLookupIsbn(lookupMode === "isbn" ? lookupIsbn : "", form.type);
-  const titleLookup = useLookupTitle(lookupMode === "title" ? lookupTitle : "", form.type);
-  const lookupResult = lookupMode === "isbn" ? isbnLookup : titleLookup;
+  const titleCandidates = useLookupTitleCandidates(lookupMode === "title" ? lookupTitle : "", form.type);
+  const targetedLookup = useLookupTitle(selectedCandidateTitle ?? "", form.type);
+  const lookupResult = lookupMode === "isbn" ? isbnLookup : targetedLookup;
 
   // Author autocomplete
   const [authorSearch, setAuthorSearch] = useState("");
@@ -165,6 +167,14 @@ export function useComicForm() {
     }
   };
 
+  const selectCandidate = (title: string) => {
+    setSelectedCandidateTitle(title);
+  };
+
+  const clearCandidate = () => {
+    setSelectedCandidateTitle(null);
+  };
+
   const applyLookup = async () => {
     const result = lookupResult.data;
     if (!result) return;
@@ -183,6 +193,7 @@ export function useComicForm() {
       }
     } else {
       applySeriesFields(result);
+      setSelectedCandidateTitle(null);
       toast.success("Informations récupérées");
     }
   };
@@ -358,6 +369,7 @@ export function useComicForm() {
     batchFrom,
     batchSize,
     batchTo,
+    clearCandidate,
     coverSearchOpen,
     form,
     handleSubmit,
@@ -376,6 +388,8 @@ export function useComicForm() {
     removeAuthor,
     removeTome,
     resolveSyncFailure,
+    selectCandidate,
+    selectedCandidateTitle,
     setAuthorSearch,
     setBatchFrom,
     setBatchTo,
@@ -384,6 +398,7 @@ export function useComicForm() {
     setLookupMode,
     setLookupTitle,
     syncFailure,
+    titleCandidates,
     tomeLookupLoading,
     update,
     updateTome,

--- a/frontend/src/hooks/useLookup.ts
+++ b/frontend/src/hooks/useLookup.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiFetch } from "../services/api";
-import type { LookupResult } from "../types/api";
+import type { LookupCandidatesResponse, LookupResult } from "../types/api";
 
 export function useLookupIsbn(isbn: string, type?: string) {
   const params = new URLSearchParams({ isbn });
@@ -21,6 +21,17 @@ export function useLookupTitle(title: string, type?: string) {
     enabled: title.length >= 2,
     queryFn: () => apiFetch<LookupResult>(`/lookup/title?${params}`),
     queryKey: ["lookup", "title", title, type],
+  });
+}
+
+export function useLookupTitleCandidates(title: string, type?: string, limit = 5) {
+  const params = new URLSearchParams({ limit: String(limit), title });
+  if (type) params.set("type", type);
+
+  return useQuery({
+    enabled: title.length >= 2,
+    queryFn: () => apiFetch<LookupCandidatesResponse>(`/lookup/title?${params}`),
+    queryKey: ["lookup", "title-candidates", title, type, limit],
   });
 }
 

--- a/frontend/src/pages/ComicForm.tsx
+++ b/frontend/src/pages/ComicForm.tsx
@@ -68,6 +68,7 @@ export default function ComicForm() {
     batchFrom,
     batchSize,
     batchTo,
+    clearCandidate,
     coverSearchOpen,
     form,
     handleSubmit,
@@ -86,6 +87,8 @@ export default function ComicForm() {
     removeAuthor,
     removeTome,
     resolveSyncFailure,
+    selectCandidate,
+    selectedCandidateTitle,
     setAuthorSearch,
     setBatchFrom,
     setBatchTo,
@@ -94,6 +97,7 @@ export default function ComicForm() {
     setLookupMode,
     setLookupTitle,
     syncFailure,
+    titleCandidates,
     tomeLookupLoading,
     update,
     updateTome,
@@ -165,6 +169,7 @@ export default function ComicForm() {
       {/* Lookup section */}
       <LookupSection
         applyLookup={applyLookup}
+        clearCandidate={clearCandidate}
         formTitle={form.title}
         isApplying={isApplying}
         isOnline={isOnline}
@@ -172,9 +177,12 @@ export default function ComicForm() {
         lookupMode={lookupMode}
         lookupResult={lookupResult}
         lookupTitle={lookupTitle}
+        selectCandidate={selectCandidate}
+        selectedCandidateTitle={selectedCandidateTitle}
         setLookupIsbn={setLookupIsbn}
         setLookupMode={setLookupMode}
         setLookupTitle={setLookupTitle}
+        titleCandidates={titleCandidates}
       />
 
       {/* Form */}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -159,3 +159,23 @@ export interface LookupResult {
   tomeEnd: number | null;
   tomeNumber: number | null;
 }
+
+export interface LookupCandidatesResponse {
+  apiMessages: Record<string, { message: string; status: string }>;
+  results: LookupCandidate[];
+  sources: string[];
+}
+
+export interface LookupCandidate {
+  authors: string | null;
+  description: string | null;
+  isbn: string | null;
+  isOneShot: boolean | null;
+  latestPublishedIssue: number | null;
+  publishedDate: string | null;
+  publisher: string | null;
+  thumbnail: string | null;
+  title: string | null;
+  tomeEnd: number | null;
+  tomeNumber: number | null;
+}


### PR DESCRIPTION
## Summary

- Paramètre `limit` sur `/api/lookup/title` (défaut 1, max 10) : `limit=1` garde le comportement existant, `limit>1` retourne un tableau de candidats
- `MultiResultLookupProviderInterface` implémenté par GoogleBooks (groupement par titre distinct) et AniList (query Page)
- Les providers single-result (Bedetheque, Wikipedia, BnF, Gemini) contribuent aussi leur résultat unique aux candidats
- Frontend : liste de candidats avec thumbnail → sélection → lookup ciblé (limit=1) → application
- Fix inclus : priorité Bedetheque thumbnail = 150 pour le type BD (au lieu de 50)

## Test plan

- [ ] Tester lookup titre "Naruto" type manga → plusieurs candidats AniList + Google Books
- [ ] Tester lookup titre "Arawn" type BD → candidats Google Books + Bedetheque (si clé Gemini configurée)
- [ ] Sélectionner un candidat → lookup ciblé charge les détails → Appliquer remplit le formulaire
- [ ] Bouton "Retour aux résultats" fonctionne
- [ ] Mode ISBN non affecté (comportement inchangé)
- [ ] `limit=1` (défaut) retourne le format existant (backward compatible)

fixes #200