### PR TITLE
fix(frontend): la modification d'une série est écrasée par un refetch obsolète

### DIFF
--- a/frontend/src/__tests__/integration/hooks/useUpdateComic.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useUpdateComic.test.tsx
@@ -57,21 +57,16 @@ describe("useUpdateComic", () => {
     expect(result.current.data?.title).toBe("Updated Title");
   });
 
-  it("invalidates comics and comic queries on success", async () => {
+  it("updates collection via setQueryData and invalidates comic detail on success", async () => {
     const queryClient = createTestQueryClient();
+    const oldComic = createMockComicSeries({ id: 3, title: "Old" });
+    const newComic = createMockComicSeries({ id: 3, title: "New" });
 
-    queryClient.setQueryData(["comics"], createMockHydraCollection([]));
-    queryClient.setQueryData(
-      ["comic", 3],
-      createMockComicSeries({ id: 3, title: "Old" }),
-    );
+    queryClient.setQueryData(["comics"], createMockHydraCollection([oldComic]));
+    queryClient.setQueryData(["comic", 3], oldComic);
 
     server.use(
-      http.patch("/api/comic_series/3", () =>
-        HttpResponse.json(
-          createMockComicSeries({ id: 3, title: "New" }),
-        ),
-      ),
+      http.patch("/api/comic_series/3", () => HttpResponse.json(newComic)),
     );
 
     const { result } = renderHook(() => useUpdateComic(), {
@@ -84,28 +79,28 @@ describe("useUpdateComic", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(queryClient.getQueryState(["comics"])?.isInvalidated).toBe(true);
+    // Collection should NOT be invalidated (updated via setQueryData instead)
+    expect(queryClient.getQueryState(["comics"])?.isInvalidated).toBe(false);
+    // Collection should contain the server response
+    const collection = queryClient.getQueryData<{ member: { id: number; title: string }[] }>(["comics"]);
+    expect(collection?.member.find((c) => c.id === 3)?.title).toBe("New");
+    // Detail should be invalidated for fresh refetch
     expect(queryClient.getQueryState(["comic", 3])?.isInvalidated).toBe(true);
   });
 
   it("does not invalidate unrelated comic detail queries", async () => {
     const queryClient = createTestQueryClient();
 
-    queryClient.setQueryData(["comics"], createMockHydraCollection([]));
-    queryClient.setQueryData(
-      ["comic", 3],
+    queryClient.setQueryData(["comics"], createMockHydraCollection([
       createMockComicSeries({ id: 3, title: "Target" }),
-    );
-    queryClient.setQueryData(
-      ["comic", 5],
       createMockComicSeries({ id: 5, title: "Other" }),
-    );
+    ]));
+    queryClient.setQueryData(["comic", 3], createMockComicSeries({ id: 3, title: "Target" }));
+    queryClient.setQueryData(["comic", 5], createMockComicSeries({ id: 5, title: "Other" }));
 
     server.use(
       http.patch("/api/comic_series/3", () =>
-        HttpResponse.json(
-          createMockComicSeries({ id: 3, title: "Updated" }),
-        ),
+        HttpResponse.json(createMockComicSeries({ id: 3, title: "Updated" })),
       ),
     );
 

--- a/frontend/src/hooks/useUpdateComic.ts
+++ b/frontend/src/hooks/useUpdateComic.ts
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { apiFetch } from "../services/api";
 import type { ComicSeries, HydraCollection } from "../types/api";
 import { useOfflineMutation } from "./useOfflineMutation";
@@ -16,6 +17,8 @@ function safeOptimisticFields(variables: Record<string, unknown>): Partial<Comic
 }
 
 export function useUpdateComic() {
+  const qc = useQueryClient();
+
   return useOfflineMutation<ComicSeries, Partial<ComicSeries> & { id: number } & Record<string, unknown>>({
     mutationFn: ({ id, ...data }) =>
       apiFetch<ComicSeries>(`/comic_series/${id}`, {
@@ -26,10 +29,22 @@ export function useUpdateComic() {
     offlineOperation: "update",
     offlineResourceId: (v) => String(v.id),
     offlineResourceType: "comic_series",
-    optimisticUpdate: (qc, variables) => {
+    onSuccess: (data, variables) => {
+      // Mettre à jour la collection avec la réponse serveur (pas de refetch)
+      qc.setQueryData<HydraCollection<ComicSeries>>(["comics"], (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          member: old.member.map((c) =>
+            c.id === variables.id ? { ...data, _syncPending: false } : c,
+          ),
+        };
+      });
+    },
+    optimisticUpdate: (queryClient, variables) => {
       const safeFields = safeOptimisticFields(variables);
       // Mettre à jour dans la liste
-      qc.setQueryData<HydraCollection<ComicSeries>>(["comics"], (old) => {
+      queryClient.setQueryData<HydraCollection<ComicSeries>>(["comics"], (old) => {
         if (!old) return old;
         return {
           ...old,
@@ -39,11 +54,11 @@ export function useUpdateComic() {
         };
       });
       // Mettre à jour dans le détail
-      qc.setQueryData<ComicSeries>(["comic", variables.id], (old) => {
+      queryClient.setQueryData<ComicSeries>(["comic", variables.id], (old) => {
         if (!old) return old;
         return { ...old, ...safeFields, _syncPending: true };
       });
     },
-    queryKeysToInvalidate: (variables) => [["comics"], ["comic", variables.id]],
+    queryKeysToInvalidate: (variables) => [["comic", variables.id]],
   });
 }


### PR DESCRIPTION
## Summary

- **`useUpdateComic`** : remplace `invalidateQueries(["comics"])` par `setQueryData` avec la réponse serveur — la collection est mise à jour directement sans refetch
- Seul `["comic", id]` est invalidé pour rafraîchir la page détail
- Corrige le bug où un refetch background retournait des données obsolètes et écrasait la modification

**Cause** : après un PATCH, l'invalidation de `["comics"]` déclenchait un refetch complet de la collection. Ce refetch retournait des données obsolètes (cache SW/backend), écrasant l'update optimiste après quelques secondes.

## Test plan

- [x] 698/698 tests passent
- [x] TypeScript clean
- [ ] Modifier le titre d'une série → retour à l'accueil → la modification persiste

#266