### PR TITLE
fix(docker): lance php-fpm en root pour l'accès stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+## [v2.8.5] - 2026-03-14
+
+### Fixed
+
+- **Docker** : Lance php-fpm en root (il drop lui-même les privileges). Corrige `Permission denied` sur stderr
+
 ## [v2.8.4] - 2026-03-14
 
 ### Fixed

--- a/backend/docker/php/docker-entrypoint.sh
+++ b/backend/docker/php/docker-entrypoint.sh
@@ -10,5 +10,6 @@ gosu www-data composer dump-env prod
 # Warmup du cache Symfony (nécessite les env vars compilées ci-dessus)
 gosu www-data php bin/console cache:warmup --env=prod --no-debug
 
-# Exécute la commande par défaut (php-fpm) en tant que www-data
-exec gosu www-data "$@"
+# php-fpm doit démarrer en root (accès stderr, bind port 9000)
+# puis drop les privileges via sa config (user = www-data)
+exec "$@"


### PR DESCRIPTION
## Summary

- php-fpm doit démarrer en root (accès stderr + bind port) puis drop les privileges via sa config (`user = www-data`)
- `exec gosu www-data php-fpm` causait `Permission denied` sur `/proc/self/fd/2` → crash immédiat

Cause du déploiement cassé depuis v2.7.0.