### PR TITLE
A11y : améliorer l'accessibilité des composants frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **A11y** : `aria-current="page"` sur le lien actif de BottomNav
+- **A11y** : `aria-label` sur tous les inputs sans label visible (TomeTable, SelectListbox)
+- **A11y** : `aria-label` dynamique sur le bouton filtres mobile avec nombre de filtres actifs
+- **A11y** : Focus ring visible sur le bouton retour du formulaire série
+- **A11y** : Séparateur visuel entre résultats et option « Créer » dans AuthorAutocomplete
+- **A11y** : `aria-label` sur les boutons supprimer (tomes desktop, retirer auteur)
+
 ## [v2.13.0] - 2026-03-17
 
 ### Added

--- a/frontend/src/__tests__/integration/components/BottomNav.test.tsx
+++ b/frontend/src/__tests__/integration/components/BottomNav.test.tsx
@@ -42,4 +42,17 @@ describe("BottomNav", () => {
     expect(homeLink?.className).toContain("text-text-secondary");
     expect(homeLink?.className).not.toContain("border-primary-500");
   });
+
+  it("sets aria-current='page' on the active link only", () => {
+    renderWithProviders(<BottomNav />, { initialEntries: ["/to-buy"] });
+
+    const toBuyLink = screen.getByText("À acheter").closest("a");
+    expect(toBuyLink).toHaveAttribute("aria-current", "page");
+
+    const homeLink = screen.getByText("Accueil").closest("a");
+    expect(homeLink).not.toHaveAttribute("aria-current");
+
+    const addLink = screen.getByText("Ajouter").closest("a");
+    expect(addLink).not.toHaveAttribute("aria-current");
+  });
 });

--- a/frontend/src/__tests__/integration/components/Filters.test.tsx
+++ b/frontend/src/__tests__/integration/components/Filters.test.tsx
@@ -131,6 +131,33 @@ describe("Filters", () => {
       expect(screen.queryByText("Tous les statuts")).not.toBeInTheDocument();
     });
 
+    it("has dynamic aria-label reflecting active filter count", () => {
+      renderWithProviders(<Filters {...defaultProps} status="buying" type="manga" />);
+
+      expect(screen.getByTestId("filters-button")).toHaveAttribute(
+        "aria-label",
+        "Filtres (2 actifs)",
+      );
+    });
+
+    it("has plain aria-label when no filters active", () => {
+      renderWithProviders(<Filters {...defaultProps} />);
+
+      expect(screen.getByTestId("filters-button")).toHaveAttribute(
+        "aria-label",
+        "Filtres",
+      );
+    });
+
+    it("has aria-label with 1 active filter", () => {
+      renderWithProviders(<Filters {...defaultProps} type="manga" />);
+
+      expect(screen.getByTestId("filters-button")).toHaveAttribute(
+        "aria-label",
+        "Filtres (1 actif)",
+      );
+    });
+
     it("shows indicator dot when filters are active", () => {
       renderWithProviders(<Filters {...defaultProps} status="buying" type="manga" />);
 

--- a/frontend/src/__tests__/integration/components/SelectListbox.test.tsx
+++ b/frontend/src/__tests__/integration/components/SelectListbox.test.tsx
@@ -50,6 +50,30 @@ describe("SelectListbox", () => {
     expect(screen.getByText("Mon champ")).toBeInTheDocument();
   });
 
+  it("adds aria-label on button when no label prop but placeholder provided", () => {
+    render(
+      <SelectListbox
+        onChange={vi.fn()}
+        options={options}
+        placeholder="Choisir un type"
+        value=""
+      />,
+    );
+    expect(screen.getByRole("button")).toHaveAttribute("aria-label", "Choisir un type");
+  });
+
+  it("does not add aria-label on button when label prop is provided", () => {
+    render(
+      <SelectListbox
+        label="Type"
+        onChange={vi.fn()}
+        options={options}
+        value="a"
+      />,
+    );
+    expect(screen.getByRole("button")).not.toHaveAttribute("aria-label");
+  });
+
   it("falls back to first option when value doesn't match and no placeholder", () => {
     render(<SelectListbox onChange={vi.fn()} options={options} value="z" />);
     expect(screen.getByText("Option A")).toBeInTheDocument();

--- a/frontend/src/__tests__/integration/components/TomeTable.test.tsx
+++ b/frontend/src/__tests__/integration/components/TomeTable.test.tsx
@@ -60,6 +60,81 @@ describe("TomeTable", () => {
     expect(generateButton).toHaveAttribute("title", "Maximum 100 tomes à la fois");
   });
 
+  it("adds aria-labels on mobile card inputs", () => {
+    const tomeManager = createMockTomeManager();
+    const form = createMockForm({
+      tomes: [
+        {
+          bought: false,
+          downloaded: false,
+          id: 1,
+          isbn: "",
+          isHorsSerie: false,
+          number: 1,
+          onNas: false,
+          read: false,
+          title: "",
+          tomeEnd: "",
+        },
+      ],
+    });
+
+    // Simulate mobile by checking the cards container
+    renderWithProviders(<TomeTable form={form} tomeManager={tomeManager} />);
+
+    const cards = screen.getByTestId("tomes-cards");
+    const numberInput = cards.querySelector("input[type='number'][aria-label='Numéro']");
+    expect(numberInput).toBeInTheDocument();
+
+    const tomeEndInput = cards.querySelector("input[aria-label='Fin']");
+    expect(tomeEndInput).toBeInTheDocument();
+
+    const titleInput = cards.querySelector("input[aria-label='Titre']");
+    expect(titleInput).toBeInTheDocument();
+
+    const isbnInput = cards.querySelector("input[aria-label='ISBN']");
+    expect(isbnInput).toBeInTheDocument();
+  });
+
+  it("adds aria-labels on desktop table inputs", () => {
+    const tomeManager = createMockTomeManager();
+    const form = createMockForm({
+      tomes: [
+        {
+          bought: false,
+          downloaded: false,
+          id: 1,
+          isbn: "",
+          isHorsSerie: false,
+          number: 1,
+          onNas: false,
+          read: false,
+          title: "",
+          tomeEnd: "",
+        },
+      ],
+    });
+
+    renderWithProviders(<TomeTable form={form} tomeManager={tomeManager} />);
+
+    const table = screen.getByTestId("tomes-table");
+    const numberInput = table.querySelector("input[type='number'][aria-label='Numéro']");
+    expect(numberInput).toBeInTheDocument();
+
+    const tomeEndInput = table.querySelector("input[aria-label='Fin']");
+    expect(tomeEndInput).toBeInTheDocument();
+
+    const titleInput = table.querySelector("input[aria-label='Titre']");
+    expect(titleInput).toBeInTheDocument();
+
+    const isbnInput = table.querySelector("input[aria-label='ISBN']");
+    expect(isbnInput).toBeInTheDocument();
+
+    // Desktop delete button should have aria-label
+    const deleteButton = table.querySelector("button[aria-label]");
+    expect(deleteButton).toHaveAttribute("aria-label", "Supprimer tome 1");
+  });
+
   it("does not show tooltip when batch is within limit", () => {
     const tomeManager = createMockTomeManager({
       batchFrom: 1,

--- a/frontend/src/components/AuthorAutocomplete.tsx
+++ b/frontend/src/components/AuthorAutocomplete.tsx
@@ -35,6 +35,7 @@ export default function AuthorAutocomplete({
           >
             {author.name}
             <button
+              aria-label={`Retirer ${author.name}`}
               className="ml-1 rounded-full p-0.5 hover:bg-primary-200 dark:hover:bg-primary-900/40"
               onClick={() => removeAuthor(i)}
               type="button"
@@ -69,13 +70,18 @@ export default function AuthorAutocomplete({
               </ComboboxOption>
             ))}
             {authorSearch.length >= 2 && !authorOptions.some((a) => a.name.toLowerCase() === authorSearch.toLowerCase()) && (
-              <ComboboxOption
-                className="cursor-pointer px-3 py-2 text-sm text-primary-700 dark:text-primary-400 data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-950/30"
-                value={{ "@id": "", id: -Date.now(), name: authorSearch } as Author}
-              >
-                <Plus className="mr-1 inline h-3 w-3" />
-                Créer « {authorSearch} »
-              </ComboboxOption>
+              <>
+                {authorOptions.length > 0 && (
+                  <div className="mx-3 border-t border-surface-border" />
+                )}
+                <ComboboxOption
+                  className="cursor-pointer px-3 py-2 text-sm font-medium text-primary-700 dark:text-primary-400 data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-950/30"
+                  value={{ "@id": "", id: -Date.now(), name: authorSearch } as Author}
+                >
+                  <Plus className="mr-1 inline h-3 w-3" />
+                  Créer « {authorSearch} »
+                </ComboboxOption>
+              </>
             )}
           </ComboboxOptions>
         </div>

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -51,6 +51,7 @@ export default function BottomNav() {
           const active = isActive(pathname);
           return (
             <Link
+              aria-current={active ? "page" : undefined}
               className={`flex flex-col items-center justify-center gap-0.5 px-3 text-xs font-medium transition-colors ${
                 active ? activeColor : "text-text-secondary"
               }`}

--- a/frontend/src/components/Filters.tsx
+++ b/frontend/src/components/Filters.tsx
@@ -119,12 +119,16 @@ export default function Filters({
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   if (isMobile) {
-    const hasActiveFilters = type !== "" || status !== "";
+    const activeFilterCount = [type, status].filter((v) => v !== "").length;
+    const hasActiveFilters = activeFilterCount > 0;
+    const filterLabel = hasActiveFilters
+      ? `Filtres (${activeFilterCount} actif${activeFilterCount > 1 ? "s" : ""})`
+      : "Filtres";
 
     return (
       <>
         <button
-          aria-label="Filtres"
+          aria-label={filterLabel}
           className="relative shrink-0 rounded-lg border border-surface-border bg-surface-primary p-2 text-text-muted transition hover:border-primary-400 hover:text-text-primary"
           data-testid="filters-button"
           onClick={() => setDrawerOpen(true)}

--- a/frontend/src/components/SelectListbox.tsx
+++ b/frontend/src/components/SelectListbox.tsx
@@ -37,6 +37,7 @@ export default function SelectListbox({
       <Listbox onChange={onChange} value={value}>
         <div className="relative">
           <ListboxButton
+            aria-label={!label ? (placeholder ?? options[0]?.label) : undefined}
             className={
               buttonClassName ??
               "flex w-full items-center justify-between gap-2 rounded-lg border border-surface-border bg-surface-primary px-3 py-1.5 text-sm text-text-primary transition hover:border-primary-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"

--- a/frontend/src/components/TomeTable.tsx
+++ b/frontend/src/components/TomeTable.tsx
@@ -93,6 +93,7 @@ export default function TomeTable({ form, tomeManager }: TomeTableProps) {
                 HS
               </label>
               <input
+                aria-label="Numéro"
                 className="w-14 rounded border border-surface-border bg-surface-tertiary px-2 py-1 text-center text-sm font-medium text-text-primary"
                 min="0"
                 onChange={(e) => updateTome(i, "number", Number(e.target.value))}
@@ -100,6 +101,7 @@ export default function TomeTable({ form, tomeManager }: TomeTableProps) {
                 value={tome.number}
               />
               <input
+                aria-label="Fin"
                 className="w-14 rounded border border-surface-border bg-surface-tertiary px-2 py-1 text-center text-sm text-text-primary"
                 min="0"
                 onChange={(e) => updateTome(i, "tomeEnd", e.target.value)}
@@ -108,6 +110,7 @@ export default function TomeTable({ form, tomeManager }: TomeTableProps) {
                 value={tome.tomeEnd}
               />
               <input
+                aria-label="Titre"
                 className="flex-1 rounded border border-surface-border bg-surface-tertiary px-2 py-1 text-sm text-text-primary"
                 onChange={(e) => updateTome(i, "title", e.target.value)}
                 placeholder="Titre"
@@ -124,6 +127,7 @@ export default function TomeTable({ form, tomeManager }: TomeTableProps) {
             </div>
             <div className="flex items-center gap-1">
               <input
+                aria-label="ISBN"
                 className="flex-1 rounded border border-surface-border bg-surface-tertiary px-2 py-1 text-sm text-text-primary"
                 onChange={(e) => updateTome(i, "isbn", e.target.value)}
                 placeholder="ISBN"
@@ -217,6 +221,7 @@ export default function TomeTable({ form, tomeManager }: TomeTableProps) {
                 <td className="px-3 py-1.5">
                   <div className="flex items-center gap-1">
                     <input
+                      aria-label="Numéro"
                       className="w-14 rounded border border-surface-border bg-surface-primary px-2 py-1 text-center text-sm text-text-primary"
                       min="0"
                       onChange={(e) => updateTome(i, "number", Number(e.target.value))}
@@ -228,6 +233,7 @@ export default function TomeTable({ form, tomeManager }: TomeTableProps) {
                 </td>
                 <td className="px-3 py-1.5">
                   <input
+                    aria-label="Fin"
                     className="w-14 rounded border border-surface-border bg-surface-primary px-2 py-1 text-center text-sm text-text-primary"
                     min="0"
                     onChange={(e) => updateTome(i, "tomeEnd", e.target.value)}
@@ -238,6 +244,7 @@ export default function TomeTable({ form, tomeManager }: TomeTableProps) {
                 </td>
                 <td className="px-3 py-1.5">
                   <input
+                    aria-label="Titre"
                     className="w-full min-w-[100px] rounded border border-surface-border bg-surface-primary px-2 py-1 text-sm text-text-primary"
                     onChange={(e) => updateTome(i, "title", e.target.value)}
                     placeholder="Titre"
@@ -247,6 +254,7 @@ export default function TomeTable({ form, tomeManager }: TomeTableProps) {
                 <td className="px-3 py-1.5">
                   <div className="flex items-center gap-1">
                     <input
+                      aria-label="ISBN"
                       className="w-full min-w-[120px] rounded border border-surface-border bg-surface-primary px-2 py-1 text-sm text-text-primary"
                       onChange={(e) => updateTome(i, "isbn", e.target.value)}
                       placeholder="ISBN"
@@ -299,6 +307,7 @@ export default function TomeTable({ form, tomeManager }: TomeTableProps) {
                 </td>
                 <td className="px-3 py-1.5">
                   <button
+                    aria-label={`Supprimer tome ${tome.number}`}
                     className="rounded p-1 text-red-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/30"
                     onClick={() => removeTome(i)}
                     type="button"

--- a/frontend/src/pages/ComicForm.tsx
+++ b/frontend/src/pages/ComicForm.tsx
@@ -94,7 +94,7 @@ export default function ComicForm() {
     <div className="mx-auto max-w-3xl space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <button aria-label="Retour" className="text-text-muted hover:text-text-secondary" onClick={() => navigate(-1)} type="button">
+        <button aria-label="Retour" className="rounded-lg text-text-muted hover:text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500" onClick={() => navigate(-1)} type="button">
           <ArrowLeft className="h-5 w-5" />
         </button>
         <h1 className="text-xl font-bold text-text-primary">


### PR DESCRIPTION
## Summary

- Ajoute `aria-current="page"` sur le lien actif de BottomNav pour les lecteurs d'écran
- Ajoute `aria-label` sur tous les inputs sans label visible (TomeTable mobile/desktop, SelectListbox sans label prop)
- Rend le `aria-label` du bouton filtres mobile dynamique avec le nombre de filtres actifs
- Ajoute un focus ring visible sur le bouton retour du formulaire série
- Ajoute un séparateur visuel entre les résultats de recherche et l'option « Créer » dans AuthorAutocomplete
- Ajoute `aria-label` sur les boutons supprimer (tomes desktop) et retirer auteur

## Test plan

- [x] Tests BottomNav : `aria-current="page"` sur le lien actif uniquement
- [x] Tests TomeTable : `aria-label` sur les inputs mobile et desktop
- [x] Tests SelectListbox : `aria-label` sur le bouton quand pas de label prop
- [x] Tests Filters : `aria-label` dynamique (0, 1, 2 filtres actifs)
- [x] 758 tests frontend passent
- [x] TypeScript clean (`tsc --noEmit`)

Fixes #272