### PR TITLE
Lookup : filtre les résultats trop éloignés de la recherche

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Lookup** : Filtre les résultats multi-candidats dont le titre ne correspond pas à la requête de recherche
+
 ## [v2.9.4] - 2026-03-15
 
 ### Added

--- a/backend/src/Service/Lookup/LookupOrchestrator.php
+++ b/backend/src/Service/Lookup/LookupOrchestrator.php
@@ -165,11 +165,17 @@ class LookupOrchestrator
             }
         }
 
+        // Filtrer les résultats dont le titre ne correspond pas à la requête
+        $filtered = \array_filter(
+            $allResults,
+            static fn (LookupResult $r) => TitleMatcher::matches($title, $r->title ?? ''),
+        );
+
         // Dédupliquer par titre normalisé, garder le premier trouvé
         $seen = [];
         $deduplicated = [];
 
-        foreach ($allResults as $result) {
+        foreach ($filtered as $result) {
             $key = \mb_strtolower(\trim($result->title ?? ''));
             if ('' === $key || isset($seen[$key])) {
                 continue;

--- a/backend/src/Service/Lookup/TitleMatcher.php
+++ b/backend/src/Service/Lookup/TitleMatcher.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Lookup;
+
+/**
+ * Compare un titre de résultat avec la requête de recherche pour déterminer la pertinence.
+ */
+final class TitleMatcher
+{
+    /** Mots trop courants pour être discriminants (articles, prépositions, etc.). */
+    private const STOPWORDS = ['au', 'aux', 'ce', 'ces', 'de', 'des', 'du', 'en', 'et', 'la', 'le', 'les', 'of', 'the', 'un', 'une'];
+
+    /** Longueur minimale pour qu'un mot soit considéré significatif. */
+    private const MIN_WORD_LENGTH = 3;
+
+    /**
+     * Vérifie si un titre de résultat correspond suffisamment à la requête.
+     *
+     * Retourne true si la requête n'a pas de mots significatifs (pas de filtrage possible)
+     * ou si au moins un mot significatif de la requête est présent dans le titre.
+     */
+    public static function matches(string $query, string $resultTitle): bool
+    {
+        $queryWords = self::extractSignificantWords($query);
+
+        // Pas de mots significatifs dans la requête → pas de filtrage
+        if (0 === \count($queryWords)) {
+            return true;
+        }
+
+        $normalizedTitle = self::normalize($resultTitle);
+
+        if ('' === $normalizedTitle) {
+            return false;
+        }
+
+        // Au moins un mot significatif de la requête doit apparaître dans le titre
+        foreach ($queryWords as $word) {
+            if (\str_contains($normalizedTitle, $word)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Extrait les mots significatifs d'une chaîne (hors stopwords et mots courts).
+     *
+     * @return list<string>
+     */
+    private static function extractSignificantWords(string $text): array
+    {
+        $normalized = self::normalize($text);
+
+        if ('' === $normalized) {
+            return [];
+        }
+
+        $words = \preg_split('/[\s\-_:,;.!?]+/', $normalized, -1, \PREG_SPLIT_NO_EMPTY) ?: [];
+        $significant = [];
+
+        foreach ($words as $word) {
+            if (\mb_strlen($word) >= self::MIN_WORD_LENGTH && !\in_array($word, self::STOPWORDS, true)) {
+                $significant[] = $word;
+            }
+        }
+
+        return $significant;
+    }
+
+    /**
+     * Normalise une chaîne : minuscules, suppression des accents, trim.
+     */
+    private static function normalize(string $text): string
+    {
+        $text = \mb_strtolower(\trim($text));
+
+        // Suppression des accents via translitération
+        $transliterated = \transliterator_transliterate('NFD; [:Nonspacing Mark:] Remove; NFC', $text);
+
+        return \is_string($transliterated) ? $transliterated : $text;
+    }
+}

--- a/backend/tests/Unit/Service/Lookup/LookupOrchestratorTest.php
+++ b/backend/tests/Unit/Service/Lookup/LookupOrchestratorTest.php
@@ -807,7 +807,7 @@ final class LookupOrchestratorTest extends TestCase
             name: 'multi_provider',
             results: [
                 new LookupResult(authors: 'Oda', source: 'multi_provider', title: 'One Piece'),
-                new LookupResult(authors: 'Kishimoto', source: 'multi_provider', title: 'Naruto'),
+                new LookupResult(authors: 'Oda', source: 'multi_provider', title: 'One Piece Party'),
             ],
             supports: true,
         );
@@ -818,7 +818,7 @@ final class LookupOrchestratorTest extends TestCase
 
         self::assertCount(2, $results);
         self::assertSame('One Piece', $results[0]->title);
-        self::assertSame('Naruto', $results[1]->title);
+        self::assertSame('One Piece Party', $results[1]->title);
     }
 
     /**
@@ -848,7 +848,7 @@ final class LookupOrchestratorTest extends TestCase
 
         $orchestrator = new LookupOrchestrator(30.0, new NullLogger(), [$provider1, $provider2]);
 
-        $results = $orchestrator->lookupByTitleMultiple('test', null, 10);
+        $results = $orchestrator->lookupByTitleMultiple('piece naruto bleach', null, 10);
 
         // 3 titres distincts: one piece, naruto, bleach
         self::assertCount(3, $results);
@@ -879,7 +879,7 @@ final class LookupOrchestratorTest extends TestCase
 
         $orchestrator = new LookupOrchestrator(30.0, new NullLogger(), [$regularProvider, $multiProvider]);
 
-        $results = $orchestrator->lookupByTitleMultiple('test', null, 5);
+        $results = $orchestrator->lookupByTitleMultiple('Result', null, 5);
 
         self::assertCount(2, $results);
         $titles = \array_map(static fn (LookupResult $r) => $r->title, $results);
@@ -906,7 +906,7 @@ final class LookupOrchestratorTest extends TestCase
 
         $orchestrator = new LookupOrchestrator(30.0, new NullLogger(), [$provider]);
 
-        $lookupResults = $orchestrator->lookupByTitleMultiple('test', null, 3);
+        $lookupResults = $orchestrator->lookupByTitleMultiple('Title', null, 3);
 
         self::assertCount(3, $lookupResults);
     }
@@ -935,6 +935,58 @@ final class LookupOrchestratorTest extends TestCase
         $messages = $orchestrator->getLastApiMessages();
         self::assertArrayHasKey('failing', $messages);
         self::assertSame('error', $messages['failing']->status);
+    }
+
+    /**
+     * Teste lookupByTitleMultiple filtre les résultats dont le titre ne correspond pas à la requête.
+     */
+    public function testLookupByTitleMultipleFiltersIrrelevantResults(): void
+    {
+        $provider = $this->createStubMultiResultProvider(
+            fieldPriority: 100,
+            name: 'provider',
+            results: [
+                new LookupResult(source: 'provider', title: '3 instincts : La survie'),
+                new LookupResult(source: 'provider', title: 'Le guide des oiseaux'),
+                new LookupResult(source: 'provider', title: 'Cuisine pour les nuls'),
+                new LookupResult(source: 'provider', title: 'Les instincts primaires'),
+                new LookupResult(source: 'provider', title: 'Jardinage facile'),
+            ],
+            supports: true,
+        );
+
+        $orchestrator = new LookupOrchestrator(30.0, new NullLogger(), [$provider]);
+
+        $results = $orchestrator->lookupByTitleMultiple('3 instincts', ComicType::BD, 5);
+
+        // Seuls les titres contenant "instinct" devraient passer
+        self::assertCount(2, $results);
+        $titles = \array_map(static fn (LookupResult $r) => $r->title, $results);
+        self::assertContains('3 instincts : La survie', $titles);
+        self::assertContains('Les instincts primaires', $titles);
+    }
+
+    /**
+     * Teste lookupByTitleMultiple ne filtre pas quand la requête n'a pas de mots significatifs.
+     */
+    public function testLookupByTitleMultipleNoFilterWhenNoSignificantWords(): void
+    {
+        $provider = $this->createStubMultiResultProvider(
+            fieldPriority: 100,
+            name: 'provider',
+            results: [
+                new LookupResult(source: 'provider', title: 'Titre A'),
+                new LookupResult(source: 'provider', title: 'Titre B'),
+            ],
+            supports: true,
+        );
+
+        $orchestrator = new LookupOrchestrator(30.0, new NullLogger(), [$provider]);
+
+        // Requête avec uniquement des mots courts → pas de filtrage
+        $results = $orchestrator->lookupByTitleMultiple('le la', null, 5);
+
+        self::assertCount(2, $results);
     }
 
     /**

--- a/backend/tests/Unit/Service/Lookup/TitleMatcherTest.php
+++ b/backend/tests/Unit/Service/Lookup/TitleMatcherTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Lookup;
+
+use App\Service\Lookup\TitleMatcher;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires pour TitleMatcher.
+ */
+final class TitleMatcherTest extends TestCase
+{
+    /**
+     * Teste les cas de correspondance évidents.
+     */
+    #[DataProvider('matchingTitlesProvider')]
+    public function testMatchingTitles(string $query, string $resultTitle): void
+    {
+        self::assertTrue(
+            TitleMatcher::matches($query, $resultTitle),
+            \sprintf('"%s" devrait correspondre à "%s"', $query, $resultTitle),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function matchingTitlesProvider(): iterable
+    {
+        yield 'titre exact' => ['One Piece', 'One Piece'];
+        yield 'casse différente' => ['one piece', 'One Piece'];
+        yield 'titre avec articles' => ['Les 3 instincts', 'Les 3 instincts'];
+        yield 'mot clé présent' => ['3 instincts', '3 instincts : La survie'];
+        yield 'sous-titre dans résultat' => ['Naruto', 'Naruto Shippuden'];
+        yield 'accentuation différente' => ['étoile', 'Etoile'];
+        yield 'pluriel/singulier' => ['instinct', 'Les instincts'];
+        yield 'titre avec tirets' => ['Spider-Man', 'Spider-Man: No Way Home'];
+        yield 'mots significatifs partagés' => ['Walking Dead', 'The Walking Dead'];
+        yield 'un seul mot significatif correspondant' => ['Astérix', 'Astérix le Gaulois'];
+    }
+
+    /**
+     * Teste les cas de non-correspondance.
+     */
+    #[DataProvider('nonMatchingTitlesProvider')]
+    public function testNonMatchingTitles(string $query, string $resultTitle): void
+    {
+        self::assertFalse(
+            TitleMatcher::matches($query, $resultTitle),
+            \sprintf('"%s" ne devrait PAS correspondre à "%s"', $query, $resultTitle),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function nonMatchingTitlesProvider(): iterable
+    {
+        yield 'aucun mot commun' => ['3 instincts', 'Le guide des oiseaux'];
+        yield 'titre complètement différent' => ['One Piece', 'Dragon Ball'];
+        yield 'partage uniquement des stopwords' => ['Les aventures', 'Les misérables'];
+        yield 'partage uniquement un article' => ['Le chat', 'Le chien'];
+    }
+
+    /**
+     * Teste que les cas limites ne plantent pas.
+     */
+    public function testEdgeCases(): void
+    {
+        // Requête vide → pas de filtrage, tout passe
+        self::assertTrue(TitleMatcher::matches('', 'Anything'));
+        self::assertTrue(TitleMatcher::matches('   ', 'Anything'));
+
+        // Titre résultat vide → ne correspond pas
+        self::assertFalse(TitleMatcher::matches('query', ''));
+
+        // Requête avec uniquement des mots courts/stopwords → tout passe
+        self::assertTrue(TitleMatcher::matches('le la de', 'Anything'));
+    }
+
+    /**
+     * Teste la normalisation des accents.
+     */
+    public function testAccentNormalization(): void
+    {
+        self::assertTrue(TitleMatcher::matches('Astérix', 'Asterix'));
+        self::assertTrue(TitleMatcher::matches('café', 'Cafe'));
+        self::assertTrue(TitleMatcher::matches('noel', 'Noël'));
+    }
+}


### PR DESCRIPTION
## Summary

- Ajoute `TitleMatcher` : compare les mots significatifs de la requête avec le titre de chaque résultat
- Filtre les résultats non pertinents dans `LookupOrchestrator::lookupByTitleMultiple()` avant déduplication
- Les résultats sans aucun mot significatif commun avec la requête sont éliminés

## Test plan

- [x] Tests unitaires `TitleMatcherTest` (16 cas : correspondances, non-correspondances, accents, cas limites)
- [x] Tests orchestrateur : filtrage des résultats non pertinents, pas de filtrage quand pas de mots significatifs
- [x] Suite complète backend (977 tests OK)

Fixes #249