### PR TITLE
refactor(frontend): hook useDebounce et filtrage optimisé

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Recherche** : Hook `useDebounce` partagé remplace les `setTimeout` manuels dans Home et ToBuy (cleanup automatique)
+
 ## [v2.11.0] - 2026-03-15
 
 ### Added

--- a/frontend/src/__tests__/unit/hooks/useDebounce.test.ts
+++ b/frontend/src/__tests__/unit/hooks/useDebounce.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDebounce } from "../../../hooks/useDebounce";
+
+describe("useDebounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns initial value immediately", () => {
+    const { result } = renderHook(() => useDebounce("hello", 300));
+    expect(result.current).toBe("hello");
+  });
+
+  it("does not update value before delay", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: "hello" } },
+    );
+
+    rerender({ value: "world" });
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+
+    expect(result.current).toBe("hello");
+  });
+
+  it("updates value after delay", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: "hello" } },
+    );
+
+    rerender({ value: "world" });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe("world");
+  });
+
+  it("resets timer on rapid changes", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: "a" } },
+    );
+
+    rerender({ value: "ab" });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    rerender({ value: "abc" });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // 400ms total but only 200ms since last change — should still be "a"
+    expect(result.current).toBe("a");
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    // 300ms since last change — should now be "abc"
+    expect(result.current).toBe("abc");
+  });
+
+  it("cleans up timer on unmount", () => {
+    const { rerender, unmount } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: "hello" } },
+    );
+
+    rerender({ value: "world" });
+    unmount();
+
+    // Should not throw or cause issues
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+  });
+});

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { BookOpen, Filter, Heart, Loader2, Search } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import CardActionBar from "../components/CardActionBar";
@@ -9,6 +9,7 @@ import ConfirmModal from "../components/ConfirmModal";
 import EmptyState from "../components/EmptyState";
 import Filters from "../components/Filters";
 import { useComics } from "../hooks/useComics";
+import { useDebounce } from "../hooks/useDebounce";
 import { useDeleteComic } from "../hooks/useDeleteComic";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import type { ComicSeries } from "../types/api";
@@ -35,13 +36,12 @@ export default function Home() {
 
   const navigate = useNavigate();
   const [search, setSearch] = useState(searchParam);
-  const [debouncedSearch, setDebouncedSearch] = useState(searchParam);
+  const debouncedSearch = useDebounce(search, 300);
   const [deleteTarget, setDeleteTarget] = useState<ComicSeries | null>(null);
   const [menuComic, setMenuComic] = useState<ComicSeries | null>(null);
 
   useEffect(() => {
     setSearch(searchParam);
-    setDebouncedSearch(searchParam);
   }, [searchParam]);
 
   const updateParam = useCallback(
@@ -68,18 +68,11 @@ export default function Home() {
     (v: SortOption) => updateParam("sort", v === "title-asc" ? "" : v),
     [updateParam],
   );
-  const searchTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const handleSearchChange = useCallback(
-    (v: string) => {
-      setSearch(v);
-      clearTimeout(searchTimerRef.current);
-      searchTimerRef.current = setTimeout(() => {
-        setDebouncedSearch(v);
-        updateParam("search", v.trim());
-      }, 300);
-    },
-    [updateParam],
-  );
+  const handleSearchChange = useCallback((v: string) => setSearch(v), []);
+
+  useEffect(() => {
+    updateParam("search", debouncedSearch.trim());
+  }, [debouncedSearch, updateParam]);
 
   const isMobile = useMediaQuery("(max-width: 639px)");
   const { data, isFetching, isLoading } = useComics();

--- a/frontend/src/pages/ToBuy.tsx
+++ b/frontend/src/pages/ToBuy.tsx
@@ -1,9 +1,10 @@
 import { Loader2, Search, ShoppingCart } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import ComicCard from "../components/ComicCard";
 import ComicCardSkeleton from "../components/ComicCardSkeleton";
 import EmptyState from "../components/EmptyState";
 import { useComics } from "../hooks/useComics";
+import { useDebounce } from "../hooks/useDebounce";
 import { searchComics } from "../utils/searchComics";
 import { filterSeriesToBuy, getNextTomesToBuy } from "../utils/toBuyUtils";
 
@@ -12,18 +13,9 @@ export default function ToBuy() {
   const allComics = data?.member ?? [];
 
   const [search, setSearch] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
-  const searchTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const debouncedSearch = useDebounce(search, 300);
 
-  const handleSearchChange = useCallback((v: string) => {
-    setSearch(v);
-    clearTimeout(searchTimerRef.current);
-    searchTimerRef.current = setTimeout(() => setDebouncedSearch(v), 300);
-  }, []);
-
-  useEffect(() => {
-    return () => clearTimeout(searchTimerRef.current);
-  }, []);
+  const handleSearchChange = useCallback((v: string) => setSearch(v), []);
 
   const filtered = useMemo(() => {
     const toBuy = filterSeriesToBuy(allComics);


### PR DESCRIPTION
## Summary

- Crée un hook partagé `useDebounce(value, delay)` avec cleanup automatique
- Remplace les `setTimeout` / `useRef` manuels dans Home.tsx et ToBuy.tsx
- Synchronisation URL debounced dans Home via `useEffect` sur `debouncedSearch`

## Test plan

- [x] 5 tests unitaires pour `useDebounce` (valeur initiale, délai, reset timer, cleanup)
- [x] 32 tests Home passent (dont debounce search)
- [x] 7 tests ToBuy passent
- [x] Suite complète : 678/678 tests verts
- [x] `tsc --noEmit` clean

Fixes #265