### PR TITLE
feat(frontend): visual design & polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 ### Changed
 
 - **ComicDetail** : Réordonne la barre d'actions (Modifier → Amazon → Supprimer) et passe le bouton Supprimer en style outline rouge
+- **ComicDetail** : Badges de statut colorés (bleu En cours, vert Terminé, orange Arrêté, violet Wishlist) au lieu du gris uniforme
+- **Layout** : Séparateur visuel avant le bouton Déconnexion dans le header
+- **Tools** : Uniformise la taille du titre de page (`text-xl` comme les autres pages)
 
 ## [v2.13.2] - 2026-03-18
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -63,6 +63,7 @@ export default function Layout() {
           >
             {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
           </button>
+          <div className="mx-1 h-5 w-px bg-surface-border" />
           <button
             aria-label="Déconnexion"
             className="rounded-lg p-2 text-text-secondary hover:bg-surface-tertiary"

--- a/frontend/src/pages/ComicDetail.tsx
+++ b/frontend/src/pages/ComicDetail.tsx
@@ -11,7 +11,7 @@ import type { Tome } from "../types/api";
 import { useComic } from "../hooks/useComic";
 import { useDeleteComic } from "../hooks/useDeleteComic";
 import { useUpdateTome } from "../hooks/useUpdateTome";
-import { ComicStatus, ComicStatusLabel, ComicTypeLabel, ComicTypePlaceholder } from "../types/enums";
+import { ComicStatus, ComicStatusColor, ComicStatusLabel, ComicTypeLabel, ComicTypePlaceholder } from "../types/enums";
 import { getCoverSrc } from "../utils/coverUtils";
 import { countCoveredTomes } from "../utils/tomeUtils";
 
@@ -163,7 +163,7 @@ export default function ComicDetail() {
             <span className="rounded-full bg-primary-100 px-3 py-1 text-sm font-medium text-primary-700 dark:bg-primary-950/30 dark:text-primary-400">
               {ComicTypeLabel[comic.type]}
             </span>
-            <span className="rounded-full bg-surface-tertiary px-3 py-1 text-sm font-medium text-text-secondary">
+            <span className={`rounded-full px-3 py-1 text-sm font-medium ${ComicStatusColor[comic.status]}`}>
               {ComicStatusLabel[comic.status]}
             </span>
             {comic.isOneShot && (

--- a/frontend/src/pages/Tools.tsx
+++ b/frontend/src/pages/Tools.tsx
@@ -58,7 +58,7 @@ export default function Tools() {
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-6">
-      <h1 className="mb-6 text-2xl font-bold text-text-primary">Outils</h1>
+      <h1 className="mb-6 text-xl font-bold text-text-primary">Outils</h1>
 
       <div className="grid gap-4 sm:grid-cols-2">
         {tools.map(({ description, icon: Icon, title, to }) => (

--- a/frontend/src/types/enums.ts
+++ b/frontend/src/types/enums.ts
@@ -7,6 +7,13 @@ export const ComicStatus = {
 
 export type ComicStatus = (typeof ComicStatus)[keyof typeof ComicStatus];
 
+export const ComicStatusColor: Record<ComicStatus, string> = {
+  [ComicStatus.BUYING]: "bg-blue-100 text-blue-700 dark:bg-blue-950/30 dark:text-blue-400",
+  [ComicStatus.FINISHED]: "bg-green-100 text-green-700 dark:bg-green-950/30 dark:text-green-400",
+  [ComicStatus.STOPPED]: "bg-orange-100 text-orange-700 dark:bg-orange-950/30 dark:text-orange-400",
+  [ComicStatus.WISHLIST]: "bg-violet-100 text-violet-700 dark:bg-violet-950/30 dark:text-violet-400",
+};
+
 export const ComicStatusLabel: Record<ComicStatus, string> = {
   [ComicStatus.BUYING]: "En cours d'achat",
   [ComicStatus.FINISHED]: "Terminé",


### PR DESCRIPTION
## Summary

- **Séparateur header** : ajoute un trait vertical subtil avant le bouton Déconnexion pour le différencier des icônes utilitaires (#299)
- **Titres de page** : uniformise sur `text-xl font-bold` (Tools utilisait `text-2xl`) (#300)
- **Badges de statut colorés** : bleu (En cours), vert (Terminé), orange (Arrêté), violet (Wishlist) au lieu du gris uniforme (#301)

Fixes #291, fixes #299, fixes #300, fixes #301

## Test plan

- [x] TypeScript compile sans erreur
- [x] 733 tests passent (Vitest)
- [ ] Vérifier visuellement le séparateur dans le header (clair + sombre)
- [ ] Vérifier les badges colorés sur une série de chaque statut
- [ ] Vérifier que la page Outils a le même style de titre que les autres