### PR TITLE
feat(frontend): réordonne les boutons d'actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Added
+
+- **CoverSearchModal** : Indicateur de scroll (dégradé) en bas de la grille d'images
+- **EmptyState** : Animation fade-in + slide-up à l'apparition (respecte `prefers-reduced-motion`)
+
+### Changed
+
+- **ComicDetail** : Réordonne la barre d'actions (Modifier → Amazon → Supprimer) et passe le bouton Supprimer en style outline rouge
+
 ## [v2.13.2] - 2026-03-18
 
 ### Fixed

--- a/frontend/src/__tests__/integration/pages/ComicDetail.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicDetail.test.tsx
@@ -940,6 +940,53 @@ describe("ComicDetail", () => {
     expect(screen.queryByRole("link", { name: /amazon/i })).not.toBeInTheDocument();
   });
 
+  it("renders action buttons in correct order: Modifier, Amazon, Supprimer", async () => {
+    server.use(
+      http.get("/api/comic_series/1", () =>
+        HttpResponse.json(
+          createMockComicSeries({
+            amazonUrl: "https://www.amazon.fr/dp/B08N5WRWNW",
+            id: 1,
+            status: ComicStatus.BUYING,
+            title: "Button Order",
+          }),
+        ),
+      ),
+    );
+
+    renderComicDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Button Order")).toBeInTheDocument();
+    });
+
+    const actionBar = screen.getByText("Modifier").closest("div.sticky")!;
+    const buttons = actionBar.querySelectorAll("a, button");
+    expect(buttons).toHaveLength(3);
+    expect(buttons[0]).toHaveTextContent("Modifier");
+    expect(buttons[1]).toHaveTextContent("Amazon");
+    expect(buttons[2]).toHaveTextContent("Supprimer");
+  });
+
+  it("renders delete button with outline/ghost red style instead of solid red", async () => {
+    server.use(
+      http.get("/api/comic_series/1", () =>
+        HttpResponse.json(createMockComicSeries({ id: 1, title: "Ghost Delete" })),
+      ),
+    );
+
+    renderComicDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Ghost Delete")).toBeInTheDocument();
+    });
+
+    const deleteButton = screen.getByText("Supprimer").closest("button")!;
+    expect(deleteButton.className).not.toContain("bg-red-600");
+    expect(deleteButton.className).toContain("border");
+    expect(deleteButton.className).toContain("text-red-600");
+  });
+
   it("shows success toast after delete confirmation", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/pages/ComicDetail.tsx
+++ b/frontend/src/pages/ComicDetail.tsx
@@ -280,14 +280,14 @@ export default function ComicDetail() {
 
       {/* Sticky action bar */}
       <div className="sticky bottom-[var(--bottom-nav-h)] z-40 flex justify-center gap-3 border-t border-surface-border bg-surface-primary px-4 py-3">
-        <button
-          className="flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 text-base font-medium text-white hover:bg-red-700"
-          onClick={() => setShowDelete(true)}
-          type="button"
+        <Link
+          className="flex items-center gap-2 rounded-lg bg-primary-600 px-5 py-2.5 text-base font-medium text-white hover:bg-primary-700"
+          to={`/comic/${comic.id}/edit`}
+          viewTransition
         >
-          <Trash2 className="h-5 w-5" />
-          Supprimer
-        </button>
+          <Edit className="h-5 w-5" />
+          Modifier
+        </Link>
         {comic.status === ComicStatus.BUYING && comic.amazonUrl && (
           <a
             className="flex items-center gap-2 rounded-lg bg-amber-600 px-5 py-2.5 text-base font-medium text-white hover:bg-amber-700"
@@ -299,14 +299,14 @@ export default function ComicDetail() {
             Amazon
           </a>
         )}
-        <Link
-          className="flex items-center gap-2 rounded-lg bg-primary-600 px-5 py-2.5 text-base font-medium text-white hover:bg-primary-700"
-          to={`/comic/${comic.id}/edit`}
-          viewTransition
+        <button
+          className="flex items-center gap-2 rounded-lg border border-red-600 px-5 py-2.5 text-base font-medium text-red-600 hover:bg-red-50 dark:text-red-400 dark:border-red-400 dark:hover:bg-red-950/30"
+          onClick={() => setShowDelete(true)}
+          type="button"
         >
-          <Edit className="h-5 w-5" />
-          Modifier
-        </Link>
+          <Trash2 className="h-5 w-5" />
+          Supprimer
+        </button>
       </div>
 
       <ConfirmModal


### PR DESCRIPTION
## Summary
- Réordonne la barre d'actions : **Modifier** → **Amazon** → **Supprimer** (l'action principale en premier)
- Le bouton Supprimer passe en style outline rouge (ghost) pour réduire son poids visuel
- Support dark mode pour le nouveau style du bouton

## Test plan
- [x] 772 tests frontend passent
- [x] Lint clean (`tsc --noEmit`)
- [ ] Vérifier visuellement l'ordre des boutons sur la page détail
- [ ] Vérifier le style outline rouge du bouton Supprimer (light + dark mode)

fixes #298