### PR TITLE
chore(tests): installe pcov et ajoute les tests manquants

### DIFF
--- a/.ddev/php/pcov.ini
+++ b/.ddev/php/pcov.ini
@@ -1,0 +1,3 @@
+[pcov]
+pcov.enabled = 1
+pcov.directory = /var/www/html/backend/src

--- a/.ddev/web-build/Dockerfile.pcov
+++ b/.ddev/web-build/Dockerfile.pcov
@@ -1,0 +1,1 @@
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends php${DDEV_PHP_VERSION}-pcov && rm -rf /var/lib/apt/lists/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 ### Added
 
 - **Lookup multi-candidats** : Le lookup par titre affiche plusieurs séries candidates regroupées par titre, permettant de choisir avant d'appliquer. Paramètre `limit` sur `/api/lookup/title` (défaut 1, max 10). Tous les providers contribuent aux candidats (#200)
+- **pcov** : Installation de pcov dans DDEV pour la couverture de code, commande `make coverage` (#172)
+- **Tests manquants** : Tests ImportBooksCommand, sw-custom, MergeGroupCard, SeriesMultiSelect, Tools page (#172)
+
+### Changed
+
+- **PurgeService** : Corrige le problème N+1 en utilisant `findBy()` au lieu de `find()` en boucle (#172)
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ Location: `docs/plans/` (gitignored). Concise only: what to do (files, logic, or
 | `make jwt` | Generate JWT keypair |
 | `make dump-env` | Compile .env for Symfony |
 | `make db-diff` / `db-migrate` / `db-reset` / `db-seed` | Migration diff / migrate / drop+create+migrate / fixtures |
+| `make coverage` | PHPUnit HTML coverage report (pcov) |
 | `make rector` / `rector-dry` | Apply / preview Rector refactorings |
 | `make deploy` | docker-compose prod |
 

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ test-back: ## Lancer les tests PHPUnit
 test-front: ## Lancer les tests Vitest
 	cd $(FRONT) && npx vitest run
 
+coverage: ## Générer le rapport de couverture HTML (backend)
+	cd $(BACK) && vendor/bin/phpunit --coverage-html var/coverage
+
 # ── Qualité de code ───────────────────────────────
 
 .PHONY: lint lint-back lint-front phpstan cs cs-dry rector rector-dry

--- a/backend/src/Service/PurgeService.php
+++ b/backend/src/Service/PurgeService.php
@@ -36,15 +36,15 @@ final class PurgeService
 
         $this->entityManager->getFilters()->disable('soft_delete');
 
+        $allSeries = $this->comicSeriesRepository->findBy(['id' => $seriesIds]);
+
         $count = 0;
 
-        foreach ($seriesIds as $id) {
-            $series = $this->comicSeriesRepository->find($id);
-
-            if ($series instanceof ComicSeries) {
-                $this->comicSeriesService->permanentDelete($id, $series);
-                ++$count;
-            }
+        foreach ($allSeries as $series) {
+            /** @var int $id entité persistée */
+            $id = $series->getId();
+            $this->comicSeriesService->permanentDelete($id, $series);
+            ++$count;
         }
 
         $this->entityManager->getFilters()->enable('soft_delete');

--- a/backend/tests/Integration/Command/ImportBooksCommandTest.php
+++ b/backend/tests/Integration/Command/ImportBooksCommandTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Command;
+
+use App\Entity\ComicSeries;
+use App\Enum\ComicStatus;
+use App\Enum\ComicType;
+use Doctrine\ORM\EntityManagerInterface;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Tests d'intégration pour la commande app:import-books.
+ */
+final class ImportBooksCommandTest extends KernelTestCase
+{
+    private CommandTester $commandTester;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+
+        /** @var \Symfony\Component\HttpKernel\KernelInterface $kernel */
+        $kernel = self::$kernel;
+        $application = new Application($kernel);
+        $command = $application->find('app:import-books');
+        $this->commandTester = new CommandTester($command);
+    }
+
+    public function testFileNotFoundReturnsFailure(): void
+    {
+        $this->commandTester->execute([
+            'file' => '/tmp/inexistant_file_12345.xlsx',
+        ]);
+
+        self::assertSame(Command::FAILURE, $this->commandTester->getStatusCode());
+        self::assertStringContainsString('n\'existe pas', $this->commandTester->getDisplay());
+    }
+
+    public function testSuccessfulImportCreatesSeriesAndTomes(): void
+    {
+        $tmpFile = $this->createBooksExcel([
+            ['9782723489003', 'One Piece - Tome 1', 'Eiichiro Oda', 'Glenat', '', 'Manga', ''],
+            ['9782723489010', 'One Piece - Tome 2', 'Eiichiro Oda', 'Glenat', '', 'Manga', ''],
+        ]);
+
+        try {
+            $this->commandTester->execute(['file' => $tmpFile]);
+
+            self::assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+            self::assertStringContainsString('1 créés', $this->commandTester->getDisplay());
+
+            $series = $this->em->getRepository(ComicSeries::class)->findOneBy(['title' => 'One Piece']);
+
+            self::assertNotNull($series);
+            self::assertSame(ComicType::MANGA, $series->getType());
+            self::assertSame(ComicStatus::FINISHED, $series->getStatus());
+            self::assertCount(2, $series->getTomes());
+        } finally {
+            @\unlink($tmpFile);
+        }
+    }
+
+    public function testDryRunDoesNotPersist(): void
+    {
+        $tmpFile = $this->createBooksExcel([
+            ['', 'Asterix', '', '', '', 'BD', ''],
+        ]);
+
+        try {
+            $this->commandTester->execute([
+                'file' => $tmpFile,
+                '--dry-run' => true,
+            ]);
+
+            self::assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+            self::assertStringContainsString('dry-run', \strtolower($this->commandTester->getDisplay()));
+
+            $series = $this->em->getRepository(ComicSeries::class)->findAll();
+            self::assertCount(0, $series);
+        } finally {
+            @\unlink($tmpFile);
+        }
+    }
+
+    public function testInvalidExcelFileReturnsFailure(): void
+    {
+        $tmpFile = \tempnam(\sys_get_temp_dir(), 'test_import_').'.xlsx';
+        \file_put_contents($tmpFile, "PK\x03\x04corrupt");
+
+        try {
+            $this->commandTester->execute(['file' => $tmpFile]);
+
+            self::assertSame(Command::FAILURE, $this->commandTester->getStatusCode());
+            self::assertStringContainsString('Impossible de lire le fichier Excel', $this->commandTester->getDisplay());
+        } finally {
+            @\unlink($tmpFile);
+        }
+    }
+
+    public function testOneShotBookCreatesOneTome(): void
+    {
+        $tmpFile = $this->createBooksExcel([
+            ['9782723489003', 'Le Petit Prince', 'Saint-Exupéry', 'Gallimard', '', 'BD', 'Un classique'],
+        ]);
+
+        try {
+            $this->commandTester->execute(['file' => $tmpFile]);
+
+            self::assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+
+            $series = $this->em->getRepository(ComicSeries::class)->findOneBy(['title' => 'Le Petit Prince']);
+
+            self::assertNotNull($series);
+            self::assertTrue($series->isOneShot());
+            self::assertCount(1, $series->getTomes());
+            $firstTome = $series->getTomes()->first();
+            self::assertNotFalse($firstTome);
+            self::assertSame('9782723489003', $firstTome->getIsbn());
+        } finally {
+            @\unlink($tmpFile);
+        }
+    }
+
+    public function testEmptyRowsAreSkipped(): void
+    {
+        $tmpFile = $this->createBooksExcel([
+            ['', '', '', '', '', '', ''],
+            ['', 'Valid Book', '', '', '', '', ''],
+            ['', '   ', '', '', '', '', ''],
+        ]);
+
+        try {
+            $this->commandTester->execute(['file' => $tmpFile]);
+
+            self::assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+
+            $series = $this->em->getRepository(ComicSeries::class)->findAll();
+            self::assertCount(1, $series);
+            self::assertSame('Valid Book', $series[0]->getTitle());
+        } finally {
+            @\unlink($tmpFile);
+        }
+    }
+
+    /**
+     * Crée un fichier Excel au format Livres.xlsx (ISBN, Titre, Auteur, Editeur, Cover, Catégories, Description).
+     *
+     * @param list<list<string>> $rows
+     */
+    private function createBooksExcel(array $rows): string
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setTitle('Livres');
+
+        // En-tête
+        $headers = ['ISBN', 'Titre', 'Auteur', 'Editeur', 'Cover', 'Catégories', 'Description'];
+        foreach ($headers as $col => $header) {
+            $sheet->setCellValue([$col + 1, 1], $header);
+        }
+
+        // Données
+        foreach ($rows as $rowIndex => $rowData) {
+            foreach ($rowData as $col => $value) {
+                $sheet->setCellValue([$col + 1, $rowIndex + 2], $value);
+            }
+        }
+
+        $tmpFile = \tempnam(\sys_get_temp_dir(), 'test_import_books_').'.xlsx';
+        $writer = new Xlsx($spreadsheet);
+        $writer->save($tmpFile);
+
+        return $tmpFile;
+    }
+}

--- a/backend/tests/Unit/Service/PurgeServiceTest.php
+++ b/backend/tests/Unit/Service/PurgeServiceTest.php
@@ -46,13 +46,9 @@ final class PurgeServiceTest extends TestCase
         $series1 = $this->createComicSeriesMock(1, 'Naruto', new \DateTimeImmutable());
         $series2 = $this->createComicSeriesMock(2, 'One Piece', new \DateTimeImmutable());
 
-        $this->comicSeriesRepository->method('find')->willReturnCallback(
-            static fn (int $id): ?ComicSeries => match ($id) {
-                1 => $series1,
-                2 => $series2,
-                default => null,
-            },
-        );
+        $this->comicSeriesRepository->method('findBy')
+            ->with(['id' => [1, 2]])
+            ->willReturn([$series1, $series2]);
 
         $this->comicSeriesService->expects(self::exactly(2))
             ->method('permanentDelete')
@@ -81,9 +77,9 @@ final class PurgeServiceTest extends TestCase
     {
         $series1 = $this->createComicSeriesMock(1, 'Naruto', new \DateTimeImmutable());
 
-        $this->comicSeriesRepository->method('find')->willReturnCallback(
-            static fn (int $id): ?ComicSeries => 1 === $id ? $series1 : null,
-        );
+        $this->comicSeriesRepository->method('findBy')
+            ->with(['id' => [1, 999]])
+            ->willReturn([$series1]);
 
         $this->comicSeriesService->expects(self::once())
             ->method('permanentDelete')
@@ -99,6 +95,25 @@ final class PurgeServiceTest extends TestCase
         $count = $this->purgeService->executePurge([]);
 
         self::assertSame(0, $count);
+    }
+
+    public function testExecutePurgeUsesBatchLoadingNotIndividualQueries(): void
+    {
+        $series1 = $this->createComicSeriesMock(1, 'Naruto', new \DateTimeImmutable());
+        $series2 = $this->createComicSeriesMock(2, 'One Piece', new \DateTimeImmutable());
+        $series3 = $this->createComicSeriesMock(3, 'Bleach', new \DateTimeImmutable());
+
+        // findBy doit être appelé une seule fois (batch), jamais find()
+        $this->comicSeriesRepository->expects(self::once())
+            ->method('findBy')
+            ->with(['id' => [1, 2, 3]])
+            ->willReturn([$series1, $series2, $series3]);
+
+        $this->comicSeriesRepository->expects(self::never())->method('find');
+
+        $count = $this->purgeService->executePurge([1, 2, 3]);
+
+        self::assertSame(3, $count);
     }
 
     public function testPurgeableSeriesIsJsonSerializable(): void

--- a/frontend/src/__tests__/integration/components/MergeGroupCard.test.tsx
+++ b/frontend/src/__tests__/integration/components/MergeGroupCard.test.tsx
@@ -1,0 +1,78 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import MergeGroupCard from "../../../components/MergeGroupCard";
+import type { MergeGroup } from "../../../types/api";
+import { renderWithProviders } from "../../helpers/test-utils";
+
+const group: MergeGroup = {
+  entries: [
+    { originalTitle: "Naruto - T1", seriesId: 1, suggestedTomeNumber: 1 },
+    { originalTitle: "Naruto - T2", seriesId: 2, suggestedTomeNumber: 2 },
+    { originalTitle: "Naruto Intégrale", seriesId: 3, suggestedTomeNumber: null },
+  ],
+  suggestedTitle: "Naruto",
+};
+
+describe("MergeGroupCard", () => {
+  it("renders the suggested title", () => {
+    renderWithProviders(
+      <MergeGroupCard group={group} onPreview={vi.fn()} onSkip={vi.fn()} />,
+    );
+
+    expect(screen.getByText("Naruto")).toBeInTheDocument();
+  });
+
+  it("renders entry count badge", () => {
+    renderWithProviders(
+      <MergeGroupCard group={group} onPreview={vi.fn()} onSkip={vi.fn()} />,
+    );
+
+    expect(screen.getByText("3 séries")).toBeInTheDocument();
+  });
+
+  it("renders all entries with their titles", () => {
+    renderWithProviders(
+      <MergeGroupCard group={group} onPreview={vi.fn()} onSkip={vi.fn()} />,
+    );
+
+    expect(screen.getByText("Naruto - T1")).toBeInTheDocument();
+    expect(screen.getByText("Naruto - T2")).toBeInTheDocument();
+    expect(screen.getByText("Naruto Intégrale")).toBeInTheDocument();
+  });
+
+  it("renders tome number for entries that have one", () => {
+    renderWithProviders(
+      <MergeGroupCard group={group} onPreview={vi.fn()} onSkip={vi.fn()} />,
+    );
+
+    expect(screen.getByText("Tome 1")).toBeInTheDocument();
+    expect(screen.getByText("Tome 2")).toBeInTheDocument();
+  });
+
+  it("calls onPreview with group when clicking preview button", async () => {
+    const user = userEvent.setup();
+    const onPreview = vi.fn();
+
+    renderWithProviders(
+      <MergeGroupCard group={group} onPreview={onPreview} onSkip={vi.fn()} />,
+    );
+
+    await user.click(screen.getByText("Aperçu et fusion"));
+
+    expect(onPreview).toHaveBeenCalledWith(group);
+  });
+
+  it("calls onSkip with group when clicking skip button", async () => {
+    const user = userEvent.setup();
+    const onSkip = vi.fn();
+
+    renderWithProviders(
+      <MergeGroupCard group={group} onPreview={vi.fn()} onSkip={onSkip} />,
+    );
+
+    await user.click(screen.getByText("Ignorer"));
+
+    expect(onSkip).toHaveBeenCalledWith(group);
+  });
+});

--- a/frontend/src/__tests__/integration/components/SeriesMultiSelect.test.tsx
+++ b/frontend/src/__tests__/integration/components/SeriesMultiSelect.test.tsx
@@ -1,0 +1,121 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it, vi } from "vitest";
+import SeriesMultiSelect from "../../../components/SeriesMultiSelect";
+import {
+  createMockComicSeries,
+  createMockHydraCollection,
+} from "../../helpers/factories";
+import { server } from "../../helpers/server";
+import { renderWithProviders } from "../../helpers/test-utils";
+
+const comics = [
+  createMockComicSeries({ id: 1, title: "Naruto", tomes: [] }),
+  createMockComicSeries({ id: 2, title: "One Piece", tomes: [] }),
+  createMockComicSeries({ id: 3, title: "Bleach", tomes: [] }),
+];
+
+function setupHandler() {
+  server.use(
+    http.get("/api/comic_series", () =>
+      HttpResponse.json(createMockHydraCollection(comics)),
+    ),
+  );
+}
+
+describe("SeriesMultiSelect", () => {
+  it("renders series list from API", async () => {
+    setupHandler();
+
+    renderWithProviders(
+      <SeriesMultiSelect onSelectionChange={vi.fn()} selectedIds={[]} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Naruto")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("One Piece")).toBeInTheDocument();
+    expect(screen.getByText("Bleach")).toBeInTheDocument();
+  });
+
+  it("filters results by search (case-insensitive)", async () => {
+    setupHandler();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <SeriesMultiSelect onSelectionChange={vi.fn()} selectedIds={[]} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Naruto")).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText("Rechercher une série..."), "one");
+
+    await waitFor(() => {
+      expect(screen.getByText("One Piece")).toBeInTheDocument();
+      expect(screen.queryByText("Naruto")).not.toBeInTheDocument();
+      expect(screen.queryByText("Bleach")).not.toBeInTheDocument();
+    });
+  });
+
+  it("calls onSelectionChange when toggling checkbox", async () => {
+    setupHandler();
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+
+    renderWithProviders(
+      <SeriesMultiSelect onSelectionChange={onSelectionChange} selectedIds={[]} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Naruto")).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[0]);
+
+    expect(onSelectionChange).toHaveBeenCalledWith([1]);
+  });
+
+  it("shows selected items as chips", async () => {
+    setupHandler();
+
+    renderWithProviders(
+      <SeriesMultiSelect onSelectionChange={vi.fn()} selectedIds={[1, 3]} />,
+    );
+
+    await waitFor(() => {
+      // Naruto appears twice: once as chip, once in list
+      expect(screen.getAllByText("Naruto")).toHaveLength(2);
+    });
+
+    // Bleach also appears twice (chip + list)
+    expect(screen.getAllByText("Bleach")).toHaveLength(2);
+
+    // "2 sélectionnées" in the count text
+    expect(screen.getByText(/2 sélectionnée/)).toBeInTheDocument();
+  });
+
+  it("calls onSelectionChange without removed ID when removing chip", async () => {
+    setupHandler();
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+
+    renderWithProviders(
+      <SeriesMultiSelect onSelectionChange={onSelectionChange} selectedIds={[1, 2]} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Naruto")).toHaveLength(2);
+    });
+
+    // Click the remove button (X) on the first chip
+    const removeButtons = screen.getAllByRole("button");
+    await user.click(removeButtons[0]);
+
+    expect(onSelectionChange).toHaveBeenCalledWith([2]);
+  });
+});

--- a/frontend/src/__tests__/integration/pages/Tools.test.tsx
+++ b/frontend/src/__tests__/integration/pages/Tools.test.tsx
@@ -1,0 +1,55 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import Tools from "../../../pages/Tools";
+import { renderWithProviders } from "../../helpers/test-utils";
+
+vi.mock("idb-keyval", () => ({
+  del: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("Tools", () => {
+  it("renders page title", () => {
+    renderWithProviders(<Tools />);
+
+    expect(screen.getByText("Outils")).toBeInTheDocument();
+  });
+
+  it("renders 4 tool cards", () => {
+    renderWithProviders(<Tools />);
+
+    expect(screen.getByText("Fusion de series")).toBeInTheDocument();
+    expect(screen.getByText("Import Excel")).toBeInTheDocument();
+    expect(screen.getByText("Lookup metadonnees")).toBeInTheDocument();
+    expect(screen.getByText("Purge corbeille")).toBeInTheDocument();
+  });
+
+  it("cards link to correct routes", () => {
+    renderWithProviders(<Tools />);
+
+    const links = screen.getAllByRole("link");
+    const hrefs = links.map((link) => link.getAttribute("href"));
+
+    expect(hrefs).toContain("/tools/merge-series");
+    expect(hrefs).toContain("/tools/import");
+    expect(hrefs).toContain("/tools/lookup");
+    expect(hrefs).toContain("/tools/purge");
+  });
+
+  it("renders cache clear button", () => {
+    renderWithProviders(<Tools />);
+
+    expect(screen.getByText("Vider le cache")).toBeInTheDocument();
+  });
+
+  it("clears cache when clicking clear button", async () => {
+    const user = userEvent.setup();
+    const { del } = await import("idb-keyval");
+
+    renderWithProviders(<Tools />);
+
+    await user.click(screen.getByText("Vider le cache"));
+
+    expect(del).toHaveBeenCalledWith("bibliotheque-query-cache");
+  });
+});

--- a/frontend/src/__tests__/unit/sw-custom.test.ts
+++ b/frontend/src/__tests__/unit/sw-custom.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock workbox modules before importing sw-custom
+vi.mock("workbox-core", () => ({
+  clientsClaim: vi.fn(),
+}));
+
+vi.mock("workbox-precaching", () => ({
+  cleanupOutdatedCaches: vi.fn(),
+  precacheAndRoute: vi.fn(),
+}));
+
+vi.mock("workbox-routing", () => ({
+  registerRoute: vi.fn(),
+}));
+
+vi.mock("workbox-strategies", () => ({
+  CacheFirst: vi.fn(),
+  NetworkFirst: vi.fn(),
+}));
+
+vi.mock("workbox-expiration", () => ({
+  ExpirationPlugin: vi.fn(),
+}));
+
+const mockProcessSyncQueue = vi.fn();
+vi.mock("../../services/syncHandler", () => ({
+  processSyncQueue: mockProcessSyncQueue,
+}));
+
+const mockIdbGet = vi.fn();
+vi.mock("idb-keyval", () => ({
+  get: (...args: unknown[]) => mockIdbGet(...args),
+}));
+
+// Mock ServiceWorkerGlobalScope
+const mockClients = {
+  matchAll: vi.fn(),
+};
+
+const mockRegistration = {
+  showNotification: vi.fn(),
+};
+
+const syncListeners: Map<string, (event: unknown) => void> = new Map();
+
+Object.assign(globalThis, {
+  self: {
+    __WB_MANIFEST: [],
+    addEventListener: (type: string, handler: (event: unknown) => void) => {
+      syncListeners.set(type, handler);
+    },
+    clients: mockClients,
+    registration: mockRegistration,
+  },
+});
+
+// Polyfill MessageChannel for Node
+if (typeof MessageChannel === "undefined") {
+  class MockPort {
+    onmessage: ((event: { data: unknown }) => void) | null = null;
+    postMessage(data: unknown) {
+      this.onmessage?.({ data });
+    }
+  }
+  class MockMessageChannel {
+    port1 = new MockPort();
+    port2 = new MockPort();
+  }
+  Object.assign(globalThis, { MessageChannel: MockMessageChannel });
+}
+
+describe("sw-custom", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    syncListeners.clear();
+  });
+
+  it("registers workbox routes on import", async () => {
+    const { registerRoute } = await import("workbox-routing");
+
+    // Force re-evaluation
+    vi.resetModules();
+    // Re-mock after reset
+    vi.doMock("workbox-core", () => ({ clientsClaim: vi.fn() }));
+    vi.doMock("workbox-precaching", () => ({
+      cleanupOutdatedCaches: vi.fn(),
+      precacheAndRoute: vi.fn(),
+    }));
+    vi.doMock("workbox-routing", () => ({ registerRoute: vi.fn() }));
+    vi.doMock("workbox-strategies", () => ({
+      CacheFirst: vi.fn(),
+      NetworkFirst: vi.fn(),
+    }));
+    vi.doMock("workbox-expiration", () => ({ ExpirationPlugin: vi.fn() }));
+    vi.doMock("../../services/syncHandler", () => ({
+      processSyncQueue: vi.fn(),
+    }));
+    vi.doMock("idb-keyval", () => ({ get: vi.fn() }));
+
+    const routingModule = await import("workbox-routing");
+    await import("../../sw-custom");
+
+    // 3 routes: /api/, /uploads/covers/, Google Books
+    expect(routingModule.registerRoute).toHaveBeenCalledTimes(3);
+  });
+
+  it("registers a sync event listener", async () => {
+    vi.resetModules();
+    syncListeners.clear();
+
+    vi.doMock("workbox-core", () => ({ clientsClaim: vi.fn() }));
+    vi.doMock("workbox-precaching", () => ({
+      cleanupOutdatedCaches: vi.fn(),
+      precacheAndRoute: vi.fn(),
+    }));
+    vi.doMock("workbox-routing", () => ({ registerRoute: vi.fn() }));
+    vi.doMock("workbox-strategies", () => ({
+      CacheFirst: vi.fn(),
+      NetworkFirst: vi.fn(),
+    }));
+    vi.doMock("workbox-expiration", () => ({ ExpirationPlugin: vi.fn() }));
+    vi.doMock("../../services/syncHandler", () => ({
+      processSyncQueue: vi.fn(),
+    }));
+    vi.doMock("idb-keyval", () => ({ get: vi.fn() }));
+
+    await import("../../sw-custom");
+
+    expect(syncListeners.has("sync")).toBe(true);
+  });
+
+  it("sync handler calls processSyncQueue with token from IndexedDB", async () => {
+    vi.resetModules();
+    syncListeners.clear();
+
+    vi.doMock("workbox-core", () => ({ clientsClaim: vi.fn() }));
+    vi.doMock("workbox-precaching", () => ({
+      cleanupOutdatedCaches: vi.fn(),
+      precacheAndRoute: vi.fn(),
+    }));
+    vi.doMock("workbox-routing", () => ({ registerRoute: vi.fn() }));
+    vi.doMock("workbox-strategies", () => ({
+      CacheFirst: vi.fn(),
+      NetworkFirst: vi.fn(),
+    }));
+    vi.doMock("workbox-expiration", () => ({ ExpirationPlugin: vi.fn() }));
+
+    const localMockSync = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("../../services/syncHandler", () => ({
+      processSyncQueue: localMockSync,
+    }));
+
+    const localMockGet = vi.fn().mockResolvedValue("test-jwt-token");
+    vi.doMock("idb-keyval", () => ({
+      get: localMockGet,
+    }));
+
+    mockClients.matchAll.mockResolvedValue([]);
+
+    await import("../../sw-custom");
+
+    const syncHandler = syncListeners.get("sync");
+    expect(syncHandler).toBeDefined();
+
+    let waitUntilPromise: Promise<void> | undefined;
+    const event = {
+      tag: "offline-sync",
+      waitUntil: (p: Promise<void>) => {
+        waitUntilPromise = p;
+      },
+    };
+
+    syncHandler!(event);
+    await waitUntilPromise;
+
+    expect(localMockGet).toHaveBeenCalledWith("jwt_token_sw");
+    expect(localMockSync).toHaveBeenCalledWith("test-jwt-token", expect.any(Function));
+  });
+
+  it("sync handler does nothing without token", async () => {
+    vi.resetModules();
+    syncListeners.clear();
+
+    vi.doMock("workbox-core", () => ({ clientsClaim: vi.fn() }));
+    vi.doMock("workbox-precaching", () => ({
+      cleanupOutdatedCaches: vi.fn(),
+      precacheAndRoute: vi.fn(),
+    }));
+    vi.doMock("workbox-routing", () => ({ registerRoute: vi.fn() }));
+    vi.doMock("workbox-strategies", () => ({
+      CacheFirst: vi.fn(),
+      NetworkFirst: vi.fn(),
+    }));
+    vi.doMock("workbox-expiration", () => ({ ExpirationPlugin: vi.fn() }));
+
+    const localMockSync = vi.fn();
+    vi.doMock("../../services/syncHandler", () => ({
+      processSyncQueue: localMockSync,
+    }));
+
+    const localMockGet = vi.fn().mockResolvedValue(null);
+    vi.doMock("idb-keyval", () => ({
+      get: localMockGet,
+    }));
+
+    mockClients.matchAll.mockResolvedValue([]);
+
+    await import("../../sw-custom");
+
+    const syncHandler = syncListeners.get("sync");
+
+    let waitUntilPromise: Promise<void> | undefined;
+    const event = {
+      tag: "offline-sync",
+      waitUntil: (p: Promise<void>) => {
+        waitUntilPromise = p;
+      },
+    };
+
+    syncHandler!(event);
+    await waitUntilPromise;
+
+    expect(localMockSync).not.toHaveBeenCalled();
+  });
+
+  it("sync handler ignores non-offline-sync tags", async () => {
+    vi.resetModules();
+    syncListeners.clear();
+
+    vi.doMock("workbox-core", () => ({ clientsClaim: vi.fn() }));
+    vi.doMock("workbox-precaching", () => ({
+      cleanupOutdatedCaches: vi.fn(),
+      precacheAndRoute: vi.fn(),
+    }));
+    vi.doMock("workbox-routing", () => ({ registerRoute: vi.fn() }));
+    vi.doMock("workbox-strategies", () => ({
+      CacheFirst: vi.fn(),
+      NetworkFirst: vi.fn(),
+    }));
+    vi.doMock("workbox-expiration", () => ({ ExpirationPlugin: vi.fn() }));
+
+    const localMockSync = vi.fn();
+    vi.doMock("../../services/syncHandler", () => ({
+      processSyncQueue: localMockSync,
+    }));
+    vi.doMock("idb-keyval", () => ({
+      get: vi.fn().mockResolvedValue("token"),
+    }));
+
+    await import("../../sw-custom");
+
+    const syncHandler = syncListeners.get("sync");
+    const waitUntil = vi.fn();
+
+    syncHandler!({ tag: "other-tag", waitUntil });
+
+    // waitUntil should NOT be called for non-matching tags
+    expect(waitUntil).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Installe pcov dans DDEV (php8.3-pcov + pcov.ini) pour la couverture de code
- Ajoute `make coverage` pour générer les rapports HTML
- Ajoute 27 nouveaux tests :
  - `ImportBooksCommandTest` (6 tests backend intégration)
  - `sw-custom.test.ts` (5 tests service worker)
  - `MergeGroupCard.test.tsx` (6 tests composant)
  - `SeriesMultiSelect.test.tsx` (5 tests composant)
  - `Tools.test.tsx` (5 tests page)
- Corrige le N+1 dans `PurgeService.executePurge()` : `findBy()` batch au lieu de `find()` en boucle

Fixes #172

## Test plan

- [x] `ddev exec php -m | grep pcov` → pcov chargé
- [x] `make test` → 859 backend + 652 frontend tests passent
- [x] `make lint` → PHPStan + CS Fixer + tsc clean
- [x] `make coverage` fonctionne (rapport HTML dans `var/coverage/`)