### PR TITLE
fix(docker): ajoute le cache warmup dans l'entrypoint PHP

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -23,7 +23,8 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "cgi-fcgi -bind -connect 127.0.0.1:9000 /ping 2>/dev/null | grep -q pong"]
       interval: 10s
-      retries: 3
+      retries: 5
+      start_period: 30s
       timeout: 5s
     environment:
       - APP_ENV=prod

--- a/backend/docker/php/docker-entrypoint.sh
+++ b/backend/docker/php/docker-entrypoint.sh
@@ -7,5 +7,8 @@ chown -R www-data:www-data var
 # Compile les variables d'environnement pour Symfony (performance)
 gosu www-data composer dump-env prod
 
+# Warmup du cache Symfony (nécessite les env vars compilées ci-dessus)
+gosu www-data php bin/console cache:warmup --env=prod --no-debug
+
 # Exécute la commande par défaut (php-fpm) en tant que www-data
 exec gosu www-data "$@"


### PR DESCRIPTION
## Summary

- Ajoute `cache:warmup` dans l'entrypoint après `dump-env` (supprimé par erreur dans #208)
- Augmente les retries du healthcheck PHP (3→5) et ajoute `start_period: 30s`

Fixes le crash du conteneur PHP en prod (unhealthy → rollback en boucle).