### PR TITLE
chore(release): v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+## [v2.9.0] - 2026-03-14
+
 ### Added
 
 - **CI** : Pré-build des images Docker (PHP + Nginx) sur ghcr.io à chaque tag, le NAS pull au lieu de rebuild (~30s vs ~10min)


### PR DESCRIPTION
Release v2.9.0 — pré-build Docker images sur ghcr.io.