### PR TITLE
Pré-build des images Docker sur ghcr.io

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,82 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: PHP image metadata
+        id: meta-php
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/soviann/bibliotheque-php
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build & push PHP
+        uses: docker/build-push-action@v6
+        with:
+          context: backend
+          file: backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta-php.outputs.tags }}
+          labels: ${{ steps.meta-php.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Nginx image metadata
+        id: meta-nginx
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/soviann/bibliotheque-nginx
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build & push Nginx
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/docker/nginx/Dockerfile
+          push: true
+          tags: ${{ steps.meta-nginx.outputs.tags }}
+          labels: ${{ steps.meta-nginx.outputs.labels }}
+          build-args: |
+            VITE_GOOGLE_CLIENT_ID=${{ secrets.OAUTH_GOOGLE_ID }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to NAS
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.NAS_HOST }}
+          username: ${{ secrets.NAS_SSH_USER }}
+          key: ${{ secrets.NAS_SSH_KEY }}
+          port: ${{ secrets.NAS_SSH_PORT }}
+          script: |
+            export PATH="/usr/local/bin:$PATH"
+            /volume1/docker/bibliotheque/scripts/nas-update.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,19 +34,3 @@ jobs:
           TAG: ${{ github.ref_name }}
           NOTES: ${{ steps.changelog.outputs.notes }}
 
-      - name: Deploy to NAS
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.NAS_HOST }}
-          username: ${{ secrets.NAS_SSH_USER }}
-          key: ${{ secrets.NAS_SSH_KEY }}
-          port: ${{ secrets.NAS_SSH_PORT }}
-          envs: DEPLOY_TAG
-          script: |
-            export PATH="/usr/local/bin:$PATH"
-            cd /volume1/docker/bibliotheque
-            git fetch --tags origin
-            git checkout "$DEPLOY_TAG"
-            scripts/nas-update.sh
-        env:
-          DEPLOY_TAG: ${{ github.ref_name }}

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   nginx:
+    image: ghcr.io/soviann/bibliotheque-nginx:${TAG:-latest}
     build:
       args:
         - VITE_GOOGLE_CLIENT_ID=${OAUTH_GOOGLE_ID}
@@ -16,6 +17,7 @@ services:
       - uploads:/var/www/html/public/uploads:ro
 
   php:
+    image: ghcr.io/soviann/bibliotheque-php:${TAG:-latest}
     build: .
     depends_on:
       db:

--- a/scripts/nas-update.sh
+++ b/scripts/nas-update.sh
@@ -26,19 +26,26 @@ current_tag() {
     git -C "$APP_DIR" describe --tags --exact-match HEAD 2>/dev/null
 }
 
-# Tente un build et vérifie que les conteneurs démarrent correctement.
+# Tente un déploiement (pull des images pré-buildées) et vérifie que les conteneurs démarrent correctement.
 # Retourne 0 si succès, 1 si échec.
-try_build() {
+try_deploy() {
     local tag
     tag=$(current_tag)
-    log "Tentative de build pour le tag ${tag:-$(git -C "$APP_DIR" rev-parse --short HEAD)}..."
+    log "Tentative de déploiement pour le tag ${tag:-$(git -C "$APP_DIR" rev-parse --short HEAD)}..."
 
     cd "$BACKEND_DIR" || { log "ERREUR: impossible d'accéder à ${BACKEND_DIR}"; return 1; }
 
+    export TAG="${tag#v}"
+
     docker compose --env-file "$ENV_FILE" down >> "$LOG_FILE" 2>&1
 
-    if ! docker compose --env-file "$ENV_FILE" up --build -d >> "$LOG_FILE" 2>&1; then
-        log "ERREUR: docker compose up --build a échoué."
+    if ! docker compose --env-file "$ENV_FILE" pull >> "$LOG_FILE" 2>&1; then
+        log "ERREUR: docker compose pull a échoué."
+        return 1
+    fi
+
+    if ! docker compose --env-file "$ENV_FILE" up -d >> "$LOG_FILE" 2>&1; then
+        log "ERREUR: docker compose up a échoué."
         return 1
     fi
 
@@ -52,7 +59,7 @@ try_build() {
         return 1
     fi
 
-    log "Build réussi."
+    log "Déploiement réussi."
     return 0
 }
 
@@ -82,7 +89,7 @@ if [ "$TARGET_TAG" = "$CURRENT_TAG" ]; then
         log "Déjà sur le tag ${TARGET_TAG}, conteneurs OK."
         exit 0
     fi
-    log "Tag ${TARGET_TAG} déjà déployé mais conteneurs non running (${RUNNING}/3). Rebuild..."
+    log "Tag ${TARGET_TAG} déjà déployé mais conteneurs non running (${RUNNING}/3). Redéploiement..."
 fi
 
 log "Mise à jour : ${CURRENT_TAG:-aucun tag} → ${TARGET_TAG}"
@@ -90,8 +97,8 @@ log "Mise à jour : ${CURRENT_TAG:-aucun tag} → ${TARGET_TAG}"
 # Checkout du tag cible
 git checkout "$TARGET_TAG" >> "$LOG_FILE" 2>&1
 
-# Tentative de build avec le nouveau tag
-if try_build; then
+# Tentative de déploiement avec le nouveau tag
+if try_deploy; then
     # Attendre que la DB soit healthy
     sleep 15
 
@@ -106,8 +113,8 @@ if try_build; then
     exit 0
 fi
 
-# Échec du build : rollback vers les tags précédents
-log "Le build a échoué pour ${TARGET_TAG}, début du rollback..."
+# Échec du déploiement : rollback vers les tags précédents
+log "Le déploiement a échoué pour ${TARGET_TAG}, début du rollback..."
 
 # Lister les tags SemVer par version décroissante, en excluant le tag qui vient d'échouer
 PREVIOUS_TAGS=$(git -C "$APP_DIR" tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${TARGET_TAG}$" | head -5)
@@ -116,7 +123,7 @@ for tag in $PREVIOUS_TAGS; do
     log "Rollback vers ${tag}..."
     git checkout "$tag" >> "$LOG_FILE" 2>&1
 
-    if try_build; then
+    if try_deploy; then
         sleep 15
         # Vider le cache Symfony après rollback (en tant que www-data pour les permissions)
         docker compose --env-file "$ENV_FILE" exec -T -u www-data php php bin/console cache:clear --env=prod >> "$LOG_FILE" 2>&1
@@ -129,6 +136,6 @@ for tag in $PREVIOUS_TAGS; do
     fi
 done
 
-log "ERREUR CRITIQUE: rollback échoué après avoir essayé les tags précédents. Intervention manuelle requise."
+log "ERREUR CRITIQUE: rollback échoué après avoir essayé les tags précédents. Intervention manuelle requise. Fallback: docker compose up --build -d"
 log "=== Mise à jour échouée ==="
 exit 1


### PR DESCRIPTION
## Summary
- Nouveau workflow `docker-publish.yml` : build & push les images PHP et Nginx sur `ghcr.io` à chaque tag, puis deploy NAS via SSH
- `docker-compose.yml` : ajout `image:` ghcr.io (conserve `build:` pour le dev local)
- `nas-update.sh` : remplace `up --build` par `pull` + `up -d`
- `release.yml` : retire le step deploy NAS (déplacé après le build des images)

Le NAS passe de ~10min de rebuild à ~30s de pull.

## Post-merge
- Rendre les packages ghcr.io publics après le premier tag (GitHub → Packages → Settings → Change visibility)
- Désactiver le cron NAS (le deploy passe par le CI)

Fixes #222