### PR TITLE
chore(release): v2.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+## [v2.8.4] - 2026-03-14
+
+### Fixed
+
+- **Scripts NAS** : Correction du commentaire obsolète dans `nas-cleanup-logs.sh`
+
 ## [v2.8.3] - 2026-03-14
 
 ### Fixed

--- a/scripts/nas-cleanup-logs.sh
+++ b/scripts/nas-cleanup-logs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Nettoyage des logs Bibliotheque — lancé par le planificateur DSM (root)
-# Supprime les fichiers .log de plus de 7 jours dans /var/log/bibliotheque/
+# Supprime les fichiers .log de plus de 7 jours dans le dossier logs du projet
 
 LOG_DIR="/volume1/docker/bibliotheque/logs"
 RETENTION_DAYS=7


### PR DESCRIPTION
## Summary
- Fix commentaire obsolète dans nas-cleanup-logs.sh
- Tag pour tester le déploiement CI → NAS