### PR TITLE
chore(docker): durcit les conteneurs de production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 - **Lookup multi-candidats** : Le lookup par titre affiche plusieurs séries candidates regroupées par titre, permettant de choisir avant d'appliquer. Paramètre `limit` sur `/api/lookup/title` (défaut 1, max 10). Tous les providers contribuent aux candidats (#200)
 
+### Changed
+
+- **Docker hardening** : Conteneurs PHP et nginx exécutés en non-root, Node.js 22, Composer pinné à v2, healthcheck php-fpm, `.dockerignore` enrichi (#171)
+
 ### Fixed
 
 - **Priorité Bedetheque thumbnail BD** : La priorité du champ thumbnail est maintenant 150 (comme les autres champs) pour le type BD, au lieu de 50 (#200)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@
 # Bibliothèque — Makefile
 # ──────────────────────────────────────────────────
 # Raccourcis pour les commandes courantes.
-# Usage : make <cible>   (ex. make test, make lint)
+# Usage : ddev exec make <cible>   (ex. ddev exec make test)
+#
+# Ce Makefile est conçu pour être exécuté à l'intérieur
+# du conteneur DDEV (via `ddev exec make ...` ou `ddev ssh`).
+# Ne pas exécuter directement sur la machine hôte.
 # ──────────────────────────────────────────────────
 
 include backend/.env

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -5,11 +5,16 @@
 .git/
 .gitignore
 .idea/
+.php-cs-fixer.cache
+docker/nginx/
 docker-compose*.yml
 Dockerfile
 node_modules/
+phpstan-baseline-new.neon
+phpunit.xml
 public/bundles/
 README.md
+rector.php
 tests/
 var/
 vendor/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,8 @@ FROM php:8.3-fpm
 
 RUN apt-get update && apt-get install -y \
     git \
+    gosu \
+    libfcgi-bin \
     libicu-dev \
     libjpeg62-turbo-dev \
     libpng-dev \
@@ -18,7 +20,7 @@ RUN apt-get update && apt-get install -y \
     zip \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
@@ -32,13 +34,10 @@ COPY . .
 
 RUN composer dump-autoload --optimize
 
-RUN mkdir -p public/uploads public/media var/cache var/log
+RUN mkdir -p public/uploads public/media var/cache var/log \
+    && chown -R www-data:www-data public/uploads public/media var
 
-RUN php bin/console cache:clear --env=prod --no-debug \
-    && php bin/console cache:warmup --env=prod --no-debug
-
-RUN chown -R www-data:www-data public/uploads public/media var
-
+COPY docker/php/healthcheck.conf /usr/local/etc/php-fpm.d/zz-healthcheck.conf
 COPY docker/php/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 EXPOSE 9000

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -6,9 +6,10 @@ services:
       context: ..
       dockerfile: backend/docker/nginx/Dockerfile
     depends_on:
-      - php
+      php:
+        condition: service_healthy
     ports:
-      - "${APP_PORT:-8080}:80"
+      - "${APP_PORT:-8080}:8080"
     restart: unless-stopped
     volumes:
       - media:/var/www/html/public/media:ro
@@ -19,6 +20,11 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "cgi-fcgi -bind -connect 127.0.0.1:9000 /ping 2>/dev/null | grep -q pong"]
+      interval: 10s
+      retries: 3
+      timeout: 5s
     environment:
       - APP_ENV=prod
       - APP_SECRET=${APP_SECRET}

--- a/backend/docker/nginx/Dockerfile
+++ b/backend/docker/nginx/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1 : Build frontend
-FROM node:20-alpine AS frontend-build
+FROM node:22-alpine AS frontend-build
 
 ARG VITE_GOOGLE_CLIENT_ID
 ENV VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID}
@@ -12,11 +12,11 @@ RUN npm ci
 COPY frontend/ .
 RUN npm run build
 
-# Stage 2 : Nginx
-FROM nginx:alpine
+# Stage 2 : Nginx (non-root, port 8080)
+FROM nginxinc/nginx-unprivileged:alpine
 
 COPY backend/docker/nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY backend/docker/nginx/security-headers.conf /etc/nginx/conf.d/security-headers.conf
 COPY --from=frontend-build /app/dist /usr/share/nginx/html
 
-EXPOSE 80
+EXPOSE 8080

--- a/backend/docker/nginx/default.conf
+++ b/backend/docker/nginx/default.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     root /usr/share/nginx/html;
     index index.html;
 

--- a/backend/docker/php/docker-entrypoint.sh
+++ b/backend/docker/php/docker-entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -e
 
-# Compile les variables d'environnement pour Symfony (performance)
-composer dump-env prod
-
-# Corrige les permissions du cache (le volume app_var persiste entre les rebuilds)
+# Corrige les permissions des volumes (nécessite root)
 chown -R www-data:www-data var
 
-# Exécute la commande par défaut (php-fpm)
-exec "$@"
+# Compile les variables d'environnement pour Symfony (performance)
+gosu www-data composer dump-env prod
+
+# Exécute la commande par défaut (php-fpm) en tant que www-data
+exec gosu www-data "$@"

--- a/backend/docker/php/healthcheck.conf
+++ b/backend/docker/php/healthcheck.conf
@@ -1,0 +1,3 @@
+[www]
+ping.path = /ping
+ping.response = pong

--- a/docs/guide-deploiement-nas.md
+++ b/docs/guide-deploiement-nas.md
@@ -232,7 +232,7 @@ sudo docker compose --env-file .env.nas up --build -d
 
 | Conteneur | Image | Port | Rôle |
 |-----------|-------|------|------|
-| nginx | nginx:alpine + frontend build | 80 → 8082 | SPA React + proxy API + uploads |
+| nginx | nginxinc/nginx-unprivileged:alpine + frontend build | 8080 → 8082 | SPA React + proxy API + uploads |
 | php | php:8.3-fpm + Symfony | 9000 (interne) | PHP-FPM, API |
 | db | mariadb:10.11 | 3306 (interne) | Base de données |
 


### PR DESCRIPTION
## Summary
- Exécute PHP-FPM en non-root via `gosu` (www-data) et nginx via `nginxinc/nginx-unprivileged:alpine` (port 8080)
- Migre Node.js 20 → 22 LTS pour le build frontend
- Pinne Composer à la version 2
- Ajoute un healthcheck php-fpm (ping/pong via `cgi-fcgi`) + nginx dépend de PHP healthy
- Enrichit `.dockerignore` (tests, configs dev, docker/nginx)
- Documente l'usage DDEV du Makefile

## Impact NAS
- **Port interne nginx** : passe de 80 à 8080. Le port exposé sur l'hôte (`APP_PORT=8082`) ne change pas — aucun changement Synology nécessaire si la config utilise `APP_PORT`.
- **Premier redémarrage** : `docker compose down && docker compose up --build -d` (rebuild nécessaire pour les nouvelles images)

## Test plan
- [ ] `docker compose up --build -d` — les 3 conteneurs démarrent et passent en healthy
- [ ] L'app répond sur le port configuré (`APP_PORT`)
- [ ] Les uploads et media sont accessibles
- [ ] `docker exec <php> whoami` → `www-data`
- [ ] `docker exec <nginx> whoami` → `nginx`

fixes #171