### PR TITLE
chore(release): v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+## [v2.10.0] - 2026-03-15
+
 ### Added
 
 - **Tomes hors-série** : Champ `isHorsSerie` sur `Tome` avec numérotation séparée (HS1, HS2…) indépendante des tomes réguliers


### PR DESCRIPTION
## Summary

- Release v2.10.0 — CHANGELOG [Unreleased] → [v2.10.0]

Tag à créer après merge.