### PR TITLE
fix(deploy): checkout du tag sur le NAS avant le script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,12 @@ jobs:
           username: ${{ secrets.NAS_SSH_USER }}
           key: ${{ secrets.NAS_SSH_KEY }}
           port: ${{ secrets.NAS_SSH_PORT }}
-          script: /volume1/docker/bibliotheque/scripts/nas-update.sh
+          envs: DEPLOY_TAG
+          script: |
+            export PATH="/usr/local/bin:$PATH"
+            cd /volume1/docker/bibliotheque
+            git fetch --tags origin
+            git checkout "$DEPLOY_TAG"
+            scripts/nas-update.sh
+        env:
+          DEPLOY_TAG: ${{ github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 ### Fixed
 
 - **Docker** : Lance php-fpm en root (il drop lui-même les privileges). Corrige `Permission denied` sur stderr
+- **Deploy** : Le workflow met à jour le repo NAS avant de lancer le script de déploiement
 
 ## [v2.8.4] - 2026-03-14
 


### PR DESCRIPTION
## Summary

- Le workflow fait `git fetch + checkout` du tag sur le NAS avant de lancer `nas-update.sh`
- Évite que le script exécuté soit une version obsolète après un rollback