### PR TITLE
feat(lookup): ajoute le lien Amazon sur les séries en cours d'achat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Added
+
+- **Lien Amazon** : Champ `amazonUrl` sur les séries, renseigné automatiquement par le lookup Gemini. Bouton Amazon affiché sur la page détail des séries en cours d'achat (#124)
+
 ## [v2.7.0] - 2026-03-14
 
 ### Added

--- a/backend/migrations/Version20260314115423.php
+++ b/backend/migrations/Version20260314115423.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260314115423 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE comic_series ADD amazon_url VARCHAR(500) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE comic_series DROP amazon_url');
+    }
+}

--- a/backend/phpstan-baseline.neon
+++ b/backend/phpstan-baseline.neon
@@ -399,7 +399,7 @@ parameters:
 		-
 			message: '#^Call to an undefined method Symfony\\Component\\Cache\\Adapter\\AdapterInterface\:\:method\(\)\.$#'
 			identifier: method.notFound
-			count: 19
+			count: 20
 			path: tests/Unit/Service/Lookup/GeminiLookupTest.php
 
 		-
@@ -417,7 +417,7 @@ parameters:
 		-
 			message: '#^Parameter \#2 \$haystack of static method PHPUnit\\Framework\\Assert\:\:assertStringContainsString\(\) expects string, mixed given\.$#'
 			identifier: argument.type
-			count: 5
+			count: 6
 			path: tests/Unit/Service/Lookup/GeminiLookupTest.php
 
 		-
@@ -454,6 +454,12 @@ parameters:
 			message: '#^Call to an undefined method App\\Repository\\AuthorRepository\:\:method\(\)\.$#'
 			identifier: method.notFound
 			count: 2
+			path: tests/Unit/Service/Lookup/LookupApplierTest.php
+
+		-
+			message: '#^Call to an undefined method Symfony\\Contracts\\HttpClient\\HttpClientInterface\:\:method\(\)\.$#'
+			identifier: method.notFound
+			count: 3
 			path: tests/Unit/Service/Lookup/LookupApplierTest.php
 
 		-

--- a/backend/src/DTO/ComicSeriesListItem.php
+++ b/backend/src/DTO/ComicSeriesListItem.php
@@ -19,6 +19,7 @@ final readonly class ComicSeriesListItem implements \JsonSerializable
      * @param int[] $ownedTomesNumbers
      */
     public function __construct(
+        public ?string $amazonUrl,
         public string $authors,
         public ?string $coverImage,
         public ?string $coverUrl,
@@ -65,6 +66,7 @@ final readonly class ComicSeriesListItem implements \JsonSerializable
      */
     public function __unserialize(array $data): void
     {
+        $this->amazonUrl = \is_string($data['amazonUrl'] ?? null) ? $data['amazonUrl'] : null;
         $this->authors = \is_string($data['authors'] ?? null) ? $data['authors'] : '';
         $this->coverImage = \is_string($data['coverImage'] ?? null) ? $data['coverImage'] : null;
         $this->coverUrl = \is_string($data['coverUrl'] ?? null) ? $data['coverUrl'] : null;
@@ -109,6 +111,7 @@ final readonly class ComicSeriesListItem implements \JsonSerializable
     public static function fromEntity(ComicSeries $comic, bool $hasNasTome): self
     {
         return new self(
+            amazonUrl: $comic->getAmazonUrl(),
             authors: $comic->getAuthorsAsString(),
             coverImage: $comic->getCoverImage(),
             coverUrl: $comic->getCoverUrl(),
@@ -154,6 +157,7 @@ final readonly class ComicSeriesListItem implements \JsonSerializable
     public function jsonSerialize(): array
     {
         return [
+            'amazonUrl' => $this->amazonUrl,
             'authors' => $this->authors,
             'coverImage' => $this->coverImage,
             'coverUrl' => $this->coverUrl,

--- a/backend/src/Entity/ComicSeries.php
+++ b/backend/src/Entity/ComicSeries.php
@@ -79,6 +79,7 @@ use Vich\UploaderBundle\Mapping\Attribute as Vich;
 class ComicSeries implements SoftDeletableInterface
 {
     use SoftDeletableTrait;
+
     #[Groups(['comic:read'])]
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -140,6 +141,18 @@ class ComicSeries implements SoftDeletableInterface
     #[Groups(['comic:read', 'comic:write'])]
     #[ORM\Column]
     private bool $isOneShot = false;
+
+    /**
+     * URL Amazon pour l'achat du prochain tome.
+     */
+    #[Groups(['comic:read', 'comic:write'])]
+    #[ORM\Column(length: 500, nullable: true)]
+    #[Assert\Regex(
+        pattern: '#^https?://(www\.)?amazon\.(fr|com|co\.\w+|de|it|es)/#',
+        message: 'L\'URL doit être un lien Amazon valide.'
+    )]
+    #[Assert\Url(requireTld: true)]
+    private ?string $amazonUrl = null;
 
     /**
      * Auteur(s) de la série.
@@ -246,6 +259,18 @@ class ComicSeries implements SoftDeletableInterface
     public function preUpdate(): void
     {
         $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getAmazonUrl(): ?string
+    {
+        return $this->amazonUrl;
+    }
+
+    public function setAmazonUrl(?string $amazonUrl): static
+    {
+        $this->amazonUrl = $amazonUrl;
+
+        return $this;
     }
 
     /**

--- a/backend/src/Service/Lookup/GeminiLookup.php
+++ b/backend/src/Service/Lookup/GeminiLookup.php
@@ -29,6 +29,7 @@ final class GeminiLookup extends AbstractGeminiLookupProvider implements Enricha
         - "latestPublishedIssue" (integer|null) : nombre de tomes parus
         - "tomeNumber" (integer|null) : si cet ISBN correspond à un tome précis, son numéro (ex : 4 pour le tome 4). Pour une intégrale/omnibus, le premier numéro couvert (ex : 4 pour « tomes 4-6 »). null si inconnu.
         - "tomeEnd" (integer|null) : uniquement pour les intégrales/omnibus couvrant plusieurs tomes, le dernier numéro couvert (ex : 6 pour « tomes 4-6 »). null si c'est un tome simple.
+        - "amazonUrl" (string|null) : URL Amazon.fr de la page de la série (pas d'un tome spécifique). De préférence un lien vers la page regroupant tous les tomes.
         TEXT;
 
     public function __construct(
@@ -87,6 +88,7 @@ final class GeminiLookup extends AbstractGeminiLookupProvider implements Enricha
     protected function buildResult(array $data): LookupResult
     {
         return new LookupResult(
+            amazonUrl: \is_string($data['amazonUrl'] ?? null) ? $data['amazonUrl'] : null,
             authors: \is_string($data['authors'] ?? null) ? $data['authors'] : null,
             description: \is_string($data['description'] ?? null) ? $data['description'] : null,
             isOneShot: \is_bool($data['isOneShot'] ?? null) ? $data['isOneShot'] : null,

--- a/backend/src/Service/Lookup/LookupApplier.php
+++ b/backend/src/Service/Lookup/LookupApplier.php
@@ -7,6 +7,7 @@ namespace App\Service\Lookup;
 use App\Entity\ComicSeries;
 use App\Entity\Tome;
 use App\Repository\AuthorRepository;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Applique un LookupResult sur une ComicSeries (uniquement les champs null).
@@ -15,6 +16,7 @@ class LookupApplier
 {
     public function __construct(
         private readonly AuthorRepository $authorRepository,
+        private readonly HttpClientInterface $httpClient,
     ) {
     }
 
@@ -26,6 +28,11 @@ class LookupApplier
     public function apply(ComicSeries $series, LookupResult $result): array
     {
         $updatedFields = [];
+
+        if (null === $series->getAmazonUrl() && null !== $result->amazonUrl && $this->isUrlReachable($result->amazonUrl)) {
+            $series->setAmazonUrl($result->amazonUrl);
+            $updatedFields[] = 'amazonUrl';
+        }
 
         if (null === $series->getDescription() && null !== $result->description) {
             $series->setDescription($result->description);
@@ -74,6 +81,20 @@ class LookupApplier
         }
 
         return $updatedFields;
+    }
+
+    /**
+     * Vérifie qu'une URL est accessible via une requête HEAD.
+     */
+    private function isUrlReachable(string $url): bool
+    {
+        try {
+            $response = $this->httpClient->request('HEAD', $url);
+
+            return $response->getStatusCode() < 400;
+        } catch (\Throwable) {
+            return false;
+        }
     }
 
     /**

--- a/backend/src/Service/Lookup/LookupOrchestrator.php
+++ b/backend/src/Service/Lookup/LookupOrchestrator.php
@@ -289,7 +289,7 @@ class LookupOrchestrator
      */
     private function mergeByFieldPriority(array $providerResults, ?ComicType $type): LookupResult
     {
-        $fields = ['authors', 'description', 'isbn', 'isOneShot', 'latestPublishedIssue', 'publishedDate', 'publisher', 'thumbnail', 'title', 'tomeEnd', 'tomeNumber'];
+        $fields = ['amazonUrl', 'authors', 'description', 'isbn', 'isOneShot', 'latestPublishedIssue', 'publishedDate', 'publisher', 'thumbnail', 'title', 'tomeEnd', 'tomeNumber'];
         $bestPriorities = \array_fill_keys($fields, -1);
         $bestValues = \array_fill_keys($fields, null);
 
@@ -309,7 +309,8 @@ class LookupOrchestrator
         }
 
         return new LookupResult(
-            authors: $bestValues['authors'], // @phpstan-ignore argument.type (accès dynamique aux propriétés typées)
+            amazonUrl: $bestValues['amazonUrl'], // @phpstan-ignore argument.type (accès dynamique aux propriétés typées)
+            authors: $bestValues['authors'], // @phpstan-ignore argument.type
             description: $bestValues['description'], // @phpstan-ignore argument.type
             isbn: $bestValues['isbn'], // @phpstan-ignore argument.type
             isOneShot: $bestValues['isOneShot'], // @phpstan-ignore argument.type

--- a/backend/src/Service/Lookup/LookupResult.php
+++ b/backend/src/Service/Lookup/LookupResult.php
@@ -10,6 +10,7 @@ namespace App\Service\Lookup;
 final class LookupResult implements \JsonSerializable
 {
     public function __construct(
+        public readonly ?string $amazonUrl = null,
         public readonly ?string $authors = null,
         public readonly ?string $description = null,
         public readonly ?string $isbn = null,
@@ -32,6 +33,7 @@ final class LookupResult implements \JsonSerializable
      */
     public function __unserialize(array $data): void
     {
+        $this->amazonUrl = \is_string($data['amazonUrl'] ?? null) ? $data['amazonUrl'] : null;
         $this->authors = \is_string($data['authors'] ?? null) ? $data['authors'] : null;
         $this->description = \is_string($data['description'] ?? null) ? $data['description'] : null;
         $this->isbn = \is_string($data['isbn'] ?? null) ? $data['isbn'] : null;
@@ -55,11 +57,12 @@ final class LookupResult implements \JsonSerializable
     }
 
     /**
-     * @return array{authors: ?string, description: ?string, isbn: ?string, isOneShot: ?bool, latestPublishedIssue: ?int, publishedDate: ?string, publisher: ?string, thumbnail: ?string, title: ?string, tomeEnd: ?int, tomeNumber: ?int}
+     * @return array{amazonUrl: ?string, authors: ?string, description: ?string, isbn: ?string, isOneShot: ?bool, latestPublishedIssue: ?int, publishedDate: ?string, publisher: ?string, thumbnail: ?string, title: ?string, tomeEnd: ?int, tomeNumber: ?int}
      */
     public function jsonSerialize(): array
     {
         return [
+            'amazonUrl' => $this->amazonUrl,
             'authors' => $this->authors,
             'description' => $this->description,
             'isbn' => $this->isbn,
@@ -80,6 +83,7 @@ final class LookupResult implements \JsonSerializable
     public function withIsbn(string $isbn): self
     {
         return new self(
+            amazonUrl: $this->amazonUrl,
             authors: $this->authors,
             description: $this->description,
             isbn: $isbn,

--- a/backend/tests/Unit/Service/Lookup/GeminiLookupTest.php
+++ b/backend/tests/Unit/Service/Lookup/GeminiLookupTest.php
@@ -170,6 +170,7 @@ final class GeminiLookupTest extends TestCase
     public function testResolveLookupSuccessWithValidResponse(): void
     {
         $jsonResponse = \json_encode([
+            'amazonUrl' => 'https://www.amazon.fr/dp/B08N5WRWNW',
             'authors' => 'Eiichiro Oda',
             'description' => 'Un manga de pirates',
             'isOneShot' => false,
@@ -210,6 +211,7 @@ final class GeminiLookupTest extends TestCase
         $result = $provider->resolveLookup($state);
 
         self::assertNotNull($result);
+        self::assertSame('https://www.amazon.fr/dp/B08N5WRWNW', $result->amazonUrl);
         self::assertSame('One Piece', $result->title);
         self::assertSame('Eiichiro Oda', $result->authors);
         self::assertSame('Glenat', $result->publisher);
@@ -514,6 +516,21 @@ final class GeminiLookupTest extends TestCase
         $result = $provider->resolveEnrich($cachedResult);
 
         self::assertSame($cachedResult, $result);
+    }
+
+    /**
+     * Teste que le prompt contient l'instruction pour amazonUrl.
+     */
+    public function testPrepareLookupPromptContainsAmazonUrlInstruction(): void
+    {
+        $cacheItem = $this->createCacheItem('test_key', null, false);
+        $this->cache->method('getItem')->willReturn($cacheItem);
+
+        $provider = $this->createProvider();
+        $state = $provider->prepareLookup('One Piece', null, 'title');
+
+        self::assertIsArray($state);
+        self::assertStringContainsString('amazonUrl', $state['prompt']);
     }
 
     /**

--- a/backend/tests/Unit/Service/Lookup/LookupApplierTest.php
+++ b/backend/tests/Unit/Service/Lookup/LookupApplierTest.php
@@ -9,6 +9,8 @@ use App\Service\Lookup\LookupApplier;
 use App\Service\Lookup\LookupResult;
 use App\Tests\Factory\EntityFactory;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * Tests unitaires pour LookupApplier.
@@ -16,12 +18,14 @@ use PHPUnit\Framework\TestCase;
 final class LookupApplierTest extends TestCase
 {
     private AuthorRepository $authorRepository;
+    private HttpClientInterface $httpClient;
     private LookupApplier $applier;
 
     protected function setUp(): void
     {
         $this->authorRepository = $this->createMock(AuthorRepository::class);
-        $this->applier = new LookupApplier($this->authorRepository);
+        $this->httpClient = $this->createMock(HttpClientInterface::class);
+        $this->applier = new LookupApplier($this->authorRepository, $this->httpClient);
     }
 
     public function testApplyFillsAllNullFields(): void
@@ -267,6 +271,79 @@ final class LookupApplierTest extends TestCase
 
         // latestPublishedIssue was already set → not updated → no tomes created
         self::assertCount(0, $series->getTomes());
+    }
+
+    public function testApplyFillsAmazonUrlWhenNullAndUrlIsValid(): void
+    {
+        $series = EntityFactory::createComicSeries('Test');
+        $result = new LookupResult(
+            amazonUrl: 'https://www.amazon.fr/dp/B08N5WRWNW',
+            source: 'test',
+        );
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->httpClient->method('request')
+            ->with('HEAD', 'https://www.amazon.fr/dp/B08N5WRWNW')
+            ->willReturn($response);
+
+        $updatedFields = $this->applier->apply($series, $result);
+
+        self::assertSame('https://www.amazon.fr/dp/B08N5WRWNW', $series->getAmazonUrl());
+        self::assertContains('amazonUrl', $updatedFields);
+    }
+
+    public function testApplySkipsAmazonUrlWhenUrlReturns404(): void
+    {
+        $series = EntityFactory::createComicSeries('Test');
+        $result = new LookupResult(
+            amazonUrl: 'https://www.amazon.fr/dp/FAKE123',
+            source: 'test',
+        );
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(404);
+        $this->httpClient->method('request')
+            ->with('HEAD', 'https://www.amazon.fr/dp/FAKE123')
+            ->willReturn($response);
+
+        $updatedFields = $this->applier->apply($series, $result);
+
+        self::assertNull($series->getAmazonUrl());
+        self::assertNotContains('amazonUrl', $updatedFields);
+    }
+
+    public function testApplySkipsAmazonUrlWhenHttpRequestThrows(): void
+    {
+        $series = EntityFactory::createComicSeries('Test');
+        $result = new LookupResult(
+            amazonUrl: 'https://www.amazon.fr/dp/ERROR',
+            source: 'test',
+        );
+
+        $this->httpClient->method('request')
+            ->willThrowException(new \RuntimeException('Connection failed'));
+
+        $updatedFields = $this->applier->apply($series, $result);
+
+        self::assertNull($series->getAmazonUrl());
+        self::assertNotContains('amazonUrl', $updatedFields);
+    }
+
+    public function testApplySkipsAmazonUrlWhenAlreadySet(): void
+    {
+        $series = EntityFactory::createComicSeries('Test');
+        $series->setAmazonUrl('https://www.amazon.fr/dp/EXISTING');
+
+        $result = new LookupResult(
+            amazonUrl: 'https://www.amazon.fr/dp/NEW',
+            source: 'test',
+        );
+
+        $updatedFields = $this->applier->apply($series, $result);
+
+        self::assertSame('https://www.amazon.fr/dp/EXISTING', $series->getAmazonUrl());
+        self::assertNotContains('amazonUrl', $updatedFields);
     }
 
     public function testApplySkipsIsOneShotWhenAlreadyTrue(): void

--- a/backend/tests/Unit/Service/Lookup/LookupResultTest.php
+++ b/backend/tests/Unit/Service/Lookup/LookupResultTest.php
@@ -19,6 +19,7 @@ final class LookupResultTest extends TestCase
     public function testConstructorWithAllFields(): void
     {
         $result = new LookupResult(
+            amazonUrl: 'https://www.amazon.fr/dp/B08N5WRWNW',
             authors: 'Eiichiro Oda',
             description: 'Un manga de pirates',
             isbn: '978-2723489',
@@ -33,6 +34,7 @@ final class LookupResultTest extends TestCase
             tomeNumber: 4,
         );
 
+        self::assertSame('https://www.amazon.fr/dp/B08N5WRWNW', $result->amazonUrl);
         self::assertSame('Eiichiro Oda', $result->authors);
         self::assertSame('Un manga de pirates', $result->description);
         self::assertSame('978-2723489', $result->isbn);
@@ -54,6 +56,7 @@ final class LookupResultTest extends TestCase
     {
         $result = new LookupResult();
 
+        self::assertNull($result->amazonUrl);
         self::assertNull($result->authors);
         self::assertNull($result->description);
         self::assertNull($result->isbn);
@@ -74,6 +77,7 @@ final class LookupResultTest extends TestCase
     public function testJsonSerializeExcludesSource(): void
     {
         $result = new LookupResult(
+            amazonUrl: 'https://www.amazon.fr/dp/B08N5WRWNW',
             authors: 'Toriyama',
             description: 'Dragon Ball',
             isbn: '1234567890',
@@ -91,6 +95,7 @@ final class LookupResultTest extends TestCase
         $json = $result->jsonSerialize();
 
         self::assertArrayNotHasKey('source', $json);
+        self::assertSame('https://www.amazon.fr/dp/B08N5WRWNW', $json['amazonUrl']);
         self::assertSame('Toriyama', $json['authors']);
         self::assertSame('Dragon Ball', $json['description']);
         self::assertSame('1234567890', $json['isbn']);
@@ -164,6 +169,7 @@ final class LookupResultTest extends TestCase
     public function testWithIsbnReturnsNewInstance(): void
     {
         $original = new LookupResult(
+            amazonUrl: 'https://www.amazon.fr/dp/B08N5WRWNW',
             authors: 'Oda',
             source: 'google_books',
             title: 'One Piece',
@@ -176,6 +182,7 @@ final class LookupResultTest extends TestCase
         self::assertNotSame($original, $withIsbn);
         self::assertNull($original->isbn);
         self::assertSame('978-2723489', $withIsbn->isbn);
+        self::assertSame('https://www.amazon.fr/dp/B08N5WRWNW', $withIsbn->amazonUrl);
         self::assertSame('Oda', $withIsbn->authors);
         self::assertSame('google_books', $withIsbn->source);
         self::assertSame('One Piece', $withIsbn->title);
@@ -189,6 +196,7 @@ final class LookupResultTest extends TestCase
     public function testUnserializeWithFullData(): void
     {
         $original = new LookupResult(
+            amazonUrl: 'https://www.amazon.fr/dp/B08N5WRWNW',
             authors: 'Oda',
             description: 'Pirates',
             isbn: '1234567890',
@@ -206,6 +214,7 @@ final class LookupResultTest extends TestCase
         /** @var LookupResult $result */
         $result = \unserialize(\serialize($original));
 
+        self::assertSame('https://www.amazon.fr/dp/B08N5WRWNW', $result->amazonUrl);
         self::assertSame('Oda', $result->authors);
         self::assertSame('Pirates', $result->description);
         self::assertSame('1234567890', $result->isbn);

--- a/frontend/src/__tests__/helpers/factories.ts
+++ b/frontend/src/__tests__/helpers/factories.ts
@@ -38,6 +38,7 @@ export function createMockComicSeries(
   const id = overrides.id ?? nextId++;
   return {
     "@id": `/api/comic_series/${id}`,
+    amazonUrl: null,
     authors: [],
     coverImage: null,
     coverUrl: null,

--- a/frontend/src/__tests__/integration/pages/ComicDetail.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicDetail.test.tsx
@@ -867,6 +867,78 @@ describe("ComicDetail", () => {
     expect(screen.getByText(/hier/)).toBeInTheDocument();
   });
 
+  it("shows Amazon button when status is BUYING and amazonUrl is set", async () => {
+    server.use(
+      http.get("/api/comic_series/1", () =>
+        HttpResponse.json(
+          createMockComicSeries({
+            amazonUrl: "https://www.amazon.fr/dp/B08N5WRWNW",
+            id: 1,
+            status: ComicStatus.BUYING,
+            title: "Amazon Test",
+          }),
+        ),
+      ),
+    );
+
+    renderComicDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Amazon Test")).toBeInTheDocument();
+    });
+
+    const amazonLink = screen.getByRole("link", { name: /amazon/i });
+    expect(amazonLink).toHaveAttribute("href", "https://www.amazon.fr/dp/B08N5WRWNW");
+    expect(amazonLink).toHaveAttribute("target", "_blank");
+    expect(amazonLink).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("does not show Amazon button when status is not BUYING", async () => {
+    server.use(
+      http.get("/api/comic_series/1", () =>
+        HttpResponse.json(
+          createMockComicSeries({
+            amazonUrl: "https://www.amazon.fr/dp/B08N5WRWNW",
+            id: 1,
+            status: ComicStatus.FINISHED,
+            title: "Not Buying",
+          }),
+        ),
+      ),
+    );
+
+    renderComicDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Not Buying")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("link", { name: /amazon/i })).not.toBeInTheDocument();
+  });
+
+  it("does not show Amazon button when amazonUrl is null", async () => {
+    server.use(
+      http.get("/api/comic_series/1", () =>
+        HttpResponse.json(
+          createMockComicSeries({
+            amazonUrl: null,
+            id: 1,
+            status: ComicStatus.BUYING,
+            title: "No Amazon",
+          }),
+        ),
+      ),
+    );
+
+    renderComicDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("No Amazon")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("link", { name: /amazon/i })).not.toBeInTheDocument();
+  });
+
   it("shows success toast after delete confirmation", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/hooks/useCreateComic.ts
+++ b/frontend/src/hooks/useCreateComic.ts
@@ -19,6 +19,7 @@ export function useCreateComic() {
         const tempSeries: ComicSeries = {
           "@id": `/api/comic_series/${tempId}`,
           _syncPending: true,
+          amazonUrl: null,
           authors: [],
           coverImage: null,
           coverUrl: (variables.coverUrl as string) ?? null,

--- a/frontend/src/pages/ComicDetail.tsx
+++ b/frontend/src/pages/ComicDetail.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Edit, Trash2 } from "lucide-react";
+import { ArrowLeft, Edit, ExternalLink, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
@@ -10,7 +10,7 @@ import type { Tome } from "../types/api";
 import { useComic } from "../hooks/useComic";
 import { useDeleteComic } from "../hooks/useDeleteComic";
 import { useUpdateTome } from "../hooks/useUpdateTome";
-import { ComicStatusLabel, ComicTypeLabel, ComicTypePlaceholder } from "../types/enums";
+import { ComicStatus, ComicStatusLabel, ComicTypeLabel, ComicTypePlaceholder } from "../types/enums";
 import { getCoverSrc } from "../utils/coverUtils";
 import { countCoveredTomes } from "../utils/tomeUtils";
 
@@ -277,6 +277,17 @@ export default function ComicDetail() {
           <Trash2 className="h-5 w-5" />
           Supprimer
         </button>
+        {comic.status === ComicStatus.BUYING && comic.amazonUrl && (
+          <a
+            className="flex items-center gap-2 rounded-lg bg-amber-600 px-5 py-2.5 text-base font-medium text-white hover:bg-amber-700"
+            href={comic.amazonUrl}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <ExternalLink className="h-5 w-5" />
+            Amazon
+          </a>
+        )}
         <Link
           className="flex items-center gap-2 rounded-lg bg-primary-600 px-5 py-2.5 text-base font-medium text-white hover:bg-primary-700"
           to={`/comic/${comic.id}/edit`}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -41,6 +41,7 @@ export interface Tome {
 export interface ComicSeries {
   "@id": string;
   _syncPending?: boolean;
+  amazonUrl: string | null;
   authors: Author[];
   coverImage: string | null;
   coverUrl: string | null;


### PR DESCRIPTION
## Summary

- Ajoute le champ `amazonUrl` sur l'entité `ComicSeries` (nullable, varchar 500, validé par `Assert\Url` + `Assert\Regex` domaine Amazon)
- Le provider Gemini demande l'URL Amazon de la série lors du lookup et le champ est fusionné par priorité dans l'orchestrateur
- Le `LookupApplier` vérifie l'URL par requête HTTP HEAD avant de la sauvegarder (ignore les 404 et erreurs réseau)
- Bouton Amazon affiché dans la barre d'action de la page détail pour les séries avec `status = BUYING` (ouvre dans un nouvel onglet)
- Migration Doctrine pour la nouvelle colonne

## Test plan

- [x] Tests unitaires backend : LookupResult, LookupApplier (URL valide, 404, erreur réseau), GeminiLookup
- [x] Tests d'intégration frontend : bouton Amazon visible (BUYING + URL), masqué (autre statut), masqué (URL null)
- [x] PHPStan + CS Fixer clean
- [x] TypeScript `tsc --noEmit` clean
- [x] 931 tests backend + 655 tests frontend passent

fixes #124