### PR TITLE
fix(deploy): ajoute /usr/local/bin au PATH du script NAS

### DIFF
--- a/scripts/nas-update.sh
+++ b/scripts/nas-update.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# Script de mise à jour automatique — lancé par le planificateur DSM (root)
+# Script de mise à jour automatique — lancé par le planificateur DSM ou GitHub Actions (SSH)
 # Déploie le dernier tag SemVer (vX.Y.Z) depuis le dépôt distant.
+
+export PATH="/usr/local/bin:$PATH"
 
 APP_DIR="/volume1/docker/bibliotheque"
 BACKEND_DIR="${APP_DIR}/backend"


### PR DESCRIPTION
## Summary
- Ajoute `/usr/local/bin` au PATH dans `nas-update.sh` pour que `git` et `docker` soient trouvés lors de l'exécution via SSH (session non-interactive)

## Test plan
- [x] `which git` et `which docker` confirmés dans `/usr/local/bin` sur le NAS