### PR TITLE
fix(frontend): corrige DataCloneError IndexedDB

### DIFF
--- a/frontend/src/queryClient.ts
+++ b/frontend/src/queryClient.ts
@@ -20,7 +20,9 @@ export const queryClient = new QueryClient({
 function createIDBPersister(idbValidKey: IDBValidKey = "reactQuery"): Persister {
   return {
     persistClient: async (client: PersistedClient) => {
-      await set(idbValidKey, client);
+      // JSON round-trip strips non-cloneable values (Promises from TanStack Query v5 suspense)
+      // that would cause DataCloneError with IndexedDB's structured clone algorithm
+      await set(idbValidKey, JSON.parse(JSON.stringify(client)) as PersistedClient);
     },
     removeClient: async () => {
       await del(idbValidKey);


### PR DESCRIPTION
## Summary
- Corrige l'erreur `DataCloneError: #<Promise> could not be cloned` dans la console
- TanStack Query v5 attache des Promises à l'état des queries (Suspense), incompatibles avec le structured clone d'IndexedDB
- Round-trip JSON avant stockage pour supprimer les valeurs non-sérialisables