### PR TITLE
feat(import): scan NAS et amélioration import Excel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Added
+
+- **Scan NAS** : Commande `app:scan-nas` qui scanne les fichiers du NAS via SSH et génère un fichier Excel compatible avec l'import
+- **Import Excel** : Nouvelle colonne « Parution terminée » (col H) pour marquer une série comme terminée sans perdre les valeurs numériques
+- **Import Excel** : Support du format « fini N » (ex: `fini 40`) dans les cellules numériques pour conserver le nombre tout en marquant comme terminé
+
 ## [v2.9.5] - 2026-03-15
 
 ### Changed

--- a/backend/src/Command/ScanNasCommand.php
+++ b/backend/src/Command/ScanNasCommand.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\DTO\NasSeriesData;
+use App\Service\Nas\NasDirectoryParser;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use phpseclib3\Net\SSH2;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Scanne le NAS via SSH et génère un fichier Excel compatible avec l'import.
+ */
+#[AsCommand(
+    name: 'app:scan-nas',
+    description: 'Scanne les fichiers du NAS et génère un fichier Excel d\'import',
+)]
+final class ScanNasCommand extends Command
+{
+    /**
+     * Correspondance type → nom d'onglet Excel (doit correspondre à ImportExcelService::SHEET_TYPE_MAP).
+     */
+    private const array TYPE_SHEET_MAP = [
+        'BD' => 'BD',
+        'Comics' => 'Comics',
+        'Livres' => 'Livre',
+        'Mangas' => 'Mangas',
+    ];
+
+    /**
+     * Sous-dossiers Comics à parcourir.
+     */
+    private const array COMICS_SUBDIRS = ['Autres', 'DC Comics', 'Marvel comics'];
+
+    private const string DEFAULT_OUTPUT = 'var/nas-import.xlsx';
+
+    private ?SSH2 $ssh = null;
+
+    public function __construct(
+        private readonly NasDirectoryParser $parser,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Chemin du fichier Excel de sortie', self::DEFAULT_OUTPUT)
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Scan des fichiers du NAS');
+
+        /** @var string $host */
+        $host = $_ENV['NAS_HOST'] ?? '';
+        /** @var string $port */
+        $port = $_ENV['NAS_PORT'] ?? '22';
+        /** @var string $username */
+        $username = $_ENV['NAS_USERNAME'] ?? '';
+        /** @var string $password */
+        $password = $_ENV['NAS_PASSWORD'] ?? '';
+
+        if ('' === $host || '' === $username || '' === $password) {
+            $io->error('Variables d\'environnement NAS_HOST, NAS_USERNAME et NAS_PASSWORD requises dans .env.local');
+
+            return Command::FAILURE;
+        }
+
+        $io->text(\sprintf('Connexion à %s:%s...', $host, $port));
+
+        try {
+            $this->ssh = new SSH2($host, (int) $port, 30);
+
+            if (!$this->ssh->login($username, $password)) {
+                $io->error('Échec de l\'authentification SSH');
+
+                return Command::FAILURE;
+            }
+        } catch (\RuntimeException $e) {
+            $io->error(\sprintf('Erreur de connexion SSH : %s', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+
+        $io->text('Connecté.');
+
+        /** @var string $outputPath */
+        $outputPath = $input->getOption('output');
+
+        $spreadsheet = new Spreadsheet();
+        $spreadsheet->removeSheetByIndex(0);
+        $totalSeries = 0;
+
+        foreach (self::TYPE_SHEET_MAP as $nasDir => $sheetName) {
+            $io->section("Scan : {$nasDir}");
+
+            $allSeries = $this->scanType($nasDir, $io);
+
+            if ([] === $allSeries) {
+                $io->warning("Aucune série trouvée pour {$nasDir}");
+
+                continue;
+            }
+
+            // Trier par titre
+            \usort($allSeries, static fn (NasSeriesData $a, NasSeriesData $b) => \strcasecmp($a->title, $b->title));
+
+            // Dédupliquer par titre (garder la version la plus "riche")
+            $allSeries = $this->deduplicateSeries($allSeries);
+
+            $this->writeSheet($spreadsheet, $sheetName, $allSeries);
+
+            $count = \count($allSeries);
+            $totalSeries += $count;
+            $io->success(\sprintf('%d séries trouvées pour %s', $count, $nasDir));
+        }
+
+        if (0 === $totalSeries) {
+            $io->error('Aucune série trouvée sur le NAS');
+
+            return Command::FAILURE;
+        }
+
+        $writer = new Xlsx($spreadsheet);
+        $writer->save($outputPath);
+
+        $io->success(\sprintf('Fichier Excel généré : %s (%d séries au total)', $outputPath, $totalSeries));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Scanne un type (BD, Comics, Livres, Mangas) et retourne toutes les séries.
+     *
+     * @return list<NasSeriesData>
+     */
+    private function scanType(string $type, SymfonyStyle $io): array
+    {
+        $basePath = '/volume1/lecture';
+        $inProgressPath = '/volume1/lecture en cours';
+        $allSeries = [];
+
+        if ('Comics' === $type) {
+            foreach (self::COMICS_SUBDIRS as $subdir) {
+                $path = "{$basePath}/Comics/{$subdir}";
+                $listing = $this->sshLs($path);
+                $filesByDir = $this->fetchFilesByDir($listing, $path);
+                $allSeries = \array_merge($allSeries, $this->parser->parseUnreadSeries($listing, $filesByDir));
+            }
+
+            $lusPath = "{$basePath}/Comics/_lus";
+            $lusListing = $this->sshLs($lusPath);
+            $lusFiles = $this->fetchFilesByDir($lusListing, $lusPath);
+            $allSeries = \array_merge($allSeries, $this->parser->parseReadSeries($lusListing, $lusFiles));
+
+            $inProgressComicsPath = "{$inProgressPath}/Comics";
+            $inProgressListing = $this->sshLs($inProgressComicsPath);
+            $inProgressFiles = $this->fetchFilesByDir($inProgressListing, $inProgressComicsPath);
+            $allSeries = \array_merge($allSeries, $this->parser->parseInProgressSeries($inProgressListing, $inProgressFiles));
+        } elseif ('Livres' === $type) {
+            $io->note('Livres : structure hétérogène, import manuel recommandé');
+
+            return [];
+        } else {
+            $path = "{$basePath}/{$type}";
+            $listing = $this->sshLs($path);
+            $filesByDir = $this->fetchFilesByDir($listing, $path);
+            $allSeries = \array_merge($allSeries, $this->parser->parseUnreadSeries($listing, $filesByDir));
+
+            $lusPath = "{$path}/_lus";
+            $lusListing = $this->sshLs($lusPath);
+            $lusFiles = $this->fetchFilesByDir($lusListing, $lusPath);
+            $allSeries = \array_merge($allSeries, $this->parser->parseReadSeries($lusListing, $lusFiles));
+
+            $inProgressTypePath = "{$inProgressPath}/{$type}";
+            $inProgressListing = $this->sshLs($inProgressTypePath);
+            $inProgressFiles = $this->fetchFilesByDir($inProgressListing, $inProgressTypePath);
+            $allSeries = \array_merge($allSeries, $this->parser->parseInProgressSeries($inProgressListing, $inProgressFiles));
+        }
+
+        return $allSeries;
+    }
+
+    /**
+     * Récupère les fichiers de chaque sous-répertoire via SSH.
+     *
+     * @param list<string> $listing
+     *
+     * @return array<string, list<string>>
+     */
+    private function fetchFilesByDir(array $listing, string $basePath): array
+    {
+        $filesByDir = [];
+
+        foreach ($listing as $entry) {
+            if (\in_array($entry, ['@eaDir', '#recycle', '_lus'], true)) {
+                continue;
+            }
+
+            $files = $this->sshLs("{$basePath}/{$entry}");
+
+            if ([] !== $files) {
+                $filesByDir[$entry] = $files;
+            }
+        }
+
+        return $filesByDir;
+    }
+
+    /**
+     * Liste un répertoire distant via SSH (connexion persistante phpseclib).
+     *
+     * @return list<string>
+     */
+    private function sshLs(string $remotePath): array
+    {
+        if (null === $this->ssh) {
+            return [];
+        }
+
+        $command = \sprintf('ls %s 2>/dev/null', \escapeshellarg($remotePath));
+
+        // phpseclib SSH2::exec() — exécution sécurisée via connexion persistante
+        $result = $this->ssh->exec($command);
+
+        if (!\is_string($result)) {
+            return [];
+        }
+
+        $result = \trim($result);
+
+        if ('' === $result) {
+            return [];
+        }
+
+        return \explode("\n", $result);
+    }
+
+    /**
+     * Écrit les données d'un type dans un onglet Excel.
+     *
+     * @param list<NasSeriesData> $seriesList
+     */
+    private function writeSheet(Spreadsheet $spreadsheet, string $sheetName, array $seriesList): void
+    {
+        $sheet = $spreadsheet->createSheet();
+        $sheet->setTitle($sheetName);
+
+        $headers = ['Titre', 'Statut', 'Dernier acheté', 'Lu jusqu\'à', 'Nombre publié', 'Dernier téléchargé', 'Sur NAS', 'Parution terminée'];
+        foreach ($headers as $col => $header) {
+            $sheet->setCellValue([$col + 1, 1], $header);
+        }
+
+        $row = 2;
+        foreach ($seriesList as $series) {
+            $sheet->setCellValue([1, $row], $series->title);
+
+            if ($series->readComplete) {
+                $sheet->setCellValue([4, $row], 'fini');
+            } elseif (null !== $series->readUpTo) {
+                $sheet->setCellValue([4, $row], $series->readUpTo);
+            }
+
+            if ($series->isComplete && null !== $series->lastDownloaded) {
+                $sheet->setCellValue([5, $row], $series->lastDownloaded);
+            }
+
+            if (null !== $series->lastDownloaded) {
+                $sheet->setCellValue([6, $row], $series->lastDownloaded);
+            }
+
+            $sheet->setCellValue([7, $row], 'oui');
+
+            if ($series->isComplete) {
+                $sheet->setCellValue([8, $row], 'oui');
+            }
+
+            ++$row;
+        }
+    }
+
+    /**
+     * Déduplique les séries par titre, en gardant la version avec le plus d'info.
+     *
+     * @param list<NasSeriesData> $series
+     *
+     * @return list<NasSeriesData>
+     */
+    private function deduplicateSeries(array $series): array
+    {
+        $byTitle = [];
+
+        foreach ($series as $s) {
+            $key = \mb_strtolower($s->title);
+
+            if (!isset($byTitle[$key])) {
+                $byTitle[$key] = $s;
+
+                continue;
+            }
+
+            $existing = $byTitle[$key];
+
+            $existingScore = ($existing->readComplete ? 2 : 0) + (null !== $existing->readUpTo ? 1 : 0);
+            $newScore = ($s->readComplete ? 2 : 0) + (null !== $s->readUpTo ? 1 : 0);
+
+            if ($newScore > $existingScore) {
+                $byTitle[$key] = $s;
+            } elseif ($newScore === $existingScore && (null !== $s->lastDownloaded) && ($s->lastDownloaded > ($existing->lastDownloaded ?? 0))) {
+                $byTitle[$key] = $s;
+            }
+        }
+
+        return \array_values($byTitle);
+    }
+}

--- a/backend/src/DTO/NasSeriesData.php
+++ b/backend/src/DTO/NasSeriesData.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+/**
+ * Données d'une série extraite du NAS.
+ */
+final readonly class NasSeriesData
+{
+    public function __construct(
+        public bool $isComplete,
+        public ?int $lastDownloaded,
+        public ?int $readUpTo,
+        public bool $readComplete,
+        public string $title,
+    ) {
+    }
+}

--- a/backend/src/Service/Import/ImportExcelService.php
+++ b/backend/src/Service/Import/ImportExcelService.php
@@ -143,10 +143,12 @@ final class ImportExcelService
         $lastDownloaded = $this->parseIntegerValue($row[5] ?? null);
         $onNas = $this->determineOnNas($row[6] ?? null);
         $onNasFini = $this->isFiniValue($row[6] ?? null);
+        $publicationFinished = $this->isOuiValue($row[7] ?? null);
         $statusFini = $this->isFiniValue($row[1] ?? null);
 
         $latestPublishedIssue = $publishedCount->value;
-        $latestPublishedIssueComplete = $publishedCount->isComplete
+        $latestPublishedIssueComplete = $publicationFinished
+            || $publishedCount->isComplete
             || $lastBought->isComplete
             || $currentIssue->isComplete
             || $lastDownloaded->isComplete
@@ -280,10 +282,10 @@ final class ImportExcelService
             $candidates[] = $currentIssueValue;
         }
 
-        if (!$lastBoughtComplete && null !== $lastBoughtValue) {
+        if (null !== $lastBoughtValue) {
             $candidates[] = $lastBoughtValue;
         }
-        if (!$lastDownloadedComplete && null !== $lastDownloadedValue) {
+        if (null !== $lastDownloadedValue) {
             $candidates[] = $lastDownloadedValue;
         }
 
@@ -336,6 +338,20 @@ final class ImportExcelService
     }
 
     /**
+     * Vérifie si une valeur est "oui".
+     */
+    private function isOuiValue(mixed $value): bool
+    {
+        if (null === $value) {
+            return false;
+        }
+
+        $value = \is_scalar($value) ? \mb_strtolower(\trim((string) $value)) : '';
+
+        return 'oui' === $value;
+    }
+
+    /**
      * Parse une valeur qui peut être un entier ou "fini".
      */
     private function parseIntegerValue(mixed $value): ParsedIntegerValue
@@ -350,8 +366,17 @@ final class ImportExcelService
             return new ParsedIntegerValue(isComplete: false, value: null);
         }
 
-        if ('fini' === \mb_strtolower($value)) {
+        $lowerValue = \mb_strtolower($value);
+
+        if ('fini' === $lowerValue) {
             return new ParsedIntegerValue(isComplete: true, value: null);
+        }
+
+        // Format "fini N" : parution terminée avec nombre de tomes
+        if (1 === \preg_match('/^fini\s+(\d+)$/i', $value, $finiMatches)) {
+            $intValue = (int) $finiMatches[1];
+
+            return new ParsedIntegerValue(isComplete: true, value: $intValue > 0 ? $intValue : null);
         }
 
         if (\str_contains($value, ',')) {

--- a/backend/src/Service/Nas/NasDirectoryParser.php
+++ b/backend/src/Service/Nas/NasDirectoryParser.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Nas;
+
+use App\DTO\NasSeriesData;
+
+/**
+ * Parse les listings de répertoires du NAS pour extraire les séries et tomes.
+ */
+final class NasDirectoryParser
+{
+    private const array IGNORED_ENTRIES = ['@eaDir', '#recycle', '_lus'];
+
+    /**
+     * Extrait le numéro de tome d'un nom de fichier/dossier.
+     *
+     * Formats supportés :
+     * - "Série 01 - Titre.cbr"
+     * - "Série - T01 - Titre.cbr"
+     * - "bd_fr_serie_t10_titre.cbr"
+     * - "BDFR - SERIE - 01 - Titre.cbz"
+     * - "04 - Vilyana.pdf"
+     * - "Nausicaa 01 (Source)"
+     * - "Série (T01-06)" → retourne 6 (max de la plage)
+     * - "Série - Tome 1 à 4" → retourne 4
+     */
+    public function extractTomeNumber(string $filename): ?int
+    {
+        // Ignorer les one-shots
+        if (1 === \preg_match('/one[- ]?shot/i', $filename)) {
+            return null;
+        }
+
+        // Format plage "Tome X à Y" ou "(TX-Y)"
+        if (1 === \preg_match('/(?:Tome\s+\d+\s*à\s*|T\d+-\s*)(\d+)/i', $filename, $matches)) {
+            return (int) $matches[1];
+        }
+
+        // Format "tNN_" (underscored, comme bd_fr_serie_t10_titre)
+        if (1 === \preg_match('/[_.]t(\d+)[_.]/', $filename, $matches)) {
+            return (int) $matches[1];
+        }
+
+        // Format "- TNN -" ou "- NN -" ou " NN " avec séparateurs
+        if (1 === \preg_match('/(?:^|\s|-)(?:T)?0*(\d+)(?:\s|[-.]|$)/i', $filename, $matches)) {
+            $number = (int) $matches[1];
+
+            // Éviter les faux positifs (années, etc.)
+            if ($number > 0 && $number < 1000) {
+                return $number;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse le nom d'un répertoire de série pour en extraire le titre et le statut complet.
+     *
+     * @return array{title: string, isComplete: bool}
+     */
+    public function parseSeriesDirectory(string $dirName): array
+    {
+        $isComplete = false;
+
+        // Détecter "(complet)" en fin de chaîne (insensible à la casse)
+        if (1 === \preg_match('/\s*\(complet\)\s*$/i', $dirName)) {
+            $isComplete = true;
+            $dirName = (string) \preg_replace('/\s*\(complet\)\s*$/i', '', $dirName);
+        }
+
+        // Retirer "(incomplet)" en fin de chaîne
+        $dirName = (string) \preg_replace('/\s*\(incomplet\)\s*$/i', '', $dirName);
+
+        // Retirer les plages de tomes : "(T01-06)", "- Tome 1 à 4"
+        $dirName = (string) \preg_replace('/\s*\(T\d+-\d+\)\s*$/i', '', $dirName);
+        $dirName = (string) \preg_replace('/\s*-\s*Tome\s+\d+\s*à\s*\d+\s*$/i', '', $dirName);
+
+        return [
+            'isComplete' => $isComplete,
+            'title' => \trim($dirName),
+        ];
+    }
+
+    /**
+     * Parse les séries non lues (/volume1/lecture/{type}/).
+     *
+     * @param list<string>                $listing    Contenu du répertoire
+     * @param array<string, list<string>> $filesByDir Fichiers par sous-répertoire
+     *
+     * @return list<NasSeriesData>
+     */
+    public function parseUnreadSeries(array $listing, array $filesByDir): array
+    {
+        $series = [];
+
+        foreach ($listing as $entry) {
+            if ($this->isIgnoredEntry($entry)) {
+                continue;
+            }
+
+            $parsed = $this->parseSeriesDirectory($entry);
+            $lastDownloaded = $this->getMaxTomeFromFiles($filesByDir[$entry] ?? []);
+
+            // Si pas de fichiers, essayer d'extraire depuis le nom du dossier lui-même
+            if (null === $lastDownloaded) {
+                $lastDownloaded = $this->extractTomeNumber($entry);
+            }
+
+            $series[] = new NasSeriesData(
+                isComplete: $parsed['isComplete'],
+                lastDownloaded: $lastDownloaded,
+                readComplete: false,
+                readUpTo: null,
+                title: $parsed['title'],
+            );
+        }
+
+        return $series;
+    }
+
+    /**
+     * Parse les séries entièrement lues (_lus/).
+     *
+     * @param list<string>                $listing    Contenu du répertoire _lus/
+     * @param array<string, list<string>> $filesByDir Fichiers par sous-répertoire
+     *
+     * @return list<NasSeriesData>
+     */
+    public function parseReadSeries(array $listing, array $filesByDir): array
+    {
+        $series = [];
+
+        foreach ($listing as $entry) {
+            if ($this->isIgnoredEntry($entry)) {
+                continue;
+            }
+
+            $parsed = $this->parseSeriesDirectory($entry);
+            $lastDownloaded = $this->getMaxTomeFromFiles($filesByDir[$entry] ?? []);
+
+            $series[] = new NasSeriesData(
+                isComplete: $parsed['isComplete'],
+                lastDownloaded: $lastDownloaded,
+                readComplete: true,
+                readUpTo: null,
+                title: $parsed['title'],
+            );
+        }
+
+        return $series;
+    }
+
+    /**
+     * Parse les séries en cours de lecture (/volume1/lecture en cours/{type}/).
+     * Si la liste commence au T10, les T1-T9 sont considérés lus.
+     *
+     * @param list<string>                $listing    Contenu du répertoire
+     * @param array<string, list<string>> $filesByDir Fichiers par sous-répertoire
+     *
+     * @return list<NasSeriesData>
+     */
+    public function parseInProgressSeries(array $listing, array $filesByDir): array
+    {
+        $series = [];
+
+        foreach ($listing as $entry) {
+            if ($this->isIgnoredEntry($entry)) {
+                continue;
+            }
+
+            $parsed = $this->parseSeriesDirectory($entry);
+            $files = $filesByDir[$entry] ?? [];
+            $tomeNumbers = $this->extractAllTomeNumbers($files);
+
+            $lastDownloaded = [] !== $tomeNumbers ? \max($tomeNumbers) : null;
+            $minTome = [] !== $tomeNumbers ? \min($tomeNumbers) : null;
+
+            // Si le premier tome n'est pas le T1, les précédents ont été lus
+            $readUpTo = (null !== $minTome && $minTome > 1) ? $minTome - 1 : null;
+
+            $series[] = new NasSeriesData(
+                isComplete: $parsed['isComplete'],
+                lastDownloaded: $lastDownloaded,
+                readComplete: false,
+                readUpTo: $readUpTo,
+                title: $parsed['title'],
+            );
+        }
+
+        return $series;
+    }
+
+    private function isIgnoredEntry(string $entry): bool
+    {
+        return \in_array($entry, self::IGNORED_ENTRIES, true);
+    }
+
+    /**
+     * Retourne le numéro de tome max trouvé parmi les fichiers.
+     *
+     * @param list<string> $files
+     */
+    private function getMaxTomeFromFiles(array $files): ?int
+    {
+        $numbers = $this->extractAllTomeNumbers($files);
+
+        return [] !== $numbers ? \max($numbers) : null;
+    }
+
+    /**
+     * Extrait tous les numéros de tomes des fichiers.
+     *
+     * @param list<string> $files
+     *
+     * @return list<int>
+     */
+    private function extractAllTomeNumbers(array $files): array
+    {
+        $numbers = [];
+
+        foreach ($files as $file) {
+            $number = $this->extractTomeNumber($file);
+            if (null !== $number) {
+                $numbers[] = $number;
+            }
+        }
+
+        return $numbers;
+    }
+}

--- a/backend/tests/Unit/Service/Import/ImportExcelServiceTest.php
+++ b/backend/tests/Unit/Service/Import/ImportExcelServiceTest.php
@@ -245,6 +245,103 @@ final class ImportExcelServiceTest extends TestCase
     }
 
     // ---------------------------------------------------------------
+    // Colonne 8 : Parution terminée
+    // ---------------------------------------------------------------
+
+    public function testImportPublicationFinishedColumnSetsCompleteAndKeepsNumbers(): void
+    {
+        $persisted = $this->importAndCapture([
+            'BD' => [
+                ['Titre', 'Buy?', 'Last bought', 'Current', 'Parution', 'Last dled', 'On NAS?', 'Parution terminée'],
+                ['Asterix', 'oui', 40, 40, 40, 40, 'oui', 'oui'],
+            ],
+        ]);
+
+        self::assertCount(1, $persisted);
+        self::assertTrue($persisted[0]->isLatestPublishedIssueComplete());
+        self::assertSame(40, $persisted[0]->getLatestPublishedIssue());
+        // Les nombres sont conservés, pas de "fini" → defaultTomeBought/Read/Downloaded restent false
+        self::assertFalse($persisted[0]->isDefaultTomeBought());
+        self::assertFalse($persisted[0]->isDefaultTomeRead());
+        self::assertFalse($persisted[0]->isDefaultTomeDownloaded());
+    }
+
+    public function testImportPublicationFinishedColumnNonDoesNotSetComplete(): void
+    {
+        $persisted = $this->importAndCapture([
+            'BD' => [
+                ['Titre', 'Buy?', 'Last bought', 'Current', 'Parution', 'Last dled', 'On NAS?', 'Parution terminée'],
+                ['Asterix', 'oui', 5, 5, 40, 5, 'oui', 'non'],
+            ],
+        ]);
+
+        self::assertFalse($persisted[0]->isLatestPublishedIssueComplete());
+    }
+
+    public function testImportWithoutPublicationFinishedColumnFallsBackToFiniDetection(): void
+    {
+        $persisted = $this->importAndCapture([
+            'BD' => [
+                ['Titre', 'Buy?', 'Last bought', 'Current', 'Parution', 'Last dled', 'On NAS?'],
+                ['Asterix', 'fini', 'fini', 'fini', 'fini', 'fini', 'fini'],
+            ],
+        ]);
+
+        self::assertTrue($persisted[0]->isLatestPublishedIssueComplete());
+        self::assertTrue($persisted[0]->isDefaultTomeBought());
+        self::assertTrue($persisted[0]->isDefaultTomeRead());
+        self::assertTrue($persisted[0]->isDefaultTomeDownloaded());
+    }
+
+    public function testImportPublicationFinishedColumnCombinesWithFini(): void
+    {
+        // Col H = oui, mais les nombres sont des entiers (pas "fini")
+        // → latestPublishedIssueComplete = true, defaultTome* = false
+        $persisted = $this->importAndCapture([
+            'BD' => [
+                ['Titre', 'Buy?', 'Last bought', 'Current', 'Parution', 'Last dled', 'On NAS?', 'Parution terminée'],
+                ['Asterix', 'oui', 10, 8, 10, 10, 'oui', 'oui'],
+            ],
+        ]);
+
+        self::assertTrue($persisted[0]->isLatestPublishedIssueComplete());
+        self::assertSame(10, $persisted[0]->getLatestPublishedIssue());
+        // 10 tomes, achetés 1-10, lus 1-8, téléchargés 1-10
+        $tomes = $persisted[0]->getTomes()->toArray();
+        self::assertCount(10, $tomes);
+    }
+
+    public function testImportParutionFiniWithNumberKeepsBothValues(): void
+    {
+        $persisted = $this->importAndCapture([
+            'BD' => [
+                ['Titre', 'Buy?', 'Last bought', 'Current', 'Parution', 'Last dled', 'On NAS?'],
+                ['Asterix', 'oui', 5, 5, 'fini 40', null, null],
+            ],
+        ]);
+
+        self::assertCount(1, $persisted);
+        self::assertTrue($persisted[0]->isLatestPublishedIssueComplete());
+        self::assertSame(40, $persisted[0]->getLatestPublishedIssue());
+    }
+
+    public function testImportLastBoughtFiniWithNumberKeepsBothValues(): void
+    {
+        $persisted = $this->importAndCapture([
+            'BD' => [
+                ['Titre', 'Buy?', 'Last bought', 'Current', 'Parution', 'Last dled', 'On NAS?'],
+                ['Asterix', 'oui', 'fini 10', null, null, null, null],
+            ],
+        ]);
+
+        self::assertTrue($persisted[0]->isDefaultTomeBought());
+        self::assertTrue($persisted[0]->isLatestPublishedIssueComplete());
+        // Le nombre 10 est conservé comme nombre de tomes
+        $tomes = $persisted[0]->getTomes()->toArray();
+        self::assertCount(10, $tomes);
+    }
+
+    // ---------------------------------------------------------------
 
     public function testImportExcelResultIsJsonSerializable(): void
     {

--- a/backend/tests/Unit/Service/Nas/NasDirectoryParserTest.php
+++ b/backend/tests/Unit/Service/Nas/NasDirectoryParserTest.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Nas;
+
+use App\Service\Nas\NasDirectoryParser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests du parsing des répertoires NAS.
+ */
+final class NasDirectoryParserTest extends TestCase
+{
+    private NasDirectoryParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new NasDirectoryParser();
+    }
+
+    // --- extractTomeNumber ---
+
+    #[DataProvider('tomeNumberProvider')]
+    public function testExtractTomeNumber(string $filename, ?int $expected): void
+    {
+        self::assertSame($expected, $this->parser->extractTomeNumber($filename));
+    }
+
+    /**
+     * @return iterable<string, array{string, ?int}>
+     */
+    public static function tomeNumberProvider(): iterable
+    {
+        yield 'format "Série 01 - Titre.cbr"' => [
+            'Androïdes 01 - Résurrection - (Digital)(phillywilly-Empire).cbr',
+            1,
+        ];
+
+        yield 'format "Série 07.cbr"' => [
+            'Androïdes 07.cbr',
+            7,
+        ];
+
+        yield 'format "Série - T01 - Titre.cbr"' => [
+            'Blake & Mortimer -  01 Le Secret de L\'Espadon [Tome 1].cbr',
+            1,
+        ];
+
+        yield 'format "BDFR - SERIE - 01 - Titre.cbz"' => [
+            'BDFR - CEDRIC - 05 - Quelle Mouche Le Pique.cbz',
+            5,
+        ];
+
+        yield 'format "bd_fr_serie_t10_titre.cbr"' => [
+            'bd_fr_achille_talon_t10_le_roi_de_la_science_diction.cbr',
+            10,
+        ];
+
+        yield 'format "04 - Vilyana.pdf"' => [
+            '04 - Vilyana.pdf',
+            4,
+        ];
+
+        yield 'format "Nausicaa 01 (Source)"' => [
+            'Nausicaa 01 (Krystal)',
+            1,
+        ];
+
+        yield 'format "Série (T01-06)"' => [
+            'Artica (T01-06)',
+            6,
+        ];
+
+        yield 'format "Anahire - Tome  1 à 4"' => [
+            'Anahire - Tome  1 à 4',
+            4,
+        ];
+
+        yield 'pas de numéro' => [
+            '@eaDir',
+            null,
+        ];
+
+        yield 'fichier unique one-shot' => [
+            'Death Note (One Shot) - fini.cbz',
+            null,
+        ];
+
+        yield 'fichier zip doublon' => [
+            'Crossbeat-[one-shot].zip',
+            null,
+        ];
+    }
+
+    // --- parseSeriesTitle ---
+
+    #[DataProvider('seriesTitleProvider')]
+    public function testParseSeriesTitle(string $dirName, string $expectedTitle, bool $expectedComplete): void
+    {
+        $result = $this->parser->parseSeriesDirectory($dirName);
+
+        self::assertSame($expectedTitle, $result['title']);
+        self::assertSame($expectedComplete, $result['isComplete']);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, bool}>
+     */
+    public static function seriesTitleProvider(): iterable
+    {
+        yield 'titre simple' => [
+            'Androides',
+            'Androides',
+            false,
+        ];
+
+        yield 'titre avec (complet)' => [
+            '4 Princes De Ganahan (les) (complet)',
+            '4 Princes De Ganahan (les)',
+            true,
+        ];
+
+        yield 'titre avec (incomplet)' => [
+            '42 agents intergalactiques (incomplet)',
+            '42 agents intergalactiques',
+            false,
+        ];
+
+        yield 'titre avec (COMPLET) majuscules' => [
+            'Axis (2014).(COMPLET).VO.cbr-KAIL',
+            'Axis (2014).(COMPLET).VO.cbr-KAIL',
+            false,
+        ];
+
+        yield 'titre avec article (l\')' => [
+            'Alkaest (l\')',
+            'Alkaest (l\')',
+            false,
+        ];
+
+        yield 'Anachron (complet)' => [
+            'Anachron (complet)',
+            'Anachron',
+            true,
+        ];
+    }
+
+    // --- parseListing pour /volume1/lecture/{type}/ ---
+
+    public function testParseUnreadListing(): void
+    {
+        $listing = [
+            '@eaDir',
+            'Androides',
+            '4 Princes De Ganahan (les) (complet)',
+            '_lus',
+        ];
+
+        $filesByDir = [
+            'Androides' => [
+                'Androïdes 01 - Résurrection.cbr',
+                'Androïdes 02 - Heureux qui comme Ulysse.cbr',
+                'Androïdes 07.cbr',
+            ],
+            '4 Princes De Ganahan (les) (complet)' => [
+                'Les 4 Princes De Ganahan - T01 - Galin.cbr',
+                'Les 4 Princes De Ganahan - T02 - Shaal.cbr',
+                'Les 4 Princes De Ganahan - T03 - Filien.cbr',
+                'Les 4 Princes De Ganahan - T04 - Althis.cbr',
+            ],
+        ];
+
+        $result = $this->parser->parseUnreadSeries($listing, $filesByDir);
+
+        self::assertCount(2, $result);
+
+        // Androides : pas complet, 7 tomes, pas lu
+        self::assertSame('Androides', $result[0]->title);
+        self::assertFalse($result[0]->isComplete);
+        self::assertSame(7, $result[0]->lastDownloaded);
+        self::assertNull($result[0]->readUpTo);
+        self::assertFalse($result[0]->readComplete);
+
+        // 4 Princes : complet, 4 tomes, pas lu
+        self::assertSame('4 Princes De Ganahan (les)', $result[1]->title);
+        self::assertTrue($result[1]->isComplete);
+        self::assertSame(4, $result[1]->lastDownloaded);
+        self::assertNull($result[1]->readUpTo);
+        self::assertFalse($result[1]->readComplete);
+    }
+
+    public function testParseReadListing(): void
+    {
+        $listing = [
+            'Blake & Mortimer',
+            'Cedric',
+        ];
+
+        $filesByDir = [
+            'Blake & Mortimer' => [
+                'Blake & Mortimer -  01 Le Secret.cbr',
+                'Blake & Mortimer -  02 Le Secret T2.cbr',
+                'Blake & Mortimer -  03 Le Secret T3.cbr',
+                'Blake & Mortimer -  04 Le Mystere.cbr',
+            ],
+            'Cedric' => [
+                'BDFR - CEDRIC - 01 - Premières Classes.cbz',
+                'BDFR - CEDRIC - 10 - Gâteau Surprise.cbz',
+            ],
+        ];
+
+        $result = $this->parser->parseReadSeries($listing, $filesByDir);
+
+        self::assertCount(2, $result);
+
+        self::assertSame('Blake & Mortimer', $result[0]->title);
+        self::assertSame(4, $result[0]->lastDownloaded);
+        self::assertTrue($result[0]->readComplete);
+
+        self::assertSame('Cedric', $result[1]->title);
+        self::assertSame(10, $result[1]->lastDownloaded);
+        self::assertTrue($result[1]->readComplete);
+    }
+
+    public function testParseInProgressListing(): void
+    {
+        $listing = [
+            'Achille Talon',
+            'Angor',
+            'Anachron (complet)',
+        ];
+
+        $filesByDir = [
+            'Achille Talon' => [
+                'bd_fr_achille_talon_t10_le_roi_de_la_science_diction.cbr',
+                'bd_fr_achille_talon_t11_brave_et_honnete.cbr',
+                'bd_fr_achille_talon_t45_le_maitre_est_talon.cbr',
+            ],
+            'Angor' => [
+                '04 - Vilyana.pdf',
+                '05 - Lekerson.pdf',
+            ],
+            'Anachron (complet)' => [
+                'Anachron 01.cbr',
+                'Anachron 02.cbr',
+                'Anachron 03.cbr',
+            ],
+        ];
+
+        $result = $this->parser->parseInProgressSeries($listing, $filesByDir);
+
+        self::assertCount(3, $result);
+
+        // Achille Talon : commence au T10, donc T1-T9 lus → readUpTo = 9
+        self::assertSame('Achille Talon', $result[0]->title);
+        self::assertSame(45, $result[0]->lastDownloaded);
+        self::assertSame(9, $result[0]->readUpTo);
+        self::assertFalse($result[0]->readComplete);
+
+        // Angor : commence au T4, donc T1-T3 lus → readUpTo = 3
+        self::assertSame('Angor', $result[1]->title);
+        self::assertSame(5, $result[1]->lastDownloaded);
+        self::assertSame(3, $result[1]->readUpTo);
+        self::assertFalse($result[1]->readComplete);
+
+        // Anachron (complet) : commence au T1, donc readUpTo = null (pas de tomes précédents lus)
+        self::assertSame('Anachron', $result[2]->title);
+        self::assertTrue($result[2]->isComplete);
+        self::assertSame(3, $result[2]->lastDownloaded);
+        self::assertNull($result[2]->readUpTo);
+        self::assertFalse($result[2]->readComplete);
+    }
+
+    public function testParseUnreadListingSkipsMetadataDirs(): void
+    {
+        $listing = ['@eaDir', '#recycle', '_lus', 'Androides'];
+        $filesByDir = [
+            'Androides' => ['Androïdes 01.cbr'],
+        ];
+
+        $result = $this->parser->parseUnreadSeries($listing, $filesByDir);
+
+        self::assertCount(1, $result);
+        self::assertSame('Androides', $result[0]->title);
+    }
+
+    public function testParseRangeTomeFormat(): void
+    {
+        $listing = ['Artica (T01-06)'];
+        $filesByDir = [];
+
+        $result = $this->parser->parseUnreadSeries($listing, $filesByDir);
+
+        self::assertCount(1, $result);
+        self::assertSame('Artica', $result[0]->title);
+        self::assertSame(6, $result[0]->lastDownloaded);
+    }
+
+    public function testParseRangeTomeFormatWithA(): void
+    {
+        $listing = ['Anahire - Tome  1 à 4'];
+        $filesByDir = [];
+
+        $result = $this->parser->parseUnreadSeries($listing, $filesByDir);
+
+        self::assertCount(1, $result);
+        self::assertSame('Anahire', $result[0]->title);
+        self::assertSame(4, $result[0]->lastDownloaded);
+    }
+}


### PR DESCRIPTION
## Summary

- Nouvelle commande `app:scan-nas` : connexion SSH au NAS via phpseclib, parsing des répertoires (lecture, lecture en cours, _lus), génération d'un fichier Excel compatible avec `app:import-excel`
- Nouvelle colonne « Parution terminée » (col H) dans l'import Excel pour marquer une série terminée sans perdre les valeurs numériques
- Support du format « fini N » (ex: `fini 40`) dans les cellules numériques

## Test plan

- [x] Tests unitaires `NasDirectoryParserTest` (24 tests) : parsing des noms de fichiers, répertoires, séries lues/non lues/en cours
- [x] Tests unitaires `ImportExcelServiceTest` (21 tests) : col H, format « fini N », rétrocompatibilité
- [x] Test réel : commande exécutée sur le NAS (749 séries générées)
- [x] PHPStan + CS Fixer clean

Fixes #251