### PR TITLE
feat(deploy): déploiement automatique via SSH après release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
           NOTES: ${{ steps.changelog.outputs.notes }}
+
+      - name: Deploy to NAS
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.NAS_HOST }}
+          username: ${{ secrets.NAS_SSH_USER }}
+          key: ${{ secrets.NAS_SSH_KEY }}
+          port: ${{ secrets.NAS_SSH_PORT }}
+          script: /volume1/docker/bibliotheque/scripts/nas-update.sh

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ node_modules/
 
 ###> nas ###
 backend/.env.nas
+logs/
 ###< nas ###
 
 ###> local ###

--- a/scripts/nas-backup.sh
+++ b/scripts/nas-backup.sh
@@ -6,7 +6,7 @@ APP_DIR="/volume1/docker/bibliotheque"
 BACKEND_DIR="${APP_DIR}/backend"
 ENV_FILE="${BACKEND_DIR}/.env.nas"
 BACKUP_DIR="/volume1/google drive/Backup/Bibliotheque"
-LOG_DIR="/var/log/bibliotheque"
+LOG_DIR="${APP_DIR}/logs"
 LOG_FILE="${LOG_DIR}/backup-$(date '+%Y-%m-%d').log"
 RETENTION_DAYS=7
 

--- a/scripts/nas-cleanup-logs.sh
+++ b/scripts/nas-cleanup-logs.sh
@@ -2,7 +2,7 @@
 # Nettoyage des logs Bibliotheque — lancé par le planificateur DSM (root)
 # Supprime les fichiers .log de plus de 7 jours dans /var/log/bibliotheque/
 
-LOG_DIR="/var/log/bibliotheque"
+LOG_DIR="/volume1/docker/bibliotheque/logs"
 RETENTION_DAYS=7
 
 if [ ! -d "$LOG_DIR" ]; then

--- a/scripts/nas-update.sh
+++ b/scripts/nas-update.sh
@@ -5,7 +5,7 @@
 APP_DIR="/volume1/docker/bibliotheque"
 BACKEND_DIR="${APP_DIR}/backend"
 ENV_FILE="${BACKEND_DIR}/.env.nas"
-LOG_DIR="/var/log/bibliotheque"
+LOG_DIR="${APP_DIR}/logs"
 LOG_FILE="${LOG_DIR}/update-$(date '+%Y-%m-%d').log"
 
 mkdir -p "$LOG_DIR"


### PR DESCRIPTION
## Summary
- Ajoute une étape SSH dans le workflow `release.yml` qui déclenche `nas-update.sh` sur le NAS immédiatement après la création d'une release GitHub
- Déplace les logs des scripts NAS de `/var/log/bibliotheque/` vers `/volume1/docker/bibliotheque/logs/` (accessible au user `deployer` sans root)
- Ajoute `logs/` au `.gitignore`

## Configuration requise
Secrets GitHub à configurer : `NAS_HOST`, `NAS_SSH_PORT`, `NAS_SSH_USER`, `NAS_SSH_KEY` ✅

## Test plan
- [x] Connexion SSH testée avec le user `deployer` depuis la machine locale
- [x] Exécution de `nas-update.sh` via SSH validée (logs écrits correctement)