### PR TITLE
chore: ignore .superpowers/ et phpstan-baseline-new.neon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,12 +64,14 @@ logs/
 ###> local ###
 .DS_Store
 .claude/
+.superpowers/
 .worktrees/
 docs/plans/
 .ddev/share-providers/
 .phpunit.cache/
 .playwright-mcp/
 assets/
+backend/phpstan-baseline-new.neon
 public/
 test-results/
 var/


### PR DESCRIPTION
## Summary
- Ajoute `.superpowers/` et `backend/phpstan-baseline-new.neon` au `.gitignore`