### PR TITLE
fix(frontend): les données API et URLs de couverture n'étaient pas sécurisées

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 - **Performance** : Invalidation ciblée des queries TanStack — `useUpdateComic` et `useDeleteComic` n'invalident plus que la série concernée
 - **Performance** : `staleTime` réduit de 30 min à 5 min, `refetchOnWindowFocus` activé
 
+### Fixed
+
+- **Sécurité** : Vidage du cache SW (`api-cache`) au logout — les données API ne persistent plus après déconnexion
+- **Sécurité** : Validation du schéma URL des couvertures (`http://`/`https://` uniquement) — bloque `javascript:` et `data:`
+- **Sécurité** : Messages d'erreur serveur sanitisés — les détails internes (SQL, stack trace) ne sont plus exposés
+
 ## [v2.11.0] - 2026-03-15
 
 ### Added

--- a/frontend/src/__tests__/integration/components/Layout.test.tsx
+++ b/frontend/src/__tests__/integration/components/Layout.test.tsx
@@ -41,6 +41,11 @@ describe("Layout", () => {
     vi.mocked(toast.success).mockClear();
     vi.mocked(toast.error).mockClear();
     mockUseSyncStatus.mockReturnValue({ error: null, status: "idle", syncedCount: 0 });
+    vi.stubGlobal("caches", { delete: vi.fn().mockResolvedValue(true) });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("renders header with app title", () => {

--- a/frontend/src/__tests__/integration/hooks/useAuth.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useAuth.test.tsx
@@ -33,6 +33,11 @@ describe("useAuth", () => {
   beforeEach(() => {
     localStorage.clear();
     mockNavigate.mockReset();
+    vi.stubGlobal("caches", { delete: vi.fn().mockResolvedValue(true) });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("returns isAuthenticated false when no token", () => {
@@ -160,5 +165,19 @@ describe("useAuth", () => {
 
     expect(localStorage.getItem("jwt_token")).toBeNull();
     expect(mockNavigate).toHaveBeenCalledWith("/login", { viewTransition: true });
+  });
+
+  it("logout clears SW api-cache", () => {
+    localStorage.setItem("jwt_token", "some-token");
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.logout();
+    });
+
+    expect(caches.delete).toHaveBeenCalledWith("api-cache");
   });
 });

--- a/frontend/src/__tests__/unit/services/api.test.ts
+++ b/frontend/src/__tests__/unit/services/api.test.ts
@@ -187,6 +187,32 @@ describe("apiFetch", () => {
     await expect(apiFetch("/test")).rejects.toThrow("Erreur 500");
   });
 
+  it("sanitizes server error details that expose internals", async () => {
+    server.use(
+      http.get("/api/test", () =>
+        HttpResponse.json(
+          { detail: "An exception occurred in the driver: SQLSTATE[42S02]: Base table or view not found" },
+          { status: 500 },
+        ),
+      ),
+    );
+
+    await expect(apiFetch("/test")).rejects.toThrow("Erreur serveur");
+  });
+
+  it("passes through safe user-facing error messages", async () => {
+    server.use(
+      http.get("/api/test", () =>
+        HttpResponse.json(
+          { detail: "Série introuvable" },
+          { status: 404 },
+        ),
+      ),
+    );
+
+    await expect(apiFetch("/test")).rejects.toThrow("Série introuvable");
+  });
+
   it("handles 401 by removing token and redirecting to /login", async () => {
     setToken("expired-token");
 

--- a/frontend/src/__tests__/unit/utils/coverUtils.test.ts
+++ b/frontend/src/__tests__/unit/utils/coverUtils.test.ts
@@ -23,4 +23,23 @@ describe("getCoverSrc", () => {
     expect(getCoverSrc({ coverImage: "local.jpg", coverUrl: "https://remote.com/img.jpg" }))
       .toBe("/uploads/covers/local.jpg");
   });
+
+  it("rejects coverUrl with javascript: scheme", () => {
+    // eslint-disable-next-line no-script-url
+    expect(getCoverSrc({ coverImage: null, coverUrl: "javascript:alert(1)" })).toBeNull();
+  });
+
+  it("rejects coverUrl with data: scheme", () => {
+    expect(getCoverSrc({ coverImage: null, coverUrl: "data:text/html,<script>alert(1)</script>" })).toBeNull();
+  });
+
+  it("accepts http:// coverUrl", () => {
+    expect(getCoverSrc({ coverImage: null, coverUrl: "http://example.com/img.jpg" }))
+      .toBe("http://example.com/img.jpg");
+  });
+
+  it("accepts https:// coverUrl", () => {
+    expect(getCoverSrc({ coverImage: null, coverUrl: "https://example.com/img.jpg" }))
+      .toBe("https://example.com/img.jpg");
+  });
 });

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -22,6 +22,7 @@ export function useAuth() {
   const logout = useCallback(() => {
     queryClient.clear();
     del("bibliotheque-query-cache");
+    void caches.delete("api-cache");
     removeToken();
     navigate("/login", { viewTransition: true });
   }, [navigate, queryClient]);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -22,6 +22,20 @@ export function isAuthenticated(): boolean {
   return getToken() !== null;
 }
 
+const SERVER_ERROR_PATTERNS = [
+  /SQLSTATE/i,
+  /exception.*driver/i,
+  /stack trace/i,
+  /vendor\//i,
+];
+
+function sanitizeErrorMessage(message: string, status: number): string {
+  if (status >= 500 && SERVER_ERROR_PATTERNS.some((p) => p.test(message))) {
+    return "Erreur serveur";
+  }
+  return message;
+}
+
 export async function apiFetch<T>(
   path: string,
   options: RequestInit = {},
@@ -67,9 +81,8 @@ export async function apiFetch<T>(
   if (!response.ok) {
     const error = await response.json().catch(() => ({}));
     const body = error as { detail?: string; error?: string };
-    throw new Error(
-      body.detail ?? body.error ?? `Erreur ${response.status}`,
-    );
+    const message = body.detail ?? body.error ?? `Erreur ${response.status}`;
+    throw new Error(sanitizeErrorMessage(message, response.status));
   }
 
   // 204 No Content

--- a/frontend/src/utils/coverUtils.ts
+++ b/frontend/src/utils/coverUtils.ts
@@ -1,6 +1,13 @@
+function isValidCoverUrl(url: string): boolean {
+  return url.startsWith("http://") || url.startsWith("https://");
+}
+
 export function getCoverSrc(comic: { coverImage: string | null; coverUrl?: string | null }): string | null {
   if (comic.coverImage) {
     return `/uploads/covers/${comic.coverImage}`;
   }
-  return comic.coverUrl ?? null;
+  if (comic.coverUrl && isValidCoverUrl(comic.coverUrl)) {
+    return comic.coverUrl;
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary

- **Logout** : le cache SW `api-cache` est maintenant supprimé à la déconnexion — les réponses API ne persistent plus
- **Cover URLs** : validation du schéma (`http://`/`https://` uniquement) — bloque `javascript:` et `data:` dans `<img src>`
- **Erreurs API** : les messages serveur contenant des détails internes (SQL, stack trace) sont remplacés par « Erreur serveur »

## Test plan

- [x] 698/698 tests Vitest passent
- [x] TypeScript `tsc --noEmit` clean
- [x] 6 nouveaux tests (1 useAuth cache, 4 coverUtils URL, 2 api sanitize)

fixes #270