### PR TITLE
fix(docker): augmente les délais du healthcheck PHP

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -23,8 +23,8 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "cgi-fcgi -bind -connect 127.0.0.1:9000 /ping 2>/dev/null | grep -q pong"]
       interval: 10s
-      retries: 5
-      start_period: 30s
+      retries: 10
+      start_period: 60s
       timeout: 5s
     environment:
       - APP_ENV=prod


### PR DESCRIPTION
## Summary

- Augmente `start_period` (30s→60s) et `retries` (5→10) du healthcheck PHP
- Le cache warmup Symfony prend du temps sur le NAS, les anciens délais étaient trop courts