### PR TITLE
feat(a11y): améliore l'accessibilité des composants frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Accessibilité** : Ajout d'`aria-label` sur les boutons icônes, inputs de recherche et checkboxes. Fermeture du `CardActionBar` via Escape (#170)
+
 ## [v2.8.1] - 2026-03-14
 
 ### Fixed

--- a/frontend/src/__tests__/integration/components/CardActionBar.test.tsx
+++ b/frontend/src/__tests__/integration/components/CardActionBar.test.tsx
@@ -68,4 +68,21 @@ describe("CardActionBar", () => {
 
     expect(defaultProps.onClose).toHaveBeenCalled();
   });
+
+  it("has role dialog with aria-label", () => {
+    renderWithProviders(<CardActionBar {...defaultProps} />);
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-label", "Actions pour Naruto");
+  });
+
+  it("closes on Escape key press", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<CardActionBar {...defaultProps} />);
+
+    await user.keyboard("{Escape}");
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
 });

--- a/frontend/src/__tests__/integration/components/ComicCard.test.tsx
+++ b/frontend/src/__tests__/integration/components/ComicCard.test.tsx
@@ -95,12 +95,12 @@ describe("ComicCard", () => {
     expect(screen.queryByText(/t\./)).not.toBeInTheDocument();
   });
 
-  it("shows the ⋮ menu button", () => {
+  it("shows the ⋮ menu button with aria-label", () => {
     const comic = createMockComicSeries({ title: "Test" });
 
     renderWithProviders(<ComicCard comic={comic} onDelete={vi.fn()} />);
 
-    const buttons = screen.getAllByTitle("Actions");
+    const buttons = screen.getAllByLabelText("Actions");
     expect(buttons.length).toBeGreaterThanOrEqual(1);
   });
 

--- a/frontend/src/__tests__/integration/components/CoverSearchModal.test.tsx
+++ b/frontend/src/__tests__/integration/components/CoverSearchModal.test.tsx
@@ -115,7 +115,7 @@ describe("CoverSearchModal", () => {
     const user = userEvent.setup();
     renderWithProviders(<CoverSearchModal {...defaultProps} />);
 
-    const closeButton = screen.getByRole("button", { name: "" });
+    const closeButton = screen.getByRole("button", { name: "Fermer" });
     await user.click(closeButton);
 
     expect(defaultProps.onClose).toHaveBeenCalledOnce();

--- a/frontend/src/__tests__/integration/components/Layout.test.tsx
+++ b/frontend/src/__tests__/integration/components/Layout.test.tsx
@@ -81,7 +81,7 @@ describe("Layout", () => {
     expect(screen.getByText("Corbeille")).toBeInTheDocument();
   });
 
-  it("has a dark mode toggle button", () => {
+  it("has a dark mode toggle button with aria-label", () => {
     renderWithProviders(
       <Routes>
         <Route element={<Layout />} path="/">
@@ -90,10 +90,10 @@ describe("Layout", () => {
       </Routes>,
     );
 
-    expect(screen.getByTitle("Mode sombre")).toBeInTheDocument();
+    expect(screen.getByLabelText("Mode sombre")).toBeInTheDocument();
   });
 
-  it("has a logout button", () => {
+  it("has a logout button with aria-label", () => {
     renderWithProviders(
       <Routes>
         <Route element={<Layout />} path="/">
@@ -102,7 +102,19 @@ describe("Layout", () => {
       </Routes>,
     );
 
-    expect(screen.getByTitle("Déconnexion")).toBeInTheDocument();
+    expect(screen.getByLabelText("Déconnexion")).toBeInTheDocument();
+  });
+
+  it("has a tools link with aria-label", () => {
+    renderWithProviders(
+      <Routes>
+        <Route element={<Layout />} path="/">
+          <Route element={<div>Content</div>} index />
+        </Route>
+      </Routes>,
+    );
+
+    expect(screen.getByLabelText("Outils")).toBeInTheDocument();
   });
 
   it("toggles dark mode when button is clicked", async () => {

--- a/frontend/src/__tests__/integration/components/MergePreviewModal.test.tsx
+++ b/frontend/src/__tests__/integration/components/MergePreviewModal.test.tsx
@@ -41,6 +41,25 @@ const defaultProps = {
   open: true,
 };
 
+describe("MergePreviewModal — accessibility", () => {
+  it("has aria-labels on tome checkboxes", () => {
+    render(
+      <MergePreviewModal
+        {...defaultProps}
+        preview={createMockPreview({
+          tomes: [createMockTome({ number: 1 }), createMockTome({ number: 2 })],
+        })}
+      />,
+    );
+
+    expect(screen.getByLabelText("Tome 1 acheté")).toBeInTheDocument();
+    expect(screen.getByLabelText("Tome 1 téléchargé")).toBeInTheDocument();
+    expect(screen.getByLabelText("Tome 1 lu")).toBeInTheDocument();
+    expect(screen.getByLabelText("Tome 1 sur NAS")).toBeInTheDocument();
+    expect(screen.getByLabelText("Tome 2 acheté")).toBeInTheDocument();
+  });
+});
+
 describe("MergePreviewModal — add tome", () => {
   it("renders an 'Ajouter un tome' button", () => {
     render(

--- a/frontend/src/components/BarcodeScanner.tsx
+++ b/frontend/src/components/BarcodeScanner.tsx
@@ -66,6 +66,7 @@ export default function BarcodeScanner({ onScan }: BarcodeScannerProps) {
           <div className="flex items-center justify-between">
             <span className="text-sm font-medium text-text-secondary">Scanner actif</span>
             <button
+              aria-label="Fermer le scanner"
               className="rounded p-1 text-text-muted hover:text-text-secondary"
               onClick={stopScanner}
               type="button"

--- a/frontend/src/components/CardActionBar.tsx
+++ b/frontend/src/components/CardActionBar.tsx
@@ -1,4 +1,5 @@
 import { Edit, Trash2 } from "lucide-react";
+import { useEffect, useRef } from "react";
 import type { ComicSeries } from "../types/api";
 
 interface CardActionBarProps {
@@ -9,6 +10,21 @@ interface CardActionBarProps {
 }
 
 export default function CardActionBar({ comic, onClose, onDelete, onEdit }: CardActionBarProps) {
+  const barRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!comic) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [comic, onClose]);
+
   if (!comic) return null;
 
   return (
@@ -21,7 +37,12 @@ export default function CardActionBar({ comic, onClose, onDelete, onEdit }: Card
       />
 
       {/* Barre d'actions */}
-      <div className="fixed inset-x-0 bottom-0 z-[60] border-t border-surface-border bg-surface-primary px-4 py-3 pb-safe">
+      <div
+        aria-label={`Actions pour ${comic.title}`}
+        className="fixed inset-x-0 bottom-0 z-[60] border-t border-surface-border bg-surface-primary px-4 py-3 pb-safe"
+        ref={barRef}
+        role="dialog"
+      >
         <p className="mb-2 truncate text-sm font-semibold text-text-primary">{comic.title}</p>
         <div className="flex gap-2">
           <button

--- a/frontend/src/components/ComicCard.tsx
+++ b/frontend/src/components/ComicCard.tsx
@@ -102,6 +102,7 @@ export default function ComicCard({ comic, onDelete, onMenuOpen }: ComicCardProp
             <>
               {/* Mobile: simple button → CardActionBar */}
               <button
+                aria-label="Actions"
                 className="shrink-0 rounded-lg p-1 text-text-muted hover:bg-surface-tertiary lg:hidden"
                 onClick={(e) => {
                   e.preventDefault();
@@ -117,6 +118,7 @@ export default function ComicCard({ comic, onDelete, onMenuOpen }: ComicCardProp
               {/* Desktop: Headless UI dropdown */}
               <Menu as="div" className="relative hidden shrink-0 lg:block">
                 <MenuButton
+                  aria-label="Actions"
                   className="rounded-lg p-1 text-text-muted hover:bg-surface-tertiary"
                   onClick={(e: React.MouseEvent) => {
                     e.preventDefault();

--- a/frontend/src/components/CoverSearchModal.tsx
+++ b/frontend/src/components/CoverSearchModal.tsx
@@ -56,6 +56,7 @@ export default function CoverSearchModal({
               Rechercher une couverture
             </DialogTitle>
             <button
+              aria-label="Fermer"
               className="rounded-lg p-1 text-text-secondary hover:bg-surface-tertiary"
               onClick={onClose}
               type="button"

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -46,6 +46,7 @@ export default function Layout() {
         </Link>
         <div className="flex items-center gap-1">
           <Link
+            aria-label="Outils"
             className="rounded-lg p-2 text-text-secondary hover:bg-surface-tertiary"
             title="Outils"
             to="/tools"
@@ -54,6 +55,7 @@ export default function Layout() {
             <Wrench className="h-5 w-5" />
           </Link>
           <button
+            aria-label={isDark ? "Mode clair" : "Mode sombre"}
             className="rounded-lg p-2 text-text-secondary hover:bg-surface-tertiary"
             onClick={toggle}
             title={isDark ? "Mode clair" : "Mode sombre"}
@@ -62,6 +64,7 @@ export default function Layout() {
             {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
           </button>
           <button
+            aria-label="Déconnexion"
             className="rounded-lg p-2 text-text-secondary hover:bg-surface-tertiary"
             onClick={logout}
             title="Déconnexion"

--- a/frontend/src/components/MergePreviewModal.tsx
+++ b/frontend/src/components/MergePreviewModal.tsx
@@ -233,6 +233,7 @@ export default function MergePreviewModal({
                         </td>
                         <td className="px-2 py-1.5 text-center">
                           <input
+                            aria-label={`Tome ${tome.number} acheté`}
                             checked={tome.bought}
                             className="h-4 w-4 rounded border-surface-border text-primary-600 focus:ring-primary-500"
                             onChange={(e) => updateTome(index, { bought: e.target.checked })}
@@ -241,6 +242,7 @@ export default function MergePreviewModal({
                         </td>
                         <td className="px-2 py-1.5 text-center">
                           <input
+                            aria-label={`Tome ${tome.number} téléchargé`}
                             checked={tome.downloaded}
                             className="h-4 w-4 rounded border-surface-border text-primary-600 focus:ring-primary-500"
                             onChange={(e) => updateTome(index, { downloaded: e.target.checked })}
@@ -249,6 +251,7 @@ export default function MergePreviewModal({
                         </td>
                         <td className="px-2 py-1.5 text-center">
                           <input
+                            aria-label={`Tome ${tome.number} lu`}
                             checked={tome.read}
                             className="h-4 w-4 rounded border-surface-border text-primary-600 focus:ring-primary-500"
                             onChange={(e) => updateTome(index, { read: e.target.checked })}
@@ -257,6 +260,7 @@ export default function MergePreviewModal({
                         </td>
                         <td className="px-2 py-1.5 text-center">
                           <input
+                            aria-label={`Tome ${tome.number} sur NAS`}
                             checked={tome.onNas}
                             className="h-4 w-4 rounded border-surface-border text-primary-600 focus:ring-primary-500"
                             onChange={(e) => updateTome(index, { onNas: e.target.checked })}

--- a/frontend/src/components/SeriesMultiSelect.tsx
+++ b/frontend/src/components/SeriesMultiSelect.tsx
@@ -67,6 +67,7 @@ export default function SeriesMultiSelect({
       <div className="relative">
         <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" />
         <input
+          aria-label="Rechercher une série"
           className="w-full rounded-lg border border-surface-border bg-surface-secondary py-2 pl-9 pr-3 text-sm text-text-primary placeholder:text-text-muted focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Rechercher une série..."

--- a/frontend/src/pages/ComicForm.tsx
+++ b/frontend/src/pages/ComicForm.tsx
@@ -150,7 +150,7 @@ export default function ComicForm() {
     <div className="mx-auto max-w-3xl space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <button className="text-text-muted hover:text-text-secondary" onClick={() => navigate(-1)} type="button">
+        <button aria-label="Retour" className="text-text-muted hover:text-text-secondary" onClick={() => navigate(-1)} type="button">
           <ArrowLeft className="h-5 w-5" />
         </button>
         <h1 className="text-xl font-bold text-text-primary">

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -102,6 +102,7 @@ export default function Home() {
         <div className="relative min-w-0 flex-1">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" />
           <input
+            aria-label="Rechercher par titre, auteur, éditeur"
             className="w-full rounded-lg border border-surface-border bg-surface-primary py-2 pl-10 pr-4 text-sm text-text-primary placeholder:text-text-muted focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
             onChange={(e) => handleSearchChange(e.target.value)}
             placeholder="Rechercher par titre, auteur, éditeur…"


### PR DESCRIPTION
## Summary

- Ajoute `aria-label` sur les boutons icônes (ComicCard, ComicForm, Layout, BarcodeScanner, CoverSearchModal)
- Ajoute `aria-label` sur les inputs de recherche (Home, SeriesMultiSelect)
- Ajoute `aria-label` sur les checkboxes du MergePreviewModal (avec numéro de tome)
- Ajoute `role="dialog"`, `aria-label` et fermeture via Escape sur CardActionBar

## Test plan

- [x] 669 tests frontend passent
- [x] TypeScript lint OK (`tsc --noEmit`)
- [x] Tests a11y spécifiques ajoutés pour aria-labels et Escape

Fixes #170