### PR TITLE
perf(frontend): invalidation ciblée des queries TanStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 - **Performance** : Virtualisation des grilles (Home, ToBuy) avec `@tanstack/react-virtual` — seules les lignes visibles sont rendues
 - **Performance** : `React.memo` sur `ComicCard`, `CardActionBar` et `MergeGroupCard` pour éviter les re-renders inutiles
 - **Performance** : Callbacks mémoïsés dans Home, stats mémoïsées dans ComicDetail
+- **Performance** : Invalidation ciblée des queries TanStack — `useUpdateComic` et `useDeleteComic` n'invalident plus que la série concernée
+- **Performance** : `staleTime` réduit de 30 min à 5 min, `refetchOnWindowFocus` activé
 
 ## [v2.11.0] - 2026-03-15
 

--- a/frontend/src/__tests__/integration/hooks/useUpdateComic.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useUpdateComic.test.tsx
@@ -88,6 +88,43 @@ describe("useUpdateComic", () => {
     expect(queryClient.getQueryState(["comic", 3])?.isInvalidated).toBe(true);
   });
 
+  it("does not invalidate unrelated comic detail queries", async () => {
+    const queryClient = createTestQueryClient();
+
+    queryClient.setQueryData(["comics"], createMockHydraCollection([]));
+    queryClient.setQueryData(
+      ["comic", 3],
+      createMockComicSeries({ id: 3, title: "Target" }),
+    );
+    queryClient.setQueryData(
+      ["comic", 5],
+      createMockComicSeries({ id: 5, title: "Other" }),
+    );
+
+    server.use(
+      http.patch("/api/comic_series/3", () =>
+        HttpResponse.json(
+          createMockComicSeries({ id: 3, title: "Updated" }),
+        ),
+      ),
+    );
+
+    const { result } = renderHook(() => useUpdateComic(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ id: 3, title: "Updated" });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // comic 3 should be invalidated (targeted)
+    expect(queryClient.getQueryState(["comic", 3])?.isInvalidated).toBe(true);
+    // comic 5 should NOT be invalidated (not related)
+    expect(queryClient.getQueryState(["comic", 5])?.isInvalidated).toBe(false);
+  });
+
   it("handles API error", async () => {
     server.use(
       http.patch("/api/comic_series/3", () =>

--- a/frontend/src/__tests__/unit/queryClient.test.ts
+++ b/frontend/src/__tests__/unit/queryClient.test.ts
@@ -7,9 +7,9 @@ describe("queryClient default options", () => {
 
     expect(defaults?.gcTime).toBe(60 * 60 * 1000);
     expect(defaults?.networkMode).toBe("offlineFirst");
-    expect(defaults?.refetchOnWindowFocus).toBe(false);
+    expect(defaults?.refetchOnWindowFocus).toBe(true);
     expect(defaults?.retry).toBe(1);
-    expect(defaults?.staleTime).toBe(30 * 60 * 1000);
+    expect(defaults?.staleTime).toBe(5 * 60 * 1000);
   });
 
   it("has correct mutation defaults", () => {

--- a/frontend/src/hooks/useDeleteComic.ts
+++ b/frontend/src/hooks/useDeleteComic.ts
@@ -19,6 +19,6 @@ export function useDeleteComic() {
         };
       });
     },
-    queryKeysToInvalidate: [["comics"], ["trash"]],
+    queryKeysToInvalidate: (variables) => [["comics"], ["comic", variables.id], ["trash"]],
   });
 }

--- a/frontend/src/hooks/useOfflineMutation.ts
+++ b/frontend/src/hooks/useOfflineMutation.ts
@@ -19,7 +19,7 @@ interface UseOfflineMutationOptions<TData, TVariables> {
   onOfflineSuccess?: () => void;
   onSuccess?: (data: TData, variables: TVariables) => void;
   optimisticUpdate?: (queryClient: QueryClient, variables: TVariables, tempId?: number) => void;
-  queryKeysToInvalidate: QueryKey[];
+  queryKeysToInvalidate: QueryKey[] | ((variables: TVariables) => QueryKey[]);
 }
 
 async function registerSync(): Promise<void> {
@@ -83,7 +83,10 @@ export function useOfflineMutation<TData, TVariables extends Record<string, unkn
     },
     onSuccess: (data, variables) => {
       if (navigator.onLine) {
-        for (const key of queryKeysToInvalidate) {
+        const keys = typeof queryKeysToInvalidate === "function"
+          ? queryKeysToInvalidate(variables)
+          : queryKeysToInvalidate;
+        for (const key of keys) {
           void queryClient.invalidateQueries({ queryKey: key });
         }
         onSuccess?.(data, variables);

--- a/frontend/src/hooks/useUpdateComic.ts
+++ b/frontend/src/hooks/useUpdateComic.ts
@@ -44,6 +44,6 @@ export function useUpdateComic() {
         return { ...old, ...safeFields, _syncPending: true };
       });
     },
-    queryKeysToInvalidate: [["comics"], ["comic"]],
+    queryKeysToInvalidate: (variables) => [["comics"], ["comic", variables.id]],
   });
 }

--- a/frontend/src/queryClient.ts
+++ b/frontend/src/queryClient.ts
@@ -7,9 +7,9 @@ export const queryClient = new QueryClient({
     queries: {
       gcTime: 60 * 60 * 1000,
       networkMode: "offlineFirst",
-      refetchOnWindowFocus: false,
+      refetchOnWindowFocus: true,
       retry: 1,
-      staleTime: 30 * 60 * 1000,
+      staleTime: 5 * 60 * 1000,
     },
     mutations: {
       networkMode: "offlineFirst",


### PR DESCRIPTION
## Summary

- **Invalidation ciblée** : `useUpdateComic` invalide `["comic", id]` au lieu de `["comic"]` (ne touche plus les détails des autres séries)
- **`useDeleteComic`** : ajoute `["comic", id]` pour nettoyer le cache de la série supprimée
- **`useOfflineMutation`** : `queryKeysToInvalidate` accepte désormais une fonction `(variables) => QueryKey[]` pour des clés dynamiques
- **`staleTime`** réduit de 30 min → 5 min + `refetchOnWindowFocus: true` activé (données fraîches au retour sur l'onglet)

## Test plan

- [x] 691/691 tests Vitest passent
- [x] TypeScript `tsc --noEmit` clean
- [x] Nouveau test : update comic 3 → comic 5 n'est PAS invalidé

fixes #266