### PR TITLE
fix(frontend): les cartes de la grille virtualisée sont collées verticalement

### DIFF
--- a/frontend/src/components/VirtualGrid.tsx
+++ b/frontend/src/components/VirtualGrid.tsx
@@ -2,7 +2,8 @@ import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import type { ReactNode } from "react";
 import { useColumnCount } from "../hooks/useColumnCount";
 
-const GRID_CLASSES = "grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6";
+const GRID_CLASSES = "grid grid-cols-2 gap-x-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6";
+const ROW_GAP = 12; // Tailwind gap-3 = 0.75rem = 12px
 
 interface VirtualGridProps<T> {
   estimateRowHeight?: number;
@@ -12,7 +13,7 @@ interface VirtualGridProps<T> {
 }
 
 export default function VirtualGrid<T>({
-  estimateRowHeight = 240,
+  estimateRowHeight = 320,
   items,
   renderItem,
   testId = "virtual-grid",
@@ -23,6 +24,7 @@ export default function VirtualGrid<T>({
   const virtualizer = useWindowVirtualizer({
     count: rowCount,
     estimateSize: () => estimateRowHeight,
+    gap: ROW_GAP,
     overscan: 3,
   });
 
@@ -42,7 +44,9 @@ export default function VirtualGrid<T>({
           return (
             <div
               className={GRID_CLASSES}
+              data-index={virtualRow.index}
               key={virtualRow.key}
+              ref={virtualizer.measureElement}
               style={{
                 left: 0,
                 position: "absolute",


### PR DESCRIPTION
## Summary

- Ajoute `gap: 12px` vertical entre les lignes via le virtualizer
- Utilise `measureElement` pour mesurer la hauteur réelle des lignes au lieu d'une estimation fixe
- Corrige `gap-3` → `gap-x-3` (horizontal uniquement, le vertical est géré par le virtualizer)

## Test plan

- [x] 698/698 tests passent
- [x] TypeScript clean
- [ ] Vérifier visuellement que les cartes ne se chevauchent plus et ont un espacement correct

#264