### PR TITLE
feat(frontend): indicateur de scroll et animation fade-in

### DIFF
--- a/frontend/src/__tests__/integration/components/CoverSearchModal.test.tsx
+++ b/frontend/src/__tests__/integration/components/CoverSearchModal.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import CoverSearchModal from "../../../components/CoverSearchModal";
@@ -129,5 +129,32 @@ describe("CoverSearchModal", () => {
     await user.click(closeButton);
 
     expect(defaultProps.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows scroll indicator when content overflows", async () => {
+    server.use(
+      http.get("/api/lookup/covers", () => HttpResponse.json(mockResults)),
+    );
+
+    renderWithProviders(<CoverSearchModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByAltText("Naruto Vol. 1")).toBeInTheDocument();
+    });
+
+    // Simulate overflow: scrollHeight > clientHeight
+    const scrollContainer = screen.getByAltText("Naruto Vol. 1").closest(".overflow-y-auto")!;
+    Object.defineProperty(scrollContainer, "scrollHeight", { value: 800, configurable: true });
+    Object.defineProperty(scrollContainer, "clientHeight", { value: 400, configurable: true });
+    Object.defineProperty(scrollContainer, "scrollTop", { value: 0, configurable: true });
+
+    // Trigger scroll event to update state
+    act(() => {
+      scrollContainer.dispatchEvent(new Event("scroll"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scroll-indicator")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/__tests__/integration/components/EmptyState.test.tsx
+++ b/frontend/src/__tests__/integration/components/EmptyState.test.tsx
@@ -64,4 +64,13 @@ describe("EmptyState", () => {
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
+
+  it("has fade-in-up animation class", () => {
+    renderWithProviders(
+      <EmptyState icon={Heart} title="Liste vide" />,
+    );
+
+    const container = screen.getByText("Liste vide").closest("div");
+    expect(container).toHaveClass("animate-fade-in-up");
+  });
 });

--- a/frontend/src/components/CoverSearchModal.tsx
+++ b/frontend/src/components/CoverSearchModal.tsx
@@ -5,7 +5,7 @@ import {
   DialogTitle,
 } from "@headlessui/react";
 import { Search, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useCoverSearch } from "../hooks/useCoverSearch";
 import SkeletonBox from "./SkeletonBox";
 
@@ -28,7 +28,30 @@ export default function CoverSearchModal({
   const [debouncedQuery, setDebouncedQuery] = useState(defaultQuery);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [showScrollIndicator, setShowScrollIndicator] = useState(false);
+
   const { data: results, isLoading } = useCoverSearch(debouncedQuery, type);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 20;
+    setShowScrollIndicator(!nearBottom);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !results || results.length === 0) {
+      setShowScrollIndicator(false);
+      return;
+    }
+    // Check after images may have loaded
+    const timer = setTimeout(() => {
+      setShowScrollIndicator(el.scrollHeight > el.clientHeight);
+    }, 100);
+    return () => clearTimeout(timer);
+  }, [results]);
 
   useEffect(() => {
     setSearchQuery(defaultQuery);
@@ -79,7 +102,8 @@ export default function CoverSearchModal({
             </div>
           </div>
 
-          <div className="overflow-y-auto p-4">
+          <div className="relative">
+          <div className="overflow-y-auto p-4" onScroll={handleScroll} ref={scrollRef}>
             {isLoading && debouncedQuery.length >= 2 && (
               <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
                 {Array.from({ length: 8 }).map((_, i) => (
@@ -122,6 +146,13 @@ export default function CoverSearchModal({
                 Saisissez au moins 2 caractères
               </p>
             )}
+          </div>
+          {showScrollIndicator && (
+            <div
+              className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-surface-primary to-transparent"
+              data-testid="scroll-indicator"
+            />
+          )}
           </div>
         </DialogPanel>
       </div>

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -21,7 +21,7 @@ export default function EmptyState({
   const ctaClassName = "mt-4 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700";
 
   return (
-    <div className="flex flex-col items-center justify-center py-16 text-center">
+    <div className="flex animate-fade-in-up flex-col items-center justify-center py-16 text-center motion-reduce:animate-none">
       <Icon
         className="mb-4 h-16 w-16 text-text-muted/40"
         data-testid="empty-state-icon"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -61,6 +61,22 @@
   }
 }
 
+/* Fade-in + slide-up animation */
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@utility animate-fade-in-up {
+  animation: fade-in-up 0.4s ease-out both;
+}
+
 /* Hide native search cancel button */
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration {


### PR DESCRIPTION
## Summary
- **CoverSearchModal** : dégradé en bas de la grille d'images qui disparaît quand l'utilisateur scrolle jusqu'en bas
- **EmptyState** : animation fade-in + slide-up à l'apparition, désactivée avec `prefers-reduced-motion`
- Tests ajoutés pour les deux composants

Fixes #271

## Test plan
- [ ] Ouvrir CoverSearchModal avec plusieurs résultats → dégradé visible en bas → scroller → dégradé disparaît
- [ ] Naviguer vers une bibliothèque vide → EmptyState apparaît avec animation douce
- [ ] Activer `prefers-reduced-motion` → EmptyState apparaît sans animation