### PR TITLE
chore(ci): met à jour les actions GitHub vers Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Lint Backend (PHPStan + CS Fixer)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -41,10 +41,10 @@ jobs:
     name: Lint Frontend (TypeScript)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -79,7 +79,7 @@ jobs:
     env:
       DATABASE_URL: mysql://app:app@127.0.0.1:3306/db?serverVersion=10.11.0-MariaDB&charset=utf8mb4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -108,10 +108,10 @@ jobs:
     name: Test Frontend (Vitest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Extract changelog for this version
         id: changelog


### PR DESCRIPTION
## Summary
- **actions/checkout** : v4 → v5
- **actions/setup-node** : v4 → v5

Élimine le warning de dépréciation Node.js 20 dans GitHub Actions (Node.js 20 sera remplacé par Node.js 24 par défaut à partir du 2 juin 2026).

## Test plan
- [ ] Vérifier que le workflow CI passe sur cette PR
- [ ] Vérifier qu'il n'y a plus de warning Node.js 20