### PR TITLE
fix(lookup): rotation de clef Gemini sur erreur 400

### DIFF
--- a/backend/src/Service/Lookup/AbstractGeminiLookupProvider.php
+++ b/backend/src/Service/Lookup/AbstractGeminiLookupProvider.php
@@ -192,7 +192,7 @@ abstract class AbstractGeminiLookupProvider extends AbstractLookupProvider
             $this->logger->error("Erreur Gemini API ({$logName}) : {error}", ['code' => $e->getErrorCode(), 'error' => $e->getMessage()]);
 
             $code = $e->getErrorCode();
-            if (\in_array($code, [401, 403, 429], true)) {
+            if (\in_array($code, [400, 401, 403, 429], true)) {
                 $this->recordApiMessage(ApiLookupStatus::RATE_LIMITED, 'Toutes les clés API épuisées (dernière erreur : '.$code.')');
             } else {
                 $this->recordApiMessage(ApiLookupStatus::ERROR, $e->getErrorMessage());

--- a/backend/src/Service/Lookup/GeminiClientPool.php
+++ b/backend/src/Service/Lookup/GeminiClientPool.php
@@ -8,7 +8,7 @@ use Gemini\Exceptions\ErrorException;
 use Psr\Log\LoggerInterface;
 
 /**
- * Pool de clients Gemini avec rotation clés × modèles sur erreur 401/403/429.
+ * Pool de clients Gemini avec rotation clés × modèles sur erreur 400/401/403/429.
  *
  * Itère modèles (outer) × clés (inner) : épuise toutes les clés sur le meilleur modèle d'abord.
  * Le suivi d'épuisement est en mémoire (suffisant pour les batchs et réinitialisé par requête web).
@@ -46,7 +46,7 @@ class GeminiClientPool
     }
 
     /**
-     * Exécute le callable avec rotation clés × modèles sur 429.
+     * Exécute le callable avec rotation clés × modèles sur 400/401/403/429.
      *
      * @template T
      *
@@ -75,7 +75,7 @@ class GeminiClientPool
                 } catch (ErrorException $e) {
                     $code = $e->getErrorCode();
 
-                    if (!\in_array($code, [401, 403, 429], true)) {
+                    if (!\in_array($code, [400, 401, 403, 429], true)) {
                         throw $e;
                     }
 

--- a/backend/tests/Unit/Service/Lookup/GeminiClientPoolTest.php
+++ b/backend/tests/Unit/Service/Lookup/GeminiClientPoolTest.php
@@ -138,6 +138,27 @@ final class GeminiClientPoolTest extends TestCase
     }
 
     /**
+     * Teste la rotation vers la deuxième clé sur 400 (clé invalide/expirée) de la première.
+     */
+    public function testRotatesToSecondKeyOn400(): void
+    {
+        $pool = new GeminiClientPool('key1,key2', $this->logger, 'gemini-2.5-flash');
+
+        $callCount = 0;
+        $result = $pool->executeWithRetry(static function ($client, $model) use (&$callCount): string {
+            ++$callCount;
+            if (1 === $callCount) {
+                throw new ErrorException(['code' => 400, 'message' => 'API key not valid. Please pass a valid API key.', 'status' => 'INVALID_ARGUMENT']);
+            }
+
+            return 'ok_key2';
+        });
+
+        self::assertSame('ok_key2', $result);
+        self::assertSame(2, $callCount);
+    }
+
+    /**
      * Teste qu'une erreur non retryable est relancée immédiatement sans rotation.
      */
     public function testNon429ErrorRethrowsImmediately(): void


### PR DESCRIPTION
## Summary
- Ajoute le code HTTP 400 (`INVALID_ARGUMENT`) à la liste des erreurs déclenchant la rotation de clef dans `GeminiClientPool`
- Corrige un bug où une clef Gemini supprimée/expirée bloquait le lookup au lieu de passer à la clef suivante
- Aligne `AbstractGeminiLookupProvider` sur les mêmes codes retryables

## Test plan
- [x] Test unitaire `testRotatesToSecondKeyOn400` ajouté
- [x] 273 tests lookup passent
- [x] PHPStan clean, CS Fixer clean