### PR TITLE
revert(ci): supprime paths-ignore incompatible avec branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - 'docs/**'
-      - 'scripts/**'
-      - '.github/workflows/release.yml'
-      - '*.md'
 
 permissions:
   contents: read


### PR DESCRIPTION
Revert du paths-ignore — incompatible avec les required checks de la branch protection classique.