### PR TITLE
Refactor : consolider la gestion d'erreurs et le 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
+- **Frontend** : Consolidation de la gestion d'erreurs — extraction de `handleUnauthorized()` et `getErrorMessage()` dans `api.ts`, remplacement de `Record<string, unknown>` par des interfaces typées (`CreateComicPayload`, `UpdateComicPayload`, `CreateTomePayload`, `TomePayload`)
 - **Frontend** : Centralisation des query keys (`queryKeys.ts`) et des endpoints API (`endpoints.ts`) — supprime les chaînes éparpillées dans 20+ hooks et 12 fichiers de tests
 - **Frontend** : Découpage de `MergePreviewModal` (587→80 lignes) en `MergeMetadataForm`, `MergeTomeTable` et `useMergePreviewForm` (useReducer)
 - **Frontend** : Découpage de `useComicForm` (420→210 lignes) en `useLookupFeature`, `useTomeManagement` et `useAuthorManagement`

--- a/frontend/src/__tests__/integration/components/ErrorFallback.test.tsx
+++ b/frontend/src/__tests__/integration/components/ErrorFallback.test.tsx
@@ -16,11 +16,21 @@ describe("ErrorFallback", () => {
     expect(screen.getByText("Quelque chose a mal tourné")).toBeInTheDocument();
   });
 
-  it("renders fallback message for non-Error values", () => {
+  it("renders string error directly", () => {
     const resetErrorBoundary = vi.fn();
 
     renderWithProviders(
       <ErrorFallback error={"string error"} resetErrorBoundary={resetErrorBoundary} />,
+    );
+
+    expect(screen.getByText("string error")).toBeInTheDocument();
+  });
+
+  it("renders fallback message for null/undefined values", () => {
+    const resetErrorBoundary = vi.fn();
+
+    renderWithProviders(
+      <ErrorFallback error={null} resetErrorBoundary={resetErrorBoundary} />,
     );
 
     expect(screen.getByText("Erreur inconnue")).toBeInTheDocument();

--- a/frontend/src/__tests__/unit/services/api.test.ts
+++ b/frontend/src/__tests__/unit/services/api.test.ts
@@ -3,13 +3,82 @@ import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   apiFetch,
+  getErrorMessage,
   getToken,
+  handleUnauthorized,
   isAuthenticated,
   loginWithGoogle,
   removeToken,
   setToken,
 } from "../../../services/api";
 import { server } from "../../helpers/server";
+
+describe("getErrorMessage", () => {
+  it("extracts message from Error instance", () => {
+    expect(getErrorMessage(new Error("Something failed"))).toBe("Something failed");
+  });
+
+  it("converts string to message", () => {
+    expect(getErrorMessage("string error")).toBe("string error");
+  });
+
+  it("converts number to string", () => {
+    expect(getErrorMessage(42)).toBe("42");
+  });
+
+  it("returns fallback for null", () => {
+    expect(getErrorMessage(null)).toBe("Erreur inconnue");
+  });
+
+  it("returns fallback for undefined", () => {
+    expect(getErrorMessage(undefined)).toBe("Erreur inconnue");
+  });
+
+  it("returns custom fallback when provided", () => {
+    expect(getErrorMessage(null, "Custom fallback")).toBe("Custom fallback");
+  });
+});
+
+describe("handleUnauthorized", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    Object.defineProperty(navigator, "onLine", { configurable: true, value: true, writable: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("removes token and redirects when online", () => {
+    setToken("expired-token");
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, href: originalLocation.href },
+      writable: true,
+    });
+
+    handleUnauthorized();
+
+    expect(getToken()).toBeNull();
+    expect(window.location.href).toBe("/login");
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  it("does NOT remove token when offline", () => {
+    setToken("my-token");
+    Object.defineProperty(navigator, "onLine", { configurable: true, value: false, writable: true });
+
+    handleUnauthorized();
+
+    expect(getToken()).toBe("my-token");
+  });
+});
 
 describe("Token helpers", () => {
   beforeEach(() => {

--- a/frontend/src/components/ErrorFallback.tsx
+++ b/frontend/src/components/ErrorFallback.tsx
@@ -1,12 +1,13 @@
 import { AlertTriangle } from "lucide-react";
 import type { FallbackProps } from "react-error-boundary";
+import { getErrorMessage } from "../services/api";
 
 export default function ErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
   return (
     <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 px-4 text-center">
       <AlertTriangle className="h-12 w-12 text-red-500" />
       <h2 className="text-xl font-bold text-text-primary">Une erreur est survenue</h2>
-      <p className="max-w-md text-text-secondary">{error instanceof Error ? error.message : "Erreur inconnue"}</p>
+      <p className="max-w-md text-text-secondary">{getErrorMessage(error)}</p>
       <button
         className="rounded-lg bg-primary-600 px-4 py-2 text-white hover:bg-primary-700"
         onClick={resetErrorBoundary}

--- a/frontend/src/hooks/useBatchLookup.ts
+++ b/frontend/src/hooks/useBatchLookup.ts
@@ -3,7 +3,7 @@ import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
 import { endpoints } from "../endpoints";
 import { queryKeys } from "../queryKeys";
-import { apiFetch, fetchSSE } from "../services/api";
+import { apiFetch, fetchSSE, getErrorMessage } from "../services/api";
 import type { BatchLookupProgress, BatchLookupSummary } from "../types/api";
 
 export function useBatchLookupPreview(
@@ -77,7 +77,7 @@ export function useBatchLookup(): BatchLookupState {
           setSummary(null);
           setIsRunning(false);
           abortRef.current = null;
-          toast.error(error instanceof Error ? error.message : "Erreur lors du batch lookup");
+          toast.error(getErrorMessage(error, "Erreur lors du batch lookup"));
         },
         controller.signal,
       );

--- a/frontend/src/hooks/useComicForm.ts
+++ b/frontend/src/hooks/useComicForm.ts
@@ -10,8 +10,8 @@ import { useSyncFailures } from "./useSyncFailures";
 import { useTomeManagement } from "./useTomeManagement";
 import { useUpdateComic } from "./useUpdateComic";
 import { endpoints } from "../endpoints";
-import { apiFetch } from "../services/api";
-import type { Author, ComicSeries } from "../types/api";
+import { apiFetch, getErrorMessage } from "../services/api";
+import type { Author, ComicSeries, CreateComicPayload, TomePayload, UpdateComicPayload } from "../types/api";
 import { ComicStatus, ComicType } from "../types/enums";
 
 export interface TomeFormData {
@@ -160,7 +160,22 @@ export function useComicForm() {
       }
     }
 
-    const payload: Record<string, unknown> = {
+    const tomes: TomePayload[] | undefined = form.isOneShot
+      ? undefined
+      : [...form.tomes].sort(compareTomes).map((t) => ({
+          ...(t.id ? { "@id": `/api/tomes/${t.id}` } : {}),
+          bought: t.bought,
+          downloaded: t.downloaded,
+          isHorsSerie: t.isHorsSerie,
+          isbn: t.isbn || null,
+          number: t.number,
+          onNas: t.onNas,
+          read: t.read,
+          title: t.title || null,
+          tomeEnd: t.tomeEnd ? Number(t.tomeEnd) : null,
+        }));
+
+    const basePayload: CreateComicPayload = {
       ...(pendingAuthors.length > 0 ? { _pendingAuthors: pendingAuthors } : {}),
       authors: authorIris,
       coverUrl: form.coverUrl || null,
@@ -173,50 +188,32 @@ export function useComicForm() {
       latestPublishedIssueComplete: form.latestPublishedIssueComplete,
       publishedDate: form.publishedDate || null,
       publisher: form.publisher || null,
-      status: form.status,
+      status: form.status as ComicStatus,
       title: form.title,
-      type: form.type,
+      tomes,
+      type: form.type as ComicType,
     };
 
-    if (!form.isOneShot) {
-      payload.tomes = [...form.tomes]
-        .sort(compareTomes)
-        .map((t) => ({
-          ...(t.id ? { "@id": `/api/tomes/${t.id}` } : {}),
-          bought: t.bought,
-          downloaded: t.downloaded,
-          isHorsSerie: t.isHorsSerie,
-          isbn: t.isbn || null,
-          number: t.number,
-          onNas: t.onNas,
-          read: t.read,
-          title: t.title || null,
-          tomeEnd: t.tomeEnd ? Number(t.tomeEnd) : null,
-        }));
-    }
-
     if (isEdit && id) {
-      updateComic.mutate(
-        { id: Number(id), ...payload } as Partial<ComicSeries> & { id: number },
-        {
-          onSuccess: (data) => {
-            if (!data) return;
-            if (syncFailure?.id) void resolveSyncFailure(syncFailure.id);
-            toast.success("Série mise à jour");
-            navigate(`/comic/${id}`, { viewTransition: true });
-          },
-          onError: (err) => toast.error(err.message),
+      const updatePayload: UpdateComicPayload = { id: Number(id), ...basePayload };
+      updateComic.mutate(updatePayload, {
+        onSuccess: (data) => {
+          if (!data) return;
+          if (syncFailure?.id) void resolveSyncFailure(syncFailure.id);
+          toast.success("Série mise à jour");
+          navigate(`/comic/${id}`, { viewTransition: true });
         },
-      );
+        onError: (err) => toast.error(getErrorMessage(err)),
+      });
     } else {
-      createComic.mutate(payload as Partial<ComicSeries>, {
+      createComic.mutate(basePayload, {
         onSuccess: (created) => {
           if (!created) return;
           if (syncFailure?.id) void resolveSyncFailure(syncFailure.id);
           toast.success("Série créée");
           navigate(`/comic/${created.id}`, { viewTransition: true });
         },
-        onError: (err) => toast.error(err.message),
+        onError: (err) => toast.error(getErrorMessage(err)),
       });
     }
 

--- a/frontend/src/hooks/useCreateComic.ts
+++ b/frontend/src/hooks/useCreateComic.ts
@@ -1,12 +1,12 @@
 import { endpoints } from "../endpoints";
 import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
-import type { ComicSeries, HydraCollection } from "../types/api";
+import type { ComicSeries, CreateComicPayload, HydraCollection } from "../types/api";
 import { ComicStatus, ComicType } from "../types/enums";
 import { useOfflineMutation } from "./useOfflineMutation";
 
 export function useCreateComic() {
-  return useOfflineMutation<ComicSeries, Partial<ComicSeries> & Record<string, unknown>>({
+  return useOfflineMutation<ComicSeries, CreateComicPayload>({
     generateTempId: true,
     mutationFn: (data) =>
       apiFetch<ComicSeries>(endpoints.comicSeries.collection, {
@@ -24,25 +24,25 @@ export function useCreateComic() {
           amazonUrl: null,
           authors: [],
           coverImage: null,
-          coverUrl: (variables.coverUrl as string) ?? null,
+          coverUrl: variables.coverUrl ?? null,
           createdAt: new Date().toISOString(),
-          defaultTomeBought: false,
-          defaultTomeDownloaded: false,
-          defaultTomeRead: false,
-          description: (variables.description as string) ?? null,
+          defaultTomeBought: variables.defaultTomeBought ?? false,
+          defaultTomeDownloaded: variables.defaultTomeDownloaded ?? false,
+          defaultTomeRead: variables.defaultTomeRead ?? false,
+          description: variables.description ?? null,
           id: tempId!,
-          isOneShot: (variables.isOneShot as boolean) ?? false,
+          isOneShot: variables.isOneShot ?? false,
           latestPublishedIssue: null,
           latestPublishedIssueComplete: false,
           latestPublishedIssueUpdatedAt: null,
           notInterestedBuy: false,
           notInterestedNas: false,
           publishedDate: null,
-          publisher: (variables.publisher as string) ?? null,
-          status: (variables.status as ComicStatus) ?? ComicStatus.BUYING,
-          title: (variables.title as string) ?? "",
+          publisher: variables.publisher ?? null,
+          status: variables.status ?? ComicStatus.BUYING,
+          title: variables.title ?? "",
           tomes: [],
-          type: (variables.type as ComicType) ?? ComicType.BD,
+          type: variables.type ?? ComicType.BD,
           updatedAt: new Date().toISOString(),
         };
         return {

--- a/frontend/src/hooks/useCreateTome.ts
+++ b/frontend/src/hooks/useCreateTome.ts
@@ -1,11 +1,11 @@
 import { endpoints } from "../endpoints";
 import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
-import type { ComicSeries, Tome } from "../types/api";
+import type { ComicSeries, CreateTomePayload, Tome } from "../types/api";
 import { useOfflineMutation } from "./useOfflineMutation";
 
 export function useCreateTome(seriesId: number) {
-  return useOfflineMutation<Tome, Partial<Tome> & Record<string, unknown>>({
+  return useOfflineMutation<Tome, CreateTomePayload>({
     generateTempId: true,
     mutationFn: (data) =>
       apiFetch<Tome>(endpoints.comicSeries.tomes(seriesId), {
@@ -22,17 +22,17 @@ export function useCreateTome(seriesId: number) {
         const tempTome: Tome = {
           "@id": `/api/tomes/${tempId}`,
           _syncPending: true,
-          bought: (variables.bought as boolean) ?? false,
+          bought: variables.bought ?? false,
           createdAt: new Date().toISOString(),
-          downloaded: (variables.downloaded as boolean) ?? false,
+          downloaded: variables.downloaded ?? false,
           id: tempId!,
-          isHorsSerie: (variables.isHorsSerie as boolean) ?? false,
-          isbn: (variables.isbn as string) ?? null,
-          number: (variables.number as number) ?? 0,
-          onNas: (variables.onNas as boolean) ?? false,
-          read: (variables.read as boolean) ?? false,
-          title: (variables.title as string) ?? null,
-          tomeEnd: (variables.tomeEnd as number) ?? null,
+          isHorsSerie: variables.isHorsSerie ?? false,
+          isbn: variables.isbn ?? null,
+          number: variables.number ?? 0,
+          onNas: variables.onNas ?? false,
+          read: variables.read ?? false,
+          title: variables.title ?? null,
+          tomeEnd: variables.tomeEnd ?? null,
           updatedAt: new Date().toISOString(),
         };
         return {

--- a/frontend/src/hooks/useOfflineMutation.ts
+++ b/frontend/src/hooks/useOfflineMutation.ts
@@ -31,7 +31,7 @@ async function registerSync(): Promise<void> {
   }
 }
 
-export function useOfflineMutation<TData, TVariables extends Record<string, unknown>>({
+export function useOfflineMutation<TData, TVariables extends object>({
   generateTempId,
   mutationFn,
   offlineContentType,

--- a/frontend/src/hooks/useUpdateComic.ts
+++ b/frontend/src/hooks/useUpdateComic.ts
@@ -2,26 +2,26 @@ import { useQueryClient } from "@tanstack/react-query";
 import { endpoints } from "../endpoints";
 import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
-import type { ComicSeries, HydraCollection } from "../types/api";
+import type { ComicSeries, HydraCollection, UpdateComicPayload } from "../types/api";
 import { useOfflineMutation } from "./useOfflineMutation";
 
 // Champs sûrs à mettre à jour de façon optimiste (mêmes types dans le payload et dans ComicSeries)
-function safeOptimisticFields(variables: Record<string, unknown>): Partial<ComicSeries> {
+function safeOptimisticFields(variables: UpdateComicPayload): Partial<ComicSeries> {
   const safe: Partial<ComicSeries> = {};
-  if (typeof variables.title === "string") safe.title = variables.title;
-  if (typeof variables.description === "string" || variables.description === null) safe.description = variables.description as string | null;
-  if (typeof variables.publisher === "string" || variables.publisher === null) safe.publisher = variables.publisher as string | null;
-  if (typeof variables.coverUrl === "string" || variables.coverUrl === null) safe.coverUrl = variables.coverUrl as string | null;
-  if (typeof variables.status === "string") safe.status = variables.status as ComicSeries["status"];
-  if (typeof variables.type === "string") safe.type = variables.type as ComicSeries["type"];
-  if (typeof variables.isOneShot === "boolean") safe.isOneShot = variables.isOneShot;
+  if (variables.title !== undefined) safe.title = variables.title;
+  if (variables.description !== undefined) safe.description = variables.description;
+  if (variables.publisher !== undefined) safe.publisher = variables.publisher;
+  if (variables.coverUrl !== undefined) safe.coverUrl = variables.coverUrl;
+  if (variables.status !== undefined) safe.status = variables.status;
+  if (variables.type !== undefined) safe.type = variables.type;
+  if (variables.isOneShot !== undefined) safe.isOneShot = variables.isOneShot;
   return safe;
 }
 
 export function useUpdateComic() {
   const qc = useQueryClient();
 
-  return useOfflineMutation<ComicSeries, Partial<ComicSeries> & { id: number } & Record<string, unknown>>({
+  return useOfflineMutation<ComicSeries, UpdateComicPayload>({
     mutationFn: ({ id, ...data }) =>
       apiFetch<ComicSeries>(endpoints.comicSeries.detail(id), {
         body: JSON.stringify(data),

--- a/frontend/src/pages/MergeSeries.tsx
+++ b/frontend/src/pages/MergeSeries.tsx
@@ -22,6 +22,7 @@ import {
   useMergePreview,
   useMergeSuggest,
 } from "../hooks/useMergeSeries";
+import { getErrorMessage } from "../services/api";
 import type { ComicSeries, HydraCollection, MergeGroup, MergePreview, MergeSuggestion } from "../types/api";
 import { type SelectOption, typeOptions } from "../types/enums";
 
@@ -68,7 +69,7 @@ export default function MergeSeries() {
 
     detectMutation.mutate(params, {
       onError: (error) => {
-        toast.error(error instanceof Error ? error.message : "Erreur lors de la détection");
+        toast.error(getErrorMessage(error, "Erreur lors de la détection"));
       },
       onSuccess: (data) => {
         setGroups(data);
@@ -107,7 +108,7 @@ export default function MergeSeries() {
 
     previewMutation.mutate(confirmedIds, {
       onError: (error) => {
-        toast.error(error instanceof Error ? error.message : "Erreur lors de la génération de l'aperçu");
+        toast.error(getErrorMessage(error, "Erreur lors de la génération de l'aperçu"));
       },
       onSuccess: (data) => {
         setPreviewData(data);
@@ -126,7 +127,7 @@ export default function MergeSeries() {
   const handleConfirmMerge = (preview: MergePreview) => {
     executeMerge.mutate(preview, {
       onError: (error) => {
-        toast.error(error instanceof Error ? error.message : "Erreur lors de la fusion");
+        toast.error(getErrorMessage(error, "Erreur lors de la fusion"));
       },
       onSuccess: () => {
         toast.success("Séries fusionnées avec succès");

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -23,6 +23,20 @@ export function isAuthenticated(): boolean {
   return getToken() !== null;
 }
 
+export function getErrorMessage(err: unknown, fallback = "Erreur inconnue"): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  if (err !== null && err !== undefined) return String(err);
+  return fallback;
+}
+
+export function handleUnauthorized(): void {
+  if (navigator.onLine) {
+    removeToken();
+    window.location.href = "/login";
+  }
+}
+
 const SERVER_ERROR_PATTERNS = [
   /SQLSTATE/i,
   /exception.*driver/i,
@@ -71,11 +85,7 @@ export async function apiFetch<T>(
   }
 
   if (response.status === 401) {
-    // Only clear token if genuinely online (not a network fluke)
-    if (navigator.onLine) {
-      removeToken();
-      window.location.href = "/login";
-    }
+    handleUnauthorized();
     throw new Error("Non authentifié");
   }
 
@@ -126,10 +136,7 @@ export async function fetchSSE<TMessage, TComplete>(
   }
 
   if (response.status === 401) {
-    if (navigator.onLine) {
-      removeToken();
-      window.location.href = "/login";
-    }
+    handleUnauthorized();
     onError(new Error("Non authentifié"));
     return;
   }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -161,6 +161,54 @@ export interface BatchLookupSummary {
   updated: number;
 }
 
+export interface CreateComicPayload {
+  _pendingAuthors?: string[];
+  authors: string[];
+  coverUrl: string | null;
+  defaultTomeBought: boolean;
+  defaultTomeDownloaded: boolean;
+  defaultTomeRead: boolean;
+  description: string | null;
+  isOneShot: boolean;
+  latestPublishedIssue: number | null;
+  latestPublishedIssueComplete: boolean;
+  publishedDate: string | null;
+  publisher: string | null;
+  status: ComicStatus;
+  title: string;
+  tomes?: TomePayload[];
+  type: ComicType;
+}
+
+export interface UpdateComicPayload extends Partial<CreateComicPayload> {
+  id: number;
+}
+
+export interface TomePayload {
+  "@id"?: string;
+  bought: boolean;
+  downloaded: boolean;
+  isHorsSerie: boolean;
+  isbn: string | null;
+  number: number;
+  onNas: boolean;
+  read: boolean;
+  title: string | null;
+  tomeEnd: number | null;
+}
+
+export interface CreateTomePayload {
+  bought: boolean;
+  downloaded: boolean;
+  isHorsSerie: boolean;
+  isbn: string | null;
+  number: number;
+  onNas: boolean;
+  read: boolean;
+  title: string | null;
+  tomeEnd: number | null;
+}
+
 export interface LookupResult {
   apiMessages: Record<string, { message: string; status: string }>;
   authors: string | null;


### PR DESCRIPTION
## Summary
- Extrait `handleUnauthorized()` dans `api.ts` pour dédupliquer la logique 401 entre `apiFetch` et `fetchSSE`
- Crée `getErrorMessage(err, fallback)` pour remplacer le pattern `error instanceof Error ? error.message : "fallback"` répété dans 5 fichiers
- Remplace `Record<string, unknown>` par des interfaces typées (`CreateComicPayload`, `UpdateComicPayload`, `CreateTomePayload`, `TomePayload`) dans les hooks de mutation
- Relâche la contrainte `TVariables` de `useOfflineMutation` (`object` au lieu de `Record<string, unknown>`)

Fixes #269

## Test plan
- [x] 744 tests frontend passent (80 fichiers)
- [x] TypeScript compile sans erreur (`tsc --noEmit`)
- [x] Tests unitaires ajoutés pour `getErrorMessage` (6 tests) et `handleUnauthorized` (2 tests)