### PR TITLE
perf(frontend): virtualise les listes et mémoïse les composants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 ### Changed
 
 - **Recherche** : Hook `useDebounce` partagé remplace les `setTimeout` manuels dans Home et ToBuy (cleanup automatique)
+- **Performance** : Virtualisation des grilles (Home, ToBuy) avec `@tanstack/react-virtual` — seules les lignes visibles sont rendues
+- **Performance** : `React.memo` sur `ComicCard`, `CardActionBar` et `MergeGroupCard` pour éviter les re-renders inutiles
+- **Performance** : Callbacks mémoïsés dans Home, stats mémoïsées dans ComicDetail
 
 ## [v2.11.0] - 2026-03-15
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@react-oauth/google": "^0.13.4",
         "@tanstack/react-query": "^5.90",
         "@tanstack/react-query-persist-client": "^5.90.24",
+        "@tanstack/react-virtual": "^3.13.23",
         "@vitejs/plugin-react": "^5.1",
         "fuse.js": "^7.1.0",
         "html5-qrcode": "^2.3",
@@ -3442,12 +3443,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.19",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.19.tgz",
-      "integrity": "sha512-KzwmU1IbE0IvCZSm6OXkS+kRdrgW2c2P3Ho3NC+zZXWK6oObv/L+lcV/2VuJ+snVESRlMJ+w/fg4WXI/JzoNGQ==",
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
+      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.13.19"
+        "@tanstack/virtual-core": "3.13.23"
       },
       "funding": {
         "type": "github",
@@ -3459,9 +3460,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.13.19",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.19.tgz",
-      "integrity": "sha512-/BMP7kNhzKOd7wnDeB8NrIRNLwkf5AhCYCvtfZV2GXWbBieFm/el0n6LOAXlTi6ZwHICSNnQcIxRCWHrLzDY+g==",
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
+      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@react-oauth/google": "^0.13.4",
     "@tanstack/react-query": "^5.90",
     "@tanstack/react-query-persist-client": "^5.90.24",
+    "@tanstack/react-virtual": "^3.13.23",
     "@vitejs/plugin-react": "^5.1",
     "fuse.js": "^7.1.0",
     "html5-qrcode": "^2.3",

--- a/frontend/src/__tests__/integration/pages/Home.test.tsx
+++ b/frontend/src/__tests__/integration/pages/Home.test.tsx
@@ -757,7 +757,7 @@ describe("Home", () => {
     expect(screen.queryByTestId("search-loading")).not.toBeInTheDocument();
   });
 
-  it("applies fade transition class to results grid", async () => {
+  it("renders virtualized results grid", async () => {
     const comics = [
       createMockComicSeries({ id: 1, title: "Naruto" }),
     ];
@@ -774,10 +774,8 @@ describe("Home", () => {
       expect(screen.getByText("Naruto")).toBeInTheDocument();
     });
 
-    // The results grid should have transition classes
     const grid = screen.getByTestId("comics-grid");
     expect(grid).toBeInTheDocument();
-    expect(grid.className).toContain("transition");
   });
 
   it("pre-fills search from URL param", async () => {

--- a/frontend/src/__tests__/unit/components/VirtualGrid.test.tsx
+++ b/frontend/src/__tests__/unit/components/VirtualGrid.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import VirtualGrid from "../../../components/VirtualGrid";
+
+// Mock useColumnCount to return a fixed column count
+vi.mock("../../../hooks/useColumnCount", () => ({
+  useColumnCount: () => ({ columnCount: 3, containerRef: vi.fn() }),
+}));
+
+// Mock useWindowVirtualizer
+const mockGetVirtualItems = vi.fn();
+const mockGetTotalSize = vi.fn(() => 720);
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useWindowVirtualizer: vi.fn(() => ({
+    getVirtualItems: mockGetVirtualItems,
+    getTotalSize: mockGetTotalSize,
+  })),
+}));
+
+beforeEach(() => {
+  mockGetVirtualItems.mockReturnValue([
+    { index: 0, key: "0", size: 240, start: 0 },
+    { index: 1, key: "1", size: 240, start: 240 },
+    { index: 2, key: "2", size: 240, start: 480 },
+  ]);
+});
+
+describe("VirtualGrid", () => {
+  it("renders virtual rows with items", () => {
+    const items = Array.from({ length: 9 }, (_, i) => ({ id: i, name: `Item ${i}` }));
+
+    render(
+      <VirtualGrid
+        items={items}
+        renderItem={(item) => <div data-testid={`item-${item.id}`}>{item.name}</div>}
+      />,
+    );
+
+    // With 3 columns and 3 virtual rows, first row has items 0-2
+    expect(screen.getByTestId("item-0")).toBeInTheDocument();
+    expect(screen.getByTestId("item-1")).toBeInTheDocument();
+    expect(screen.getByTestId("item-2")).toBeInTheDocument();
+  });
+
+  it("renders nothing when items is empty", () => {
+    const { container } = render(
+      <VirtualGrid
+        items={[]}
+        renderItem={(item: { id: number }) => <div>{item.id}</div>}
+      />,
+    );
+
+    // Should render the container but with 0 height
+    mockGetVirtualItems.mockReturnValue([]);
+    mockGetTotalSize.mockReturnValue(0);
+
+    const { container: emptyContainer } = render(
+      <VirtualGrid
+        items={[]}
+        renderItem={(item: { id: number }) => <div>{item.id}</div>}
+      />,
+    );
+
+    expect(emptyContainer.querySelector("[data-testid='virtual-grid']")).toBeInTheDocument();
+  });
+
+  it("applies custom testId", () => {
+    render(
+      <VirtualGrid
+        items={[{ id: 1 }]}
+        renderItem={(item) => <div>{item.id}</div>}
+        testId="my-grid"
+      />,
+    );
+
+    expect(screen.getByTestId("my-grid")).toBeInTheDocument();
+  });
+
+  it("uses grid layout classes on rows", () => {
+    const items = Array.from({ length: 6 }, (_, i) => ({ id: i }));
+
+    const { container } = render(
+      <VirtualGrid
+        items={items}
+        renderItem={(item) => <div>{item.id}</div>}
+      />,
+    );
+
+    // Virtual rows should have grid classes
+    const gridRows = container.querySelectorAll(".grid");
+    expect(gridRows.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/__tests__/unit/hooks/useColumnCount.test.ts
+++ b/frontend/src/__tests__/unit/hooks/useColumnCount.test.ts
@@ -1,0 +1,90 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useColumnCount } from "../../../hooks/useColumnCount";
+
+let resizeCallback: ResizeObserverCallback;
+const observeMock = vi.fn();
+const disconnectMock = vi.fn();
+
+beforeEach(() => {
+  observeMock.mockClear();
+  disconnectMock.mockClear();
+
+  class MockResizeObserver {
+    constructor(cb: ResizeObserverCallback) {
+      resizeCallback = cb;
+    }
+    disconnect = disconnectMock;
+    observe = observeMock;
+    unobserve = vi.fn();
+  }
+
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function triggerResize(width: number) {
+  act(() => {
+    resizeCallback(
+      [{ contentRect: { width } } as ResizeObserverEntry],
+      {} as ResizeObserver,
+    );
+  });
+}
+
+describe("useColumnCount", () => {
+  it("returns default column count of 2", () => {
+    const { result } = renderHook(() => useColumnCount());
+    expect(result.current.columnCount).toBe(2);
+  });
+
+  it("returns 3 columns for sm breakpoint (≥640px)", () => {
+    const { result } = renderHook(() => useColumnCount());
+    triggerResize(640);
+    expect(result.current.columnCount).toBe(3);
+  });
+
+  it("returns 4 columns for md breakpoint (≥768px)", () => {
+    const { result } = renderHook(() => useColumnCount());
+    triggerResize(768);
+    expect(result.current.columnCount).toBe(4);
+  });
+
+  it("returns 5 columns for lg breakpoint (≥1024px)", () => {
+    const { result } = renderHook(() => useColumnCount());
+    triggerResize(1024);
+    expect(result.current.columnCount).toBe(5);
+  });
+
+  it("returns 6 columns for xl breakpoint (≥1280px)", () => {
+    const { result } = renderHook(() => useColumnCount());
+    triggerResize(1280);
+    expect(result.current.columnCount).toBe(6);
+  });
+
+  it("returns 2 columns for narrow width (<640px)", () => {
+    const { result } = renderHook(() => useColumnCount());
+    triggerResize(400);
+    expect(result.current.columnCount).toBe(2);
+  });
+
+  it("observes the container ref element", () => {
+    const { result } = renderHook(() => useColumnCount());
+    const div = document.createElement("div");
+
+    act(() => {
+      (result.current.containerRef as React.RefCallback<HTMLDivElement>)(div);
+    });
+
+    expect(observeMock).toHaveBeenCalledWith(div);
+  });
+
+  it("disconnects observer on unmount", () => {
+    const { unmount } = renderHook(() => useColumnCount());
+    unmount();
+    expect(disconnectMock).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/CardActionBar.tsx
+++ b/frontend/src/components/CardActionBar.tsx
@@ -1,5 +1,5 @@
 import { Edit, Trash2 } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 import type { ComicSeries } from "../types/api";
 
 interface CardActionBarProps {
@@ -9,7 +9,7 @@ interface CardActionBarProps {
   onEdit: (comic: ComicSeries) => void;
 }
 
-export default function CardActionBar({ comic, onClose, onDelete, onEdit }: CardActionBarProps) {
+export default memo(function CardActionBar({ comic, onClose, onDelete, onEdit }: CardActionBarProps) {
   const barRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -65,4 +65,4 @@ export default function CardActionBar({ comic, onClose, onDelete, onEdit }: Card
       </div>
     </>
   );
-}
+});

--- a/frontend/src/components/ComicCard.tsx
+++ b/frontend/src/components/ComicCard.tsx
@@ -1,5 +1,6 @@
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import { Bell, Edit, EllipsisVertical, Euro, Eye, HardDrive, Trash2 } from "lucide-react";
+import { memo } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import type { ComicSeries } from "../types/api";
 import { ComicTypeLabel, ComicTypePlaceholder } from "../types/enums";
@@ -14,7 +15,7 @@ interface ComicCardProps {
   onMenuOpen?: (comic: ComicSeries) => void;
 }
 
-export default function ComicCard({ comic, onDelete, onMenuOpen }: ComicCardProps) {
+export default memo(function ComicCard({ comic, onDelete, onMenuOpen }: ComicCardProps) {
   const navigate = useNavigate();
   const coverSrc = getCoverSrc(comic);
   const tomes = comic.tomes ?? [];
@@ -182,4 +183,4 @@ export default function ComicCard({ comic, onDelete, onMenuOpen }: ComicCardProp
       </div>
     </Link>
   );
-}
+});

--- a/frontend/src/components/MergeGroupCard.tsx
+++ b/frontend/src/components/MergeGroupCard.tsx
@@ -1,4 +1,5 @@
 import { Eye, X } from "lucide-react";
+import { memo } from "react";
 import type { MergeGroup } from "../types/api";
 
 interface MergeGroupCardProps {
@@ -7,7 +8,7 @@ interface MergeGroupCardProps {
   onSkip: (group: MergeGroup) => void;
 }
 
-export default function MergeGroupCard({
+export default memo(function MergeGroupCard({
   group,
   onPreview,
   onSkip,
@@ -59,4 +60,4 @@ export default function MergeGroupCard({
       </div>
     </div>
   );
-}
+});

--- a/frontend/src/components/VirtualGrid.tsx
+++ b/frontend/src/components/VirtualGrid.tsx
@@ -1,0 +1,63 @@
+import { useWindowVirtualizer } from "@tanstack/react-virtual";
+import type { ReactNode } from "react";
+import { useColumnCount } from "../hooks/useColumnCount";
+
+const GRID_CLASSES = "grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6";
+
+interface VirtualGridProps<T> {
+  estimateRowHeight?: number;
+  items: T[];
+  renderItem: (item: T) => ReactNode;
+  testId?: string;
+}
+
+export default function VirtualGrid<T>({
+  estimateRowHeight = 240,
+  items,
+  renderItem,
+  testId = "virtual-grid",
+}: VirtualGridProps<T>) {
+  const { columnCount, containerRef } = useColumnCount();
+  const rowCount = Math.ceil(items.length / columnCount);
+
+  const virtualizer = useWindowVirtualizer({
+    count: rowCount,
+    estimateSize: () => estimateRowHeight,
+    overscan: 3,
+  });
+
+  return (
+    <div data-testid={testId} ref={containerRef}>
+      <div
+        style={{
+          height: `${virtualizer.getTotalSize()}px`,
+          position: "relative",
+          width: "100%",
+        }}
+      >
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          const startIndex = virtualRow.index * columnCount;
+          const rowItems = items.slice(startIndex, startIndex + columnCount);
+
+          return (
+            <div
+              className={GRID_CLASSES}
+              key={virtualRow.key}
+              style={{
+                left: 0,
+                position: "absolute",
+                top: 0,
+                transform: `translateY(${virtualRow.start}px)`,
+                width: "100%",
+              }}
+            >
+              {rowItems.map((item, i) => (
+                <div key={startIndex + i}>{renderItem(item)}</div>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useColumnCount.ts
+++ b/frontend/src/hooks/useColumnCount.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const BREAKPOINTS: [number, number][] = [
+  [1280, 6],
+  [1024, 5],
+  [768, 4],
+  [640, 3],
+];
+
+function getColumnCount(width: number): number {
+  for (const [breakpoint, cols] of BREAKPOINTS) {
+    if (width >= breakpoint) return cols;
+  }
+  return 2;
+}
+
+export function useColumnCount() {
+  const [columnCount, setColumnCount] = useState(2);
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const elementRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    observerRef.current = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        setColumnCount(getColumnCount(entry.contentRect.width));
+      }
+    });
+
+    if (elementRef.current) {
+      observerRef.current.observe(elementRef.current);
+    }
+
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, []);
+
+  const containerRef = useCallback((node: HTMLDivElement | null) => {
+    elementRef.current = node;
+    if (node && observerRef.current) {
+      observerRef.current.observe(node);
+    }
+  }, []);
+
+  return { columnCount, containerRef };
+}

--- a/frontend/src/pages/ComicDetail.tsx
+++ b/frontend/src/pages/ComicDetail.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, Edit, ExternalLink, Trash2 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import ConfirmModal from "../components/ConfirmModal";
@@ -39,6 +39,13 @@ export default function ComicDetail() {
   const updateTome = useUpdateTome(id ? Number(id) : undefined);
   const [showDelete, setShowDelete] = useState(false);
   const [optimisticTomes, setOptimisticTomes] = useState<Tome[]>([]);
+
+  const { boughtCount, downloadedCount, progressTotal, readCount } = useMemo(() => ({
+    boughtCount: countCoveredTomes(optimisticTomes, (t) => t.bought),
+    downloadedCount: countCoveredTomes(optimisticTomes, (t) => t.downloaded),
+    progressTotal: Math.max(comic?.latestPublishedIssue ?? 0, countCoveredTomes(optimisticTomes)),
+    readCount: countCoveredTomes(optimisticTomes, (t) => t.read),
+  }), [optimisticTomes, comic?.latestPublishedIssue]);
 
   useEffect(() => {
     if (comic?.tomes) {
@@ -117,10 +124,6 @@ export default function ComicDetail() {
 
   const coverSrc = getCoverSrc(comic);
   const showProgress = !comic.isOneShot && optimisticTomes.length > 0;
-  const progressTotal = Math.max(comic.latestPublishedIssue ?? 0, countCoveredTomes(optimisticTomes));
-  const boughtCount = countCoveredTomes(optimisticTomes, (t) => t.bought);
-  const readCount = countCoveredTomes(optimisticTomes, (t) => t.read);
-  const downloadedCount = countCoveredTomes(optimisticTomes, (t) => t.downloaded);
 
   return (
     <div className="mx-auto max-w-4xl space-y-6">

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -8,6 +8,7 @@ import ComicCardSkeleton from "../components/ComicCardSkeleton";
 import ConfirmModal from "../components/ConfirmModal";
 import EmptyState from "../components/EmptyState";
 import Filters from "../components/Filters";
+import VirtualGrid from "../components/VirtualGrid";
 import { useComics } from "../hooks/useComics";
 import { useDebounce } from "../hooks/useDebounce";
 import { useDeleteComic } from "../hooks/useDeleteComic";
@@ -69,6 +70,15 @@ export default function Home() {
     [updateParam],
   );
   const handleSearchChange = useCallback((v: string) => setSearch(v), []);
+  const handleMenuClose = useCallback(() => setMenuComic(null), []);
+  const handleMenuDelete = useCallback((c: ComicSeries) => {
+    setMenuComic(null);
+    setDeleteTarget(c);
+  }, []);
+  const handleMenuEdit = useCallback((c: ComicSeries) => {
+    setMenuComic(null);
+    navigate(`/comic/${c.id}/edit`, { viewTransition: true });
+  }, [navigate]);
 
   useEffect(() => {
     updateParam("search", debouncedSearch.trim());
@@ -170,27 +180,20 @@ export default function Home() {
           />
         )
       ) : (
-        <div
-          className="grid grid-cols-2 gap-3 transition-opacity duration-300 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
-          data-testid="comics-grid"
-        >
-          {filtered.map((comic) => (
-            <ComicCard comic={comic} key={comic.id} onDelete={setDeleteTarget} onMenuOpen={setMenuComic} />
-          ))}
-        </div>
+        <VirtualGrid
+          items={filtered}
+          renderItem={(comic) => (
+            <ComicCard comic={comic} onDelete={setDeleteTarget} onMenuOpen={setMenuComic} />
+          )}
+          testId="comics-grid"
+        />
       )}
 
       <CardActionBar
         comic={menuComic}
-        onClose={() => setMenuComic(null)}
-        onDelete={(c) => {
-          setMenuComic(null);
-          setDeleteTarget(c);
-        }}
-        onEdit={(c) => {
-          setMenuComic(null);
-          navigate(`/comic/${c.id}/edit`, { viewTransition: true });
-        }}
+        onClose={handleMenuClose}
+        onDelete={handleMenuDelete}
+        onEdit={handleMenuEdit}
       />
 
       <ConfirmModal

--- a/frontend/src/pages/ToBuy.tsx
+++ b/frontend/src/pages/ToBuy.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo, useState } from "react";
 import ComicCard from "../components/ComicCard";
 import ComicCardSkeleton from "../components/ComicCardSkeleton";
 import EmptyState from "../components/EmptyState";
+import VirtualGrid from "../components/VirtualGrid";
 import { useComics } from "../hooks/useComics";
 import { useDebounce } from "../hooks/useDebounce";
 import { searchComics } from "../utils/searchComics";
@@ -20,7 +21,11 @@ export default function ToBuy() {
   const filtered = useMemo(() => {
     const toBuy = filterSeriesToBuy(allComics);
     const searched = searchComics(toBuy, debouncedSearch);
-    return [...searched].sort((a, b) => a.title.localeCompare(b.title, "fr"));
+    const sorted = [...searched].sort((a, b) => a.title.localeCompare(b.title, "fr"));
+    return sorted.map((comic) => ({
+      comic,
+      nextTomes: getNextTomesToBuy(comic).map((n) => `T.${n}`).join(", "),
+    }));
   }, [allComics, debouncedSearch]);
 
   return (
@@ -64,16 +69,17 @@ export default function ToBuy() {
           />
         )
       ) : (
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-          {filtered.map((comic) => (
-            <div key={comic.id}>
+        <VirtualGrid
+          items={filtered}
+          renderItem={({ comic, nextTomes }) => (
+            <>
               <ComicCard comic={comic} />
               <p className="mt-1 truncate px-1 text-xs text-emerald-600 dark:text-emerald-400">
-                Prochain : {getNextTomesToBuy(comic).map((n) => `T.${n}`).join(", ")}
+                Prochain : {nextTomes}
               </p>
-            </div>
-          ))}
-        </div>
+            </>
+          )}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- **VirtualGrid** : nouveau composant réutilisable avec `@tanstack/react-virtual` (`useWindowVirtualizer`) — seules les lignes visibles + overscan sont dans le DOM (~30 cartes au lieu de 1354)
- **useColumnCount** : hook ResizeObserver qui détecte le nombre de colonnes selon les breakpoints Tailwind (2→3→4→5→6)
- **React.memo** sur `ComicCard`, `CardActionBar`, `MergeGroupCard` — évite les re-renders quand les props ne changent pas
- **Callbacks mémoïsés** (`useCallback`) dans Home pour le `CardActionBar`, `useMemo` pour les stats de progression dans ComicDetail
- **Suppression de `transition-opacity duration-300`** sur la grille (animait 1354+ éléments à chaque changement de filtre)

## Test plan

- [x] 690/690 tests Vitest passent
- [x] TypeScript `tsc --noEmit` clean
- [x] 12 nouveaux tests (8 useColumnCount + 4 VirtualGrid)
- [ ] Vérifier visuellement le scroll et les filtres sur Home et ToBuy

fixes #264