### PR TITLE
Refactor : centraliser query keys et endpoints API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Frontend** : Centralisation des query keys (`queryKeys.ts`) et des endpoints API (`endpoints.ts`) — supprime les chaînes éparpillées dans 20+ hooks et 12 fichiers de tests
+
 ## [v2.12.0] - 2026-03-16
 
 ### Changed

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { ErrorBoundary } from "react-error-boundary";
 import { createBrowserRouter, createRoutesFromElements, Outlet, Route, RouterProvider, useLocation } from "react-router-dom";
 import { Toaster } from "sonner";
 import AuthGuard from "./components/AuthGuard";
+import { queryKeys } from "./queryKeys";
 import ErrorFallback from "./components/ErrorFallback";
 import Layout from "./components/Layout";
 import Home from "./pages/Home";
@@ -120,7 +121,7 @@ export default function App() {
             dehydrateOptions: {
               shouldDehydrateQuery: (query) => {
                 const key = query.queryKey[0];
-                return key === "comics" || key === "comic";
+                return key === queryKeys.comics.all[0] || key === queryKeys.comics.detailPrefix[0];
               },
             },
             maxAge: 60 * 60 * 1000,

--- a/frontend/src/__tests__/integration/hooks/useComic.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useComic.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from "msw";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { useComic } from "../../../hooks/useComic";
+import { queryKeys } from "../../../queryKeys";
 import { createTestQueryClient } from "../../helpers/test-utils";
 import {
   createMockComicSeries,
@@ -81,7 +82,7 @@ describe("useComic", () => {
 
     // Pre-populate comics collection
     queryClient.setQueryData(
-      ["comics"],
+      queryKeys.comics.all,
       createMockHydraCollection([comic]),
     );
 
@@ -100,7 +101,7 @@ describe("useComic", () => {
 
     // Pre-populate comics collection with a different comic
     queryClient.setQueryData(
-      ["comics"],
+      queryKeys.comics.all,
       createMockHydraCollection([otherComic]),
     );
 

--- a/frontend/src/__tests__/integration/hooks/useComics.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useComics.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from "msw";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { useComics } from "../../../hooks/useComics";
+import { queryKeys } from "../../../queryKeys";
 import { createTestQueryClient } from "../../helpers/test-utils";
 import {
   createMockComicSeries,
@@ -109,7 +110,7 @@ describe("useComics", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const cachedComic = queryClient.getQueryData(["comic", 42]);
+    const cachedComic = queryClient.getQueryData(queryKeys.comics.detail(42));
     expect(cachedComic).toEqual(series);
   });
 });

--- a/frontend/src/__tests__/integration/hooks/useCreateComic.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useCreateComic.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from "msw";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { useCreateComic } from "../../../hooks/useCreateComic";
+import { queryKeys } from "../../../queryKeys";
 import { createTestQueryClient } from "../../helpers/test-utils";
 import {
   createMockComicSeries,
@@ -57,7 +58,7 @@ describe("useCreateComic", () => {
     const queryClient = createTestQueryClient();
 
     // Pre-populate cache
-    queryClient.setQueryData(["comics"], createMockHydraCollection([]));
+    queryClient.setQueryData(queryKeys.comics.all, createMockHydraCollection([]));
 
     server.use(
       http.post("/api/comic_series", () =>
@@ -79,7 +80,7 @@ describe("useCreateComic", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     // Cache should be invalidated
-    const state = queryClient.getQueryState(["comics"]);
+    const state = queryClient.getQueryState(queryKeys.comics.all);
     expect(state?.isInvalidated).toBe(true);
   });
 

--- a/frontend/src/__tests__/integration/hooks/useCreateTome.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useCreateTome.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from "msw";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { useCreateTome } from "../../../hooks/useCreateTome";
+import { queryKeys } from "../../../queryKeys";
 import { createTestQueryClient } from "../../helpers/test-utils";
 import { createMockComicSeries, createMockTome } from "../../helpers/factories";
 import { server } from "../../helpers/server";
@@ -80,7 +81,7 @@ describe("useCreateTome", () => {
 
     const queryClient = createTestQueryClient();
     const series = createMockComicSeries({ id: 5, tomes: [] });
-    queryClient.setQueryData(["comic", 5], series);
+    queryClient.setQueryData(queryKeys.comics.detail(5), series);
 
     const { result } = renderHook(() => useCreateTome(5), {
       wrapper: createWrapper(queryClient),
@@ -92,7 +93,7 @@ describe("useCreateTome", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const cached = queryClient.getQueryData<typeof series>(["comic", 5]);
+    const cached = queryClient.getQueryData<typeof series>(queryKeys.comics.detail(5));
     expect(cached?.tomes).toHaveLength(1);
     expect(cached?.tomes[0].number).toBe(3);
     expect(cached?.tomes[0]._syncPending).toBe(true);

--- a/frontend/src/__tests__/integration/hooks/useDeleteComic.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useDeleteComic.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from "msw";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { useDeleteComic } from "../../../hooks/useDeleteComic";
+import { queryKeys } from "../../../queryKeys";
 import { enqueue } from "../../../services/offlineQueue";
 import { createTestQueryClient } from "../../helpers/test-utils";
 import { createMockHydraCollection } from "../../helpers/factories";
@@ -55,9 +56,9 @@ describe("useDeleteComic", () => {
   it("invalidates comics and trash queries on success", async () => {
     const queryClient = createTestQueryClient();
 
-    queryClient.setQueryData(["comics"], createMockHydraCollection([]));
+    queryClient.setQueryData(queryKeys.comics.all, createMockHydraCollection([]));
     queryClient.setQueryData(
-      ["trash"],
+      queryKeys.trash.all,
       createMockHydraCollection([], "/api/trash"),
     );
 
@@ -77,8 +78,8 @@ describe("useDeleteComic", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(queryClient.getQueryState(["comics"])?.isInvalidated).toBe(true);
-    expect(queryClient.getQueryState(["trash"])?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(queryKeys.comics.all)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(queryKeys.trash.all)?.isInvalidated).toBe(true);
   });
 
   it("handles API error", async () => {

--- a/frontend/src/__tests__/integration/hooks/useDeleteTome.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useDeleteTome.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from "msw";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { useDeleteTome } from "../../../hooks/useDeleteTome";
+import { queryKeys } from "../../../queryKeys";
 import { createTestQueryClient } from "../../helpers/test-utils";
 import { createMockComicSeries, createMockTome } from "../../helpers/factories";
 import { server } from "../../helpers/server";
@@ -79,7 +80,7 @@ describe("useDeleteTome", () => {
     const queryClient = createTestQueryClient();
     const tome = createMockTome({ id: 10, number: 1 });
     const series = createMockComicSeries({ id: 5, tomes: [tome] });
-    queryClient.setQueryData(["comic", 5], series);
+    queryClient.setQueryData(queryKeys.comics.detail(5), series);
 
     const { result } = renderHook(() => useDeleteTome(5), {
       wrapper: createWrapper(queryClient),
@@ -91,7 +92,7 @@ describe("useDeleteTome", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const cached = queryClient.getQueryData<typeof series>(["comic", 5]);
+    const cached = queryClient.getQueryData<typeof series>(queryKeys.comics.detail(5));
     expect(cached?.tomes).toHaveLength(0);
   });
 });

--- a/frontend/src/__tests__/integration/hooks/useMergeSeries.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useMergeSeries.test.tsx
@@ -9,6 +9,7 @@ import {
   useMergePreview,
   useMergeSuggest,
 } from "../../../hooks/useMergeSeries";
+import { queryKeys } from "../../../queryKeys";
 import type { MergePreview } from "../../../types/api";
 import { createMockHydraCollection } from "../../helpers/factories";
 import { server } from "../../helpers/server";
@@ -168,7 +169,7 @@ describe("useMergeSeries", () => {
       );
 
       const queryClient = createTestQueryClient();
-      queryClient.setQueryData(["comics"], createMockHydraCollection([]));
+      queryClient.setQueryData(queryKeys.comics.all, createMockHydraCollection([]));
 
       const preview: MergePreview = {
         amazonUrl: null,
@@ -207,7 +208,7 @@ describe("useMergeSeries", () => {
         title: "Astérix",
         type: "BD",
       });
-      expect(queryClient.getQueryState(["comics"])?.isInvalidated).toBe(true);
+      expect(queryClient.getQueryState(queryKeys.comics.all)?.isInvalidated).toBe(true);
     });
   });
 });

--- a/frontend/src/__tests__/integration/hooks/useOfflineMutation.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useOfflineMutation.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from "react-router-dom";
 import { toast } from "sonner";
 import { useCreateComic } from "../../../hooks/useCreateComic";
 import { useUpdateComic } from "../../../hooks/useUpdateComic";
+import { queryKeys } from "../../../queryKeys";
 import { createTestQueryClient } from "../../helpers/test-utils";
 import { createMockComicSeries } from "../../helpers/factories";
 import { server } from "../../helpers/server";
@@ -248,7 +249,7 @@ describe("useOfflineMutation", () => {
           offlineOperation: "create" as const,
           offlineResourceType: "comic_series" as const,
           onOfflineSuccess,
-          queryKeysToInvalidate: [["comics"]],
+          queryKeysToInvalidate: [queryKeys.comics.all],
         }),
       { wrapper: createWrapper() },
     );
@@ -351,7 +352,7 @@ describe("useOfflineMutation", () => {
     });
 
     const queryClient = createTestQueryClient();
-    queryClient.setQueryData(["comics"], { member: [], totalItems: 0 });
+    queryClient.setQueryData(queryKeys.comics.all, { member: [], totalItems: 0 });
 
     const { result } = renderHook(() => useCreateComic(), {
       wrapper: createWrapper(queryClient),
@@ -364,6 +365,6 @@ describe("useOfflineMutation", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     // Should NOT invalidate when offline
-    expect(queryClient.getQueryState(["comics"])?.isInvalidated).toBe(false);
+    expect(queryClient.getQueryState(queryKeys.comics.all)?.isInvalidated).toBe(false);
   });
 });

--- a/frontend/src/__tests__/integration/hooks/useTrash.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useTrash.test.tsx
@@ -8,6 +8,7 @@ import {
   useRestoreComic,
   usePermanentDelete,
 } from "../../../hooks/useTrash";
+import { queryKeys } from "../../../queryKeys";
 import { enqueue } from "../../../services/offlineQueue";
 import { createTestQueryClient } from "../../helpers/test-utils";
 import {
@@ -146,8 +147,8 @@ describe("useRestoreComic", () => {
   it("invalidates trash and comics queries on success", async () => {
     const queryClient = createTestQueryClient();
 
-    queryClient.setQueryData(["trash"], createMockHydraCollection([], "/api/trash"));
-    queryClient.setQueryData(["comics"], createMockHydraCollection([]));
+    queryClient.setQueryData(queryKeys.trash.all, createMockHydraCollection([], "/api/trash"));
+    queryClient.setQueryData(queryKeys.comics.all, createMockHydraCollection([]));
 
     server.use(
       http.put("/api/comic_series/7/restore", () =>
@@ -165,8 +166,8 @@ describe("useRestoreComic", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(queryClient.getQueryState(["trash"])?.isInvalidated).toBe(true);
-    expect(queryClient.getQueryState(["comics"])?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(queryKeys.trash.all)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(queryKeys.comics.all)?.isInvalidated).toBe(true);
   });
 });
 
@@ -201,7 +202,7 @@ describe("usePermanentDelete", () => {
   it("invalidates trash queries on success", async () => {
     const queryClient = createTestQueryClient();
 
-    queryClient.setQueryData(["trash"], createMockHydraCollection([], "/api/trash"));
+    queryClient.setQueryData(queryKeys.trash.all, createMockHydraCollection([], "/api/trash"));
 
     server.use(
       http.delete("/api/trash/9/permanent", () =>
@@ -219,7 +220,7 @@ describe("usePermanentDelete", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(queryClient.getQueryState(["trash"])?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(queryKeys.trash.all)?.isInvalidated).toBe(true);
   });
 
   it("returns error on failed DELETE", async () => {

--- a/frontend/src/__tests__/integration/hooks/useUpdateComic.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useUpdateComic.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from "msw";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { useUpdateComic } from "../../../hooks/useUpdateComic";
+import { queryKeys } from "../../../queryKeys";
 import { enqueue } from "../../../services/offlineQueue";
 import { createTestQueryClient } from "../../helpers/test-utils";
 import {
@@ -62,8 +63,8 @@ describe("useUpdateComic", () => {
     const oldComic = createMockComicSeries({ id: 3, title: "Old" });
     const newComic = createMockComicSeries({ id: 3, title: "New" });
 
-    queryClient.setQueryData(["comics"], createMockHydraCollection([oldComic]));
-    queryClient.setQueryData(["comic", 3], oldComic);
+    queryClient.setQueryData(queryKeys.comics.all, createMockHydraCollection([oldComic]));
+    queryClient.setQueryData(queryKeys.comics.detail(3), oldComic);
 
     server.use(
       http.patch("/api/comic_series/3", () => HttpResponse.json(newComic)),
@@ -80,23 +81,23 @@ describe("useUpdateComic", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     // Collection should NOT be invalidated (updated via setQueryData instead)
-    expect(queryClient.getQueryState(["comics"])?.isInvalidated).toBe(false);
+    expect(queryClient.getQueryState(queryKeys.comics.all)?.isInvalidated).toBe(false);
     // Collection should contain the server response
-    const collection = queryClient.getQueryData<{ member: { id: number; title: string }[] }>(["comics"]);
+    const collection = queryClient.getQueryData<{ member: { id: number; title: string }[] }>(queryKeys.comics.all);
     expect(collection?.member.find((c) => c.id === 3)?.title).toBe("New");
     // Detail should be invalidated for fresh refetch
-    expect(queryClient.getQueryState(["comic", 3])?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(queryKeys.comics.detail(3))?.isInvalidated).toBe(true);
   });
 
   it("does not invalidate unrelated comic detail queries", async () => {
     const queryClient = createTestQueryClient();
 
-    queryClient.setQueryData(["comics"], createMockHydraCollection([
+    queryClient.setQueryData(queryKeys.comics.all, createMockHydraCollection([
       createMockComicSeries({ id: 3, title: "Target" }),
       createMockComicSeries({ id: 5, title: "Other" }),
     ]));
-    queryClient.setQueryData(["comic", 3], createMockComicSeries({ id: 3, title: "Target" }));
-    queryClient.setQueryData(["comic", 5], createMockComicSeries({ id: 5, title: "Other" }));
+    queryClient.setQueryData(queryKeys.comics.detail(3), createMockComicSeries({ id: 3, title: "Target" }));
+    queryClient.setQueryData(queryKeys.comics.detail(5), createMockComicSeries({ id: 5, title: "Other" }));
 
     server.use(
       http.patch("/api/comic_series/3", () =>
@@ -115,9 +116,9 @@ describe("useUpdateComic", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     // comic 3 should be invalidated (targeted)
-    expect(queryClient.getQueryState(["comic", 3])?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(queryKeys.comics.detail(3))?.isInvalidated).toBe(true);
     // comic 5 should NOT be invalidated (not related)
-    expect(queryClient.getQueryState(["comic", 5])?.isInvalidated).toBe(false);
+    expect(queryClient.getQueryState(queryKeys.comics.detail(5))?.isInvalidated).toBe(false);
   });
 
   it("handles API error", async () => {

--- a/frontend/src/__tests__/integration/hooks/useUpdateTome.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useUpdateTome.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from "msw";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { useUpdateTome } from "../../../hooks/useUpdateTome";
+import { queryKeys } from "../../../queryKeys";
 import { enqueue } from "../../../services/offlineQueue";
 import { createTestQueryClient } from "../../helpers/test-utils";
 import {
@@ -66,7 +67,7 @@ describe("useUpdateTome", () => {
     const queryClient = createTestQueryClient();
 
     queryClient.setQueryData(
-      ["comic", 1],
+      queryKeys.comics.detail(1),
       createMockComicSeries({ id: 1, title: "Test" }),
     );
 
@@ -86,7 +87,7 @@ describe("useUpdateTome", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(queryClient.getQueryState(["comic", 1])?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(queryKeys.comics.detail(1))?.isInvalidated).toBe(true);
   });
 
   it("handles API error", async () => {

--- a/frontend/src/__tests__/integration/pages/ToBuy.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ToBuy.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from "@testing-library/react";
+import { queryKeys } from "../../../queryKeys";
 import type { ComicSeries } from "../../../types/api";
 import { createTestQueryClient, renderWithProviders } from "../../helpers/test-utils";
 import ToBuy from "../../../pages/ToBuy";
@@ -49,7 +50,7 @@ function makeSeries(id: number, title: string, overrides: Partial<ComicSeries> =
 
 function renderWithComics(comics: ComicSeries[]) {
   const queryClient = createTestQueryClient();
-  queryClient.setQueryData(["comics"], {
+  queryClient.setQueryData(queryKeys.comics.all, {
     "@context": "/api/contexts/ComicSeries",
     "@id": "/api/comics",
     "@type": "Collection",

--- a/frontend/src/__tests__/unit/endpoints.test.ts
+++ b/frontend/src/__tests__/unit/endpoints.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { endpoints } from "../../endpoints";
+
+describe("endpoints", () => {
+  describe("authors", () => {
+    it("retourne le chemin de base", () => {
+      expect(endpoints.authors).toBe("/authors");
+    });
+  });
+
+  describe("batchLookup", () => {
+    it("retourne le chemin preview", () => {
+      expect(endpoints.batchLookup.preview).toBe("/tools/batch-lookup/preview");
+    });
+
+    it("retourne le chemin run", () => {
+      expect(endpoints.batchLookup.run).toBe("/tools/batch-lookup/run");
+    });
+  });
+
+  describe("comicSeries", () => {
+    it("retourne le chemin de collection", () => {
+      expect(endpoints.comicSeries.collection).toBe("/comic_series");
+    });
+
+    it("retourne le chemin de détail", () => {
+      expect(endpoints.comicSeries.detail(42)).toBe("/comic_series/42");
+    });
+
+    it("retourne le chemin de restauration", () => {
+      expect(endpoints.comicSeries.restore(7)).toBe("/comic_series/7/restore");
+    });
+
+    it("retourne le chemin des tomes", () => {
+      expect(endpoints.comicSeries.tomes(7)).toBe("/comic_series/7/tomes");
+    });
+  });
+
+  describe("import", () => {
+    it("retourne le chemin books", () => {
+      expect(endpoints.import.books).toBe("/tools/import/books");
+    });
+
+    it("retourne le chemin excel", () => {
+      expect(endpoints.import.excel).toBe("/tools/import/excel");
+    });
+  });
+
+  describe("login", () => {
+    it("retourne le chemin google", () => {
+      expect(endpoints.login.google).toBe("/login/google");
+    });
+  });
+
+  describe("lookup", () => {
+    it("retourne le chemin covers", () => {
+      expect(endpoints.lookup.covers).toBe("/lookup/covers");
+    });
+
+    it("retourne le chemin isbn", () => {
+      expect(endpoints.lookup.isbn).toBe("/lookup/isbn");
+    });
+
+    it("retourne le chemin title", () => {
+      expect(endpoints.lookup.title).toBe("/lookup/title");
+    });
+  });
+
+  describe("mergeSeries", () => {
+    it("retourne le chemin detect", () => {
+      expect(endpoints.mergeSeries.detect).toBe("/merge-series/detect");
+    });
+
+    it("retourne le chemin execute", () => {
+      expect(endpoints.mergeSeries.execute).toBe("/merge-series/execute");
+    });
+
+    it("retourne le chemin preview", () => {
+      expect(endpoints.mergeSeries.preview).toBe("/merge-series/preview");
+    });
+
+    it("retourne le chemin suggest", () => {
+      expect(endpoints.mergeSeries.suggest).toBe("/merge-series/suggest");
+    });
+  });
+
+  describe("purge", () => {
+    it("retourne le chemin execute", () => {
+      expect(endpoints.purge.execute).toBe("/tools/purge/execute");
+    });
+
+    it("retourne le chemin preview", () => {
+      expect(endpoints.purge.preview).toBe("/tools/purge/preview");
+    });
+  });
+
+  describe("tomes", () => {
+    it("retourne le chemin de détail", () => {
+      expect(endpoints.tomes.detail(99)).toBe("/tomes/99");
+    });
+  });
+
+  describe("trash", () => {
+    it("retourne le chemin de collection", () => {
+      expect(endpoints.trash.collection).toBe("/trash");
+    });
+
+    it("retourne le chemin de suppression permanente", () => {
+      expect(endpoints.trash.permanent(5)).toBe("/trash/5/permanent");
+    });
+  });
+});

--- a/frontend/src/__tests__/unit/queryKeys.test.ts
+++ b/frontend/src/__tests__/unit/queryKeys.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { queryKeys } from "../../queryKeys";
+
+describe("queryKeys", () => {
+  describe("authors", () => {
+    it("retourne la clé de recherche avec le terme", () => {
+      expect(queryKeys.authors.search("Urasawa")).toEqual(["authors", "Urasawa"]);
+    });
+  });
+
+  describe("batchLookup", () => {
+    it("retourne la clé de preview avec type et force", () => {
+      expect(queryKeys.batchLookup.preview("manga", true)).toEqual([
+        "batch-lookup-preview", "manga", true,
+      ]);
+    });
+
+    it("retourne la clé de preview avec valeurs par défaut", () => {
+      expect(queryKeys.batchLookup.preview("", false)).toEqual([
+        "batch-lookup-preview", "", false,
+      ]);
+    });
+  });
+
+  describe("comics", () => {
+    it("retourne la clé de collection", () => {
+      expect(queryKeys.comics.all).toEqual(["comics"]);
+    });
+
+    it("retourne la clé de détail avec l'id", () => {
+      expect(queryKeys.comics.detail(42)).toEqual(["comic", 42]);
+    });
+
+    it("retourne la clé de détail avec undefined", () => {
+      expect(queryKeys.comics.detail(undefined)).toEqual(["comic", undefined]);
+    });
+
+    it("retourne le préfixe pour l'invalidation en masse", () => {
+      expect(queryKeys.comics.detailPrefix).toEqual(["comic"]);
+    });
+  });
+
+  describe("lookup", () => {
+    it("retourne la clé ISBN", () => {
+      expect(queryKeys.lookup.isbn("978-2-1234", "bd")).toEqual([
+        "lookup", "isbn", "978-2-1234", "bd",
+      ]);
+    });
+
+    it("retourne la clé titre", () => {
+      expect(queryKeys.lookup.title("Naruto", "manga")).toEqual([
+        "lookup", "title", "Naruto", "manga",
+      ]);
+    });
+
+    it("retourne la clé candidats titre", () => {
+      expect(queryKeys.lookup.titleCandidates("Naruto", "manga", 5)).toEqual([
+        "lookup", "title-candidates", "Naruto", "manga", 5,
+      ]);
+    });
+
+    it("retourne la clé covers", () => {
+      expect(queryKeys.lookup.covers("Naruto", "manga")).toEqual([
+        "lookup", "covers", "Naruto", "manga",
+      ]);
+    });
+  });
+
+  describe("offline", () => {
+    it("retourne la clé du compteur de queue", () => {
+      expect(queryKeys.offline.queueCount).toEqual(["offline-queue-count"]);
+    });
+
+    it("retourne la clé des échecs de sync", () => {
+      expect(queryKeys.offline.syncFailures).toEqual(["syncFailures"]);
+    });
+  });
+
+  describe("purge", () => {
+    it("retourne la clé de preview avec le nombre de jours", () => {
+      expect(queryKeys.purge.preview(30)).toEqual(["purge-preview", 30]);
+    });
+  });
+
+  describe("trash", () => {
+    it("retourne la clé de collection", () => {
+      expect(queryKeys.trash.all).toEqual(["trash"]);
+    });
+  });
+});

--- a/frontend/src/endpoints.ts
+++ b/frontend/src/endpoints.ts
@@ -1,0 +1,42 @@
+export const endpoints = {
+  authors: "/authors",
+  batchLookup: {
+    preview: "/tools/batch-lookup/preview",
+    run: "/tools/batch-lookup/run",
+  },
+  comicSeries: {
+    collection: "/comic_series",
+    detail: (id: number) => `/comic_series/${id}`,
+    restore: (id: number) => `/comic_series/${id}/restore`,
+    tomes: (seriesId: number) => `/comic_series/${seriesId}/tomes`,
+  },
+  import: {
+    books: "/tools/import/books",
+    excel: "/tools/import/excel",
+  },
+  login: {
+    google: "/login/google",
+  },
+  lookup: {
+    covers: "/lookup/covers",
+    isbn: "/lookup/isbn",
+    title: "/lookup/title",
+  },
+  mergeSeries: {
+    detect: "/merge-series/detect",
+    execute: "/merge-series/execute",
+    preview: "/merge-series/preview",
+    suggest: "/merge-series/suggest",
+  },
+  purge: {
+    execute: "/tools/purge/execute",
+    preview: "/tools/purge/preview",
+  },
+  tomes: {
+    detail: (id: number) => `/tomes/${id}`,
+  },
+  trash: {
+    collection: "/trash",
+    permanent: (id: number) => `/trash/${id}/permanent`,
+  },
+} as const;

--- a/frontend/src/hooks/useAuthors.ts
+++ b/frontend/src/hooks/useAuthors.ts
@@ -1,4 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { Author, HydraCollection } from "../types/api";
 
@@ -7,7 +9,7 @@ export function useAuthors(search: string = "") {
 
   return useQuery({
     enabled: search.length >= 1,
-    queryFn: () => apiFetch<HydraCollection<Author>>(`/authors${params}`),
-    queryKey: ["authors", search],
+    queryFn: () => apiFetch<HydraCollection<Author>>(`${endpoints.authors}${params}`),
+    queryKey: queryKeys.authors.search(search),
   });
 }

--- a/frontend/src/hooks/useBatchLookup.ts
+++ b/frontend/src/hooks/useBatchLookup.ts
@@ -1,6 +1,8 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch, fetchSSE } from "../services/api";
 import type { BatchLookupProgress, BatchLookupSummary } from "../types/api";
 
@@ -16,9 +18,9 @@ export function useBatchLookupPreview(
   return useQuery({
     queryFn: () =>
       apiFetch<{ count: number }>(
-        `/tools/batch-lookup/preview${qs ? `?${qs}` : ""}`,
+        `${endpoints.batchLookup.preview}${qs ? `?${qs}` : ""}`,
       ),
-    queryKey: ["batch-lookup-preview", type ?? "", force],
+    queryKey: queryKeys.batchLookup.preview(type ?? "", force),
   });
 }
 
@@ -57,7 +59,7 @@ export function useBatchLookup(): BatchLookupState {
       setSummary(null);
 
       void fetchSSE<BatchLookupProgress, BatchLookupSummary>(
-        "/tools/batch-lookup/run",
+        endpoints.batchLookup.run,
         options,
         (data) => {
           setProgress((prev) => [...prev, data]);
@@ -66,9 +68,9 @@ export function useBatchLookup(): BatchLookupState {
           setSummary(data);
           setIsRunning(false);
           abortRef.current = null;
-          queryClient.invalidateQueries({ queryKey: ["comics"] });
+          queryClient.invalidateQueries({ queryKey: queryKeys.comics.all });
           queryClient.invalidateQueries({
-            queryKey: ["batch-lookup-preview"],
+            queryKey: queryKeys.batchLookup.previewPrefix,
           });
         },
         (error) => {

--- a/frontend/src/hooks/useComic.ts
+++ b/frontend/src/hooks/useComic.ts
@@ -1,4 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { ComicSeries, HydraCollection } from "../types/api";
 
@@ -9,12 +11,12 @@ export function useComic(id: number | undefined) {
     enabled: id !== undefined,
     initialData: () => {
       // Extraire depuis la collection déjà chargée (navigation hors ligne)
-      const collection = queryClient.getQueryData<HydraCollection<ComicSeries>>(["comics"]);
+      const collection = queryClient.getQueryData<HydraCollection<ComicSeries>>(queryKeys.comics.all);
       return collection?.member.find((s) => s.id === id);
     },
     initialDataUpdatedAt: () =>
-      queryClient.getQueryState(["comics"])?.dataUpdatedAt,
-    queryFn: () => apiFetch<ComicSeries>(`/comic_series/${id}`),
-    queryKey: ["comic", id],
+      queryClient.getQueryState(queryKeys.comics.all)?.dataUpdatedAt,
+    queryFn: () => apiFetch<ComicSeries>(endpoints.comicSeries.detail(id!)),
+    queryKey: queryKeys.comics.detail(id),
   });
 }

--- a/frontend/src/hooks/useComicForm.ts
+++ b/frontend/src/hooks/useComicForm.ts
@@ -8,6 +8,7 @@ import { useCreateComic } from "./useCreateComic";
 import { fetchLookupIsbn, fetchLookupTitle, useLookupIsbn, useLookupTitle, useLookupTitleCandidates } from "./useLookup";
 import { useSyncFailures } from "./useSyncFailures";
 import { useUpdateComic } from "./useUpdateComic";
+import { endpoints } from "../endpoints";
 import { apiFetch } from "../services/api";
 import type { Author, ComicSeries } from "../types/api";
 import { ComicStatus, ComicType } from "../types/enums";
@@ -294,7 +295,7 @@ export function useComicForm() {
         pendingAuthors.push(a.name);
       } else {
         try {
-          const created = await apiFetch<Author>("/authors", {
+          const created = await apiFetch<Author>(endpoints.authors, {
             body: JSON.stringify({ name: a.name }),
             method: "POST",
           });

--- a/frontend/src/hooks/useComics.ts
+++ b/frontend/src/hooks/useComics.ts
@@ -1,4 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { ComicSeries, HydraCollection } from "../types/api";
 
@@ -8,14 +10,14 @@ export function useComics() {
   return useQuery({
     queryFn: async () => {
       const data =
-        await apiFetch<HydraCollection<ComicSeries>>("/comic_series");
+        await apiFetch<HydraCollection<ComicSeries>>(endpoints.comicSeries.collection);
       // Seeder le cache individuel pour la navigation hors ligne
       data.member.forEach((series) => {
-        queryClient.setQueryData(["comic", series.id], series);
+        queryClient.setQueryData(queryKeys.comics.detail(series.id), series);
       });
       return data;
     },
-    queryKey: ["comics"],
+    queryKey: queryKeys.comics.all,
     staleTime: 30 * 60 * 1000,
   });
 }

--- a/frontend/src/hooks/useCoverSearch.ts
+++ b/frontend/src/hooks/useCoverSearch.ts
@@ -1,4 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { CoverSearchResult } from "../types/api";
 
@@ -8,8 +10,8 @@ export function useCoverSearch(query: string, type?: string) {
 
   return useQuery({
     enabled: query.length >= 2,
-    queryFn: () => apiFetch<CoverSearchResult[]>(`/lookup/covers?${params}`),
-    queryKey: ["lookup", "covers", query, type],
+    queryFn: () => apiFetch<CoverSearchResult[]>(`${endpoints.lookup.covers}?${params}`),
+    queryKey: queryKeys.lookup.covers(query, type),
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/frontend/src/hooks/useCreateComic.ts
+++ b/frontend/src/hooks/useCreateComic.ts
@@ -1,3 +1,5 @@
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { ComicSeries, HydraCollection } from "../types/api";
 import { ComicStatus, ComicType } from "../types/enums";
@@ -7,14 +9,14 @@ export function useCreateComic() {
   return useOfflineMutation<ComicSeries, Partial<ComicSeries> & Record<string, unknown>>({
     generateTempId: true,
     mutationFn: (data) =>
-      apiFetch<ComicSeries>("/comic_series", {
+      apiFetch<ComicSeries>(endpoints.comicSeries.collection, {
         body: JSON.stringify(data),
         method: "POST",
       }),
     offlineOperation: "create",
     offlineResourceType: "comic_series",
     optimisticUpdate: (qc, variables, tempId) => {
-      qc.setQueryData<HydraCollection<ComicSeries>>(["comics"], (old) => {
+      qc.setQueryData<HydraCollection<ComicSeries>>(queryKeys.comics.all, (old) => {
         if (!old) return old;
         const tempSeries: ComicSeries = {
           "@id": `/api/comic_series/${tempId}`,
@@ -50,6 +52,6 @@ export function useCreateComic() {
         };
       });
     },
-    queryKeysToInvalidate: [["comics"]],
+    queryKeysToInvalidate: [queryKeys.comics.all],
   });
 }

--- a/frontend/src/hooks/useCreateTome.ts
+++ b/frontend/src/hooks/useCreateTome.ts
@@ -1,3 +1,5 @@
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { ComicSeries, Tome } from "../types/api";
 import { useOfflineMutation } from "./useOfflineMutation";
@@ -6,7 +8,7 @@ export function useCreateTome(seriesId: number) {
   return useOfflineMutation<Tome, Partial<Tome> & Record<string, unknown>>({
     generateTempId: true,
     mutationFn: (data) =>
-      apiFetch<Tome>(`/comic_series/${seriesId}/tomes`, {
+      apiFetch<Tome>(endpoints.comicSeries.tomes(seriesId), {
         body: JSON.stringify(data),
         method: "POST",
       }),
@@ -15,7 +17,7 @@ export function useCreateTome(seriesId: number) {
     offlineParentResourceType: "comic_series",
     offlineResourceType: "tome",
     optimisticUpdate: (qc, variables, tempId) => {
-      qc.setQueryData<ComicSeries>(["comic", seriesId], (old) => {
+      qc.setQueryData<ComicSeries>(queryKeys.comics.detail(seriesId), (old) => {
         if (!old) return old;
         const tempTome: Tome = {
           "@id": `/api/tomes/${tempId}`,
@@ -42,6 +44,6 @@ export function useCreateTome(seriesId: number) {
         };
       });
     },
-    queryKeysToInvalidate: [["comic", seriesId]],
+    queryKeysToInvalidate: [queryKeys.comics.detail(seriesId)],
   });
 }

--- a/frontend/src/hooks/useDeleteComic.ts
+++ b/frontend/src/hooks/useDeleteComic.ts
@@ -1,3 +1,5 @@
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { ComicSeries, HydraCollection } from "../types/api";
 import { useOfflineMutation } from "./useOfflineMutation";
@@ -5,12 +7,12 @@ import { useOfflineMutation } from "./useOfflineMutation";
 export function useDeleteComic() {
   return useOfflineMutation<unknown, { id: number }>({
     mutationFn: ({ id }) =>
-      apiFetch(`/comic_series/${id}`, { method: "DELETE" }),
+      apiFetch(endpoints.comicSeries.detail(id), { method: "DELETE" }),
     offlineOperation: "delete",
     offlineResourceId: (v) => String(v.id),
     offlineResourceType: "comic_series",
     optimisticUpdate: (qc, variables) => {
-      qc.setQueryData<HydraCollection<ComicSeries>>(["comics"], (old) => {
+      qc.setQueryData<HydraCollection<ComicSeries>>(queryKeys.comics.all, (old) => {
         if (!old) return old;
         return {
           ...old,
@@ -19,6 +21,6 @@ export function useDeleteComic() {
         };
       });
     },
-    queryKeysToInvalidate: (variables) => [["comics"], ["comic", variables.id], ["trash"]],
+    queryKeysToInvalidate: (variables) => [queryKeys.comics.all, queryKeys.comics.detail(variables.id), queryKeys.trash.all],
   });
 }

--- a/frontend/src/hooks/useDeleteTome.ts
+++ b/frontend/src/hooks/useDeleteTome.ts
@@ -1,3 +1,5 @@
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { ComicSeries } from "../types/api";
 import { useOfflineMutation } from "./useOfflineMutation";
@@ -5,14 +7,14 @@ import { useOfflineMutation } from "./useOfflineMutation";
 export function useDeleteTome(seriesId: number) {
   return useOfflineMutation<unknown, { id: number }>({
     mutationFn: ({ id }) =>
-      apiFetch(`/tomes/${id}`, { method: "DELETE" }),
+      apiFetch(endpoints.tomes.detail(id), { method: "DELETE" }),
     offlineOperation: "delete",
     offlineParentResourceId: String(seriesId),
     offlineParentResourceType: "comic_series",
     offlineResourceId: (v) => String(v.id),
     offlineResourceType: "tome",
     optimisticUpdate: (qc, variables) => {
-      qc.setQueryData<ComicSeries>(["comic", seriesId], (old) => {
+      qc.setQueryData<ComicSeries>(queryKeys.comics.detail(seriesId), (old) => {
         if (!old) return old;
         return {
           ...old,
@@ -20,6 +22,6 @@ export function useDeleteTome(seriesId: number) {
         };
       });
     },
-    queryKeysToInvalidate: [["comic", seriesId]],
+    queryKeysToInvalidate: [queryKeys.comics.detail(seriesId)],
   });
 }

--- a/frontend/src/hooks/useImport.ts
+++ b/frontend/src/hooks/useImport.ts
@@ -1,4 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { ImportBooksResult, ImportExcelResult } from "../types/api";
 
@@ -14,13 +16,13 @@ export function useImportExcel() {
 
   return useMutation({
     mutationFn: ({ dryRun, file }: { dryRun: boolean; file: File }) =>
-      apiFetch<ImportExcelResult>("/tools/import/excel", {
+      apiFetch<ImportExcelResult>(endpoints.import.excel, {
         body: buildFormData(file, dryRun),
         method: "POST",
       }),
     onSuccess: (_, variables) => {
       if (!variables.dryRun) {
-        queryClient.invalidateQueries({ queryKey: ["comics"] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.comics.all });
       }
     },
   });
@@ -31,13 +33,13 @@ export function useImportBooks() {
 
   return useMutation({
     mutationFn: ({ dryRun, file }: { dryRun: boolean; file: File }) =>
-      apiFetch<ImportBooksResult>("/tools/import/books", {
+      apiFetch<ImportBooksResult>(endpoints.import.books, {
         body: buildFormData(file, dryRun),
         method: "POST",
       }),
     onSuccess: (_, variables) => {
       if (!variables.dryRun) {
-        queryClient.invalidateQueries({ queryKey: ["comics"] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.comics.all });
       }
     },
   });

--- a/frontend/src/hooks/useLookup.ts
+++ b/frontend/src/hooks/useLookup.ts
@@ -1,4 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { LookupCandidatesResponse, LookupResult } from "../types/api";
 
@@ -8,8 +10,8 @@ export function useLookupIsbn(isbn: string, type?: string) {
 
   return useQuery({
     enabled: isbn.length >= 10,
-    queryFn: () => apiFetch<LookupResult>(`/lookup/isbn?${params}`),
-    queryKey: ["lookup", "isbn", isbn, type],
+    queryFn: () => apiFetch<LookupResult>(`${endpoints.lookup.isbn}?${params}`),
+    queryKey: queryKeys.lookup.isbn(isbn, type),
   });
 }
 
@@ -19,8 +21,8 @@ export function useLookupTitle(title: string, type?: string) {
 
   return useQuery({
     enabled: title.length >= 2,
-    queryFn: () => apiFetch<LookupResult>(`/lookup/title?${params}`),
-    queryKey: ["lookup", "title", title, type],
+    queryFn: () => apiFetch<LookupResult>(`${endpoints.lookup.title}?${params}`),
+    queryKey: queryKeys.lookup.title(title, type),
   });
 }
 
@@ -30,8 +32,8 @@ export function useLookupTitleCandidates(title: string, type?: string, limit = 5
 
   return useQuery({
     enabled: title.length >= 2,
-    queryFn: () => apiFetch<LookupCandidatesResponse>(`/lookup/title?${params}`),
-    queryKey: ["lookup", "title-candidates", title, type, limit],
+    queryFn: () => apiFetch<LookupCandidatesResponse>(`${endpoints.lookup.title}?${params}`),
+    queryKey: queryKeys.lookup.titleCandidates(title, type, limit),
   });
 }
 
@@ -39,12 +41,12 @@ export function useLookupTitleCandidates(title: string, type?: string, limit = 5
 export async function fetchLookupIsbn(isbn: string, type?: string): Promise<LookupResult> {
   const params = new URLSearchParams({ isbn });
   if (type) params.set("type", type);
-  return apiFetch<LookupResult>(`/lookup/isbn?${params}`);
+  return apiFetch<LookupResult>(`${endpoints.lookup.isbn}?${params}`);
 }
 
 /** Appel impératif — lookup par titre */
 export async function fetchLookupTitle(title: string, type?: string): Promise<LookupResult> {
   const params = new URLSearchParams({ title });
   if (type) params.set("type", type);
-  return apiFetch<LookupResult>(`/lookup/title?${params}`);
+  return apiFetch<LookupResult>(`${endpoints.lookup.title}?${params}`);
 }

--- a/frontend/src/hooks/useMergeSeries.ts
+++ b/frontend/src/hooks/useMergeSeries.ts
@@ -1,4 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type {
   MergeGroup,
@@ -15,7 +17,7 @@ interface DetectParams {
 export function useDetectMergeGroups() {
   return useMutation({
     mutationFn: (params: DetectParams) =>
-      apiFetch<MergeGroup[]>("/merge-series/detect", {
+      apiFetch<MergeGroup[]>(endpoints.mergeSeries.detect, {
         body: JSON.stringify(params),
         method: "POST",
       }),
@@ -25,7 +27,7 @@ export function useDetectMergeGroups() {
 export function useMergePreview() {
   return useMutation({
     mutationFn: (seriesIds: number[]) =>
-      apiFetch<MergePreview>("/merge-series/preview", {
+      apiFetch<MergePreview>(endpoints.mergeSeries.preview, {
         body: JSON.stringify({ seriesIds }),
         method: "POST",
       }),
@@ -35,7 +37,7 @@ export function useMergePreview() {
 export function useMergeSuggest() {
   return useMutation({
     mutationFn: (seriesIds: number[]) =>
-      apiFetch<MergeSuggestion>("/merge-series/suggest", {
+      apiFetch<MergeSuggestion>(endpoints.mergeSeries.suggest, {
         body: JSON.stringify({ seriesIds }),
         method: "POST",
       }),
@@ -48,14 +50,14 @@ export function useExecuteMerge() {
   return useMutation({
     mutationFn: (preview: MergePreview) =>
       apiFetch<{ id: number; title: string; type: string }>(
-        "/merge-series/execute",
+        endpoints.mergeSeries.execute,
         {
           body: JSON.stringify(preview),
           method: "POST",
         },
       ),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["comics"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.comics.all });
     },
   });
 }

--- a/frontend/src/hooks/usePendingQueueCount.ts
+++ b/frontend/src/hooks/usePendingQueueCount.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "../queryKeys";
 import { getPendingCount } from "../services/offlineQueue";
 
 export function usePendingQueueCount(): number {
   const { data } = useQuery({
     queryFn: getPendingCount,
-    queryKey: ["offline-queue-count"],
+    queryKey: queryKeys.offline.queueCount,
     refetchInterval: 2000,
   });
 

--- a/frontend/src/hooks/usePurge.ts
+++ b/frontend/src/hooks/usePurge.ts
@@ -1,4 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { PurgeableSeries } from "../types/api";
 
@@ -6,8 +8,8 @@ export function usePurgePreview(days: number) {
   return useQuery({
     enabled: days > 0,
     queryFn: () =>
-      apiFetch<PurgeableSeries[]>(`/tools/purge/preview?days=${days}`),
-    queryKey: ["purge-preview", days],
+      apiFetch<PurgeableSeries[]>(`${endpoints.purge.preview}?days=${days}`),
+    queryKey: queryKeys.purge.preview(days),
   });
 }
 
@@ -16,13 +18,13 @@ export function useExecutePurge() {
 
   return useMutation({
     mutationFn: (seriesIds: number[]) =>
-      apiFetch<{ purged: number }>("/tools/purge/execute", {
+      apiFetch<{ purged: number }>(endpoints.purge.execute, {
         body: JSON.stringify({ seriesIds }),
         method: "POST",
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["purge-preview"] });
-      queryClient.invalidateQueries({ queryKey: ["comics"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.purge.previewPrefix });
+      queryClient.invalidateQueries({ queryKey: queryKeys.comics.all });
     },
   });
 }

--- a/frontend/src/hooks/useSyncFailures.ts
+++ b/frontend/src/hooks/useSyncFailures.ts
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
+import { queryKeys } from "../queryKeys";
 import {
   getSyncFailures,
   removeSyncFailure as removeFailure,
@@ -12,7 +13,7 @@ export function useSyncFailures() {
 
   const { data: failures = [] } = useQuery<SyncFailure[]>({
     queryFn: getSyncFailures,
-    queryKey: ["syncFailures"],
+    queryKey: queryKeys.offline.syncFailures,
     refetchInterval: 3000,
   });
 
@@ -20,7 +21,7 @@ export function useSyncFailures() {
   useEffect(() => {
     const handler = (event: MessageEvent) => {
       if (event.data?.type === "sync-failure") {
-        void queryClient.invalidateQueries({ queryKey: ["syncFailures"] });
+        void queryClient.invalidateQueries({ queryKey: queryKeys.offline.syncFailures });
       }
     };
 
@@ -32,12 +33,12 @@ export function useSyncFailures() {
 
   const resolveSyncFailure = async (id: number) => {
     await resolveFailure(id);
-    void queryClient.invalidateQueries({ queryKey: ["syncFailures"] });
+    void queryClient.invalidateQueries({ queryKey: queryKeys.offline.syncFailures });
   };
 
   const removeSyncFailure = async (id: number) => {
     await removeFailure(id);
-    void queryClient.invalidateQueries({ queryKey: ["syncFailures"] });
+    void queryClient.invalidateQueries({ queryKey: queryKeys.offline.syncFailures });
   };
 
   return { failures, removeSyncFailure, resolveSyncFailure };

--- a/frontend/src/hooks/useSyncStatus.ts
+++ b/frontend/src/hooks/useSyncStatus.ts
@@ -1,5 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useState } from "react";
+import { queryKeys } from "../queryKeys";
 
 export type SyncStatus = "error" | "idle" | "success" | "syncing";
 
@@ -28,8 +29,8 @@ export function useSyncStatus() {
       case "sync-complete":
         setState({ error: null, status: "success", syncedCount: data.count ?? 0 });
         if ((data.count ?? 0) > 0) {
-          void queryClient.invalidateQueries({ queryKey: ["comics"] });
-          void queryClient.invalidateQueries({ queryKey: ["comic"] });
+          void queryClient.invalidateQueries({ queryKey: queryKeys.comics.all });
+          void queryClient.invalidateQueries({ queryKey: queryKeys.comics.detailPrefix });
         }
         break;
       case "sync-error":

--- a/frontend/src/hooks/useTrash.ts
+++ b/frontend/src/hooks/useTrash.ts
@@ -1,4 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { ComicSeries, HydraCollection } from "../types/api";
 import { useOfflineMutation } from "./useOfflineMutation";
@@ -6,32 +8,32 @@ import { useOfflineMutation } from "./useOfflineMutation";
 export function useTrash() {
   return useQuery({
     queryFn: () =>
-      apiFetch<HydraCollection<ComicSeries>>("/trash"),
-    queryKey: ["trash"],
+      apiFetch<HydraCollection<ComicSeries>>(endpoints.trash.collection),
+    queryKey: queryKeys.trash.all,
   });
 }
 
 export function useRestoreComic() {
   return useOfflineMutation<ComicSeries, { id: number }>({
     mutationFn: ({ id }) =>
-      apiFetch<ComicSeries>(`/comic_series/${id}/restore`, {
+      apiFetch<ComicSeries>(endpoints.comicSeries.restore(id), {
         body: JSON.stringify({}),
         method: "PUT",
       }),
     offlineOperation: "update",
     offlineResourceId: (v) => String(v.id),
     offlineResourceType: "comic_series",
-    queryKeysToInvalidate: [["trash"], ["comics"]],
+    queryKeysToInvalidate: [queryKeys.trash.all, queryKeys.comics.all],
   });
 }
 
 export function usePermanentDelete() {
   return useOfflineMutation<unknown, { id: number }>({
     mutationFn: ({ id }) =>
-      apiFetch(`/trash/${id}/permanent`, { method: "DELETE" }),
+      apiFetch(endpoints.trash.permanent(id), { method: "DELETE" }),
     offlineOperation: "delete",
     offlineResourceId: (v) => String(v.id),
     offlineResourceType: "comic_series",
-    queryKeysToInvalidate: [["trash"]],
+    queryKeysToInvalidate: [queryKeys.trash.all],
   });
 }

--- a/frontend/src/hooks/useUpdateComic.ts
+++ b/frontend/src/hooks/useUpdateComic.ts
@@ -1,4 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { ComicSeries, HydraCollection } from "../types/api";
 import { useOfflineMutation } from "./useOfflineMutation";
@@ -21,7 +23,7 @@ export function useUpdateComic() {
 
   return useOfflineMutation<ComicSeries, Partial<ComicSeries> & { id: number } & Record<string, unknown>>({
     mutationFn: ({ id, ...data }) =>
-      apiFetch<ComicSeries>(`/comic_series/${id}`, {
+      apiFetch<ComicSeries>(endpoints.comicSeries.detail(id), {
         body: JSON.stringify(data),
         headers: { "Content-Type": "application/merge-patch+json" },
         method: "PATCH",
@@ -31,7 +33,7 @@ export function useUpdateComic() {
     offlineResourceType: "comic_series",
     onSuccess: (data, variables) => {
       // Mettre à jour la collection avec la réponse serveur (pas de refetch)
-      qc.setQueryData<HydraCollection<ComicSeries>>(["comics"], (old) => {
+      qc.setQueryData<HydraCollection<ComicSeries>>(queryKeys.comics.all, (old) => {
         if (!old) return old;
         return {
           ...old,
@@ -44,7 +46,7 @@ export function useUpdateComic() {
     optimisticUpdate: (queryClient, variables) => {
       const safeFields = safeOptimisticFields(variables);
       // Mettre à jour dans la liste
-      queryClient.setQueryData<HydraCollection<ComicSeries>>(["comics"], (old) => {
+      queryClient.setQueryData<HydraCollection<ComicSeries>>(queryKeys.comics.all, (old) => {
         if (!old) return old;
         return {
           ...old,
@@ -54,11 +56,11 @@ export function useUpdateComic() {
         };
       });
       // Mettre à jour dans le détail
-      queryClient.setQueryData<ComicSeries>(["comic", variables.id], (old) => {
+      queryClient.setQueryData<ComicSeries>(queryKeys.comics.detail(variables.id), (old) => {
         if (!old) return old;
         return { ...old, ...safeFields, _syncPending: true };
       });
     },
-    queryKeysToInvalidate: (variables) => [["comic", variables.id]],
+    queryKeysToInvalidate: (variables) => [queryKeys.comics.detail(variables.id)],
   });
 }

--- a/frontend/src/hooks/useUpdateTome.ts
+++ b/frontend/src/hooks/useUpdateTome.ts
@@ -1,3 +1,5 @@
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { ComicSeries, Tome } from "../types/api";
 import { useOfflineMutation } from "./useOfflineMutation";
@@ -5,7 +7,7 @@ import { useOfflineMutation } from "./useOfflineMutation";
 export function useUpdateTome(seriesId?: number) {
   return useOfflineMutation<Tome, Partial<Tome> & { id: number }>({
     mutationFn: ({ id, ...data }) =>
-      apiFetch<Tome>(`/tomes/${id}`, {
+      apiFetch<Tome>(endpoints.tomes.detail(id), {
         body: JSON.stringify(data),
         headers: { "Content-Type": "application/merge-patch+json" },
         method: "PATCH",
@@ -19,7 +21,7 @@ export function useUpdateTome(seriesId?: number) {
     offlineResourceType: "tome",
     optimisticUpdate: (qc, variables) => {
       if (!seriesId) return;
-      qc.setQueryData<ComicSeries>(["comic", seriesId], (old) => {
+      qc.setQueryData<ComicSeries>(queryKeys.comics.detail(seriesId), (old) => {
         if (!old) return old;
         return {
           ...old,
@@ -29,6 +31,6 @@ export function useUpdateTome(seriesId?: number) {
         };
       });
     },
-    queryKeysToInvalidate: [["comic"]],
+    queryKeysToInvalidate: [queryKeys.comics.detailPrefix],
   });
 }

--- a/frontend/src/queryKeys.ts
+++ b/frontend/src/queryKeys.ts
@@ -1,0 +1,32 @@
+export const queryKeys = {
+  authors: {
+    search: (search: string) => ["authors", search] as const,
+  },
+  batchLookup: {
+    preview: (type: string, force: boolean) => ["batch-lookup-preview", type, force] as const,
+    previewPrefix: ["batch-lookup-preview"] as const,
+  },
+  comics: {
+    all: ["comics"] as const,
+    detail: (id: number | undefined) => ["comic", id] as const,
+    detailPrefix: ["comic"] as const,
+  },
+  lookup: {
+    covers: (query: string, type?: string) => ["lookup", "covers", query, type] as const,
+    isbn: (isbn: string, type?: string) => ["lookup", "isbn", isbn, type] as const,
+    title: (title: string, type?: string) => ["lookup", "title", title, type] as const,
+    titleCandidates: (title: string, type?: string, limit?: number) =>
+      ["lookup", "title-candidates", title, type, limit] as const,
+  },
+  offline: {
+    queueCount: ["offline-queue-count"] as const,
+    syncFailures: ["syncFailures"] as const,
+  },
+  purge: {
+    preview: (days: number) => ["purge-preview", days] as const,
+    previewPrefix: ["purge-preview"] as const,
+  },
+  trash: {
+    all: ["trash"] as const,
+  },
+} as const;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,5 @@
 import { del, set } from "idb-keyval";
+import { endpoints } from "../endpoints";
 
 const API_BASE = "/api";
 const TOKEN_KEY = "jwt_token";
@@ -192,7 +193,7 @@ export async function fetchSSE<TMessage, TComplete>(
 }
 
 export async function loginWithGoogle(credential: string): Promise<string> {
-  const response = await fetch(`${API_BASE}/login/google`, {
+  const response = await fetch(`${API_BASE}${endpoints.login.google}`, {
     body: JSON.stringify({ credential }),
     headers: { "Content-Type": "application/json" },
     method: "POST",


### PR DESCRIPTION
## Summary

- Crée `queryKeys.ts` — factory type-safe pour toutes les query keys TanStack (13 patterns centralisés)
- Crée `endpoints.ts` — constantes centralisées pour les 20+ URLs API
- Migre 21 hooks, `App.tsx`, `api.ts` et 12 fichiers de tests vers les modules centralisés
- Élimine les chaînes magiques éparpillées et le risque de typos silencieuses dans l'invalidation du cache

Fixes #267

## Test plan

- [x] 735 tests passent (80 fichiers)
- [x] `tsc --noEmit` — aucune erreur de type
- [x] Grep confirme : plus aucune query key en chaîne brute dans les hooks