### PR TITLE
chore(ci): skip les checks pour les PRs non-code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,12 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'docs/**'
+      - 'scripts/**'
+      - '.github/workflows/release.yml'
+      - '*.md'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Ajoute `paths-ignore` sur le workflow CI pour ne pas déclencher les 4 checks quand seuls des fichiers non-code changent (CHANGELOG, docs, scripts, .md)
- Les PRs de release ne bloquent plus sur la CI