### PR TITLE
feat(frontend): actions en masse sur la table des tomes

### DIFF
--- a/frontend/src/__tests__/integration/pages/ComicDetailToggle.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicDetailToggle.test.tsx
@@ -223,6 +223,185 @@ describe("ComicDetail — inline tome toggle", () => {
     });
   });
 
+  it("renders header checkboxes for bulk toggle", async () => {
+    const tomes = [
+      createMockTome({ bought: true, downloaded: false, id: 10, number: 1, onNas: false, read: false }),
+      createMockTome({ bought: true, downloaded: false, id: 11, number: 2, onNas: false, read: false }),
+    ];
+
+    server.use(
+      http.get("/api/comic_series/1", () =>
+        HttpResponse.json(
+          createMockComicSeries({ id: 1, isOneShot: false, title: "Test", tomes }),
+        ),
+      ),
+    );
+
+    renderComicDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Tomes (2)")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("checkbox", { name: /tout cocher acheté/i })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: /tout cocher téléchargé/i })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: /tout cocher lu/i })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: /tout cocher nas/i })).toBeInTheDocument();
+  });
+
+  it("select all: when none checked, click checks all and sends PATCH for each", async () => {
+    const user = userEvent.setup();
+    const patchedIds: number[] = [];
+
+    const tomes = [
+      createMockTome({ bought: false, id: 10, number: 1 }),
+      createMockTome({ bought: false, id: 11, number: 2 }),
+      createMockTome({ bought: false, id: 12, number: 3 }),
+    ];
+
+    server.use(
+      http.get("/api/comic_series/1", () =>
+        HttpResponse.json(
+          createMockComicSeries({ id: 1, isOneShot: false, title: "Test", tomes }),
+        ),
+      ),
+      http.patch("/api/tomes/:id", async ({ params }) => {
+        patchedIds.push(Number(params.id));
+        return HttpResponse.json(createMockTome({ bought: true, id: Number(params.id) }));
+      }),
+    );
+
+    renderComicDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Tomes (3)")).toBeInTheDocument();
+    });
+
+    const headerCheckbox = screen.getByRole("checkbox", { name: /tout cocher acheté/i });
+    await user.click(headerCheckbox);
+
+    // All row checkboxes should be checked optimistically
+    const rows = screen.getAllByRole("row").slice(1); // skip header
+    for (const row of rows) {
+      const checkboxes = within(row).getAllByRole("checkbox");
+      expect(checkboxes[0]).toBeChecked(); // bought column
+    }
+
+    // PATCH calls for all 3 tomes
+    await waitFor(() => {
+      expect(patchedIds).toHaveLength(3);
+    });
+    expect(patchedIds.sort()).toEqual([10, 11, 12]);
+  });
+
+  it("deselect all: when all checked, click unchecks all", async () => {
+    const user = userEvent.setup();
+    const patchBodies: Array<Record<string, unknown>> = [];
+
+    const tomes = [
+      createMockTome({ bought: true, id: 10, number: 1 }),
+      createMockTome({ bought: true, id: 11, number: 2 }),
+    ];
+
+    server.use(
+      http.get("/api/comic_series/1", () =>
+        HttpResponse.json(
+          createMockComicSeries({ id: 1, isOneShot: false, title: "Test", tomes }),
+        ),
+      ),
+      http.patch("/api/tomes/:id", async ({ request }) => {
+        patchBodies.push((await request.json()) as Record<string, unknown>);
+        return HttpResponse.json(createMockTome({ bought: false, id: 10 }));
+      }),
+    );
+
+    renderComicDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Tomes (2)")).toBeInTheDocument();
+    });
+
+    const headerCheckbox = screen.getByRole("checkbox", { name: /tout cocher acheté/i });
+    expect(headerCheckbox).toBeChecked();
+
+    await user.click(headerCheckbox);
+
+    // All row checkboxes should be unchecked
+    const rows = screen.getAllByRole("row").slice(1);
+    for (const row of rows) {
+      const checkboxes = within(row).getAllByRole("checkbox");
+      expect(checkboxes[0]).not.toBeChecked();
+    }
+
+    await waitFor(() => {
+      expect(patchBodies).toHaveLength(2);
+    });
+    expect(patchBodies[0]).toEqual(expect.objectContaining({ bought: false }));
+  });
+
+  it("header checkbox is indeterminate when some tomes are checked", async () => {
+    const tomes = [
+      createMockTome({ bought: true, id: 10, number: 1 }),
+      createMockTome({ bought: false, id: 11, number: 2 }),
+    ];
+
+    server.use(
+      http.get("/api/comic_series/1", () =>
+        HttpResponse.json(
+          createMockComicSeries({ id: 1, isOneShot: false, title: "Test", tomes }),
+        ),
+      ),
+    );
+
+    renderComicDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Tomes (2)")).toBeInTheDocument();
+    });
+
+    const headerCheckbox = screen.getByRole("checkbox", { name: /tout cocher acheté/i }) as HTMLInputElement;
+    expect(headerCheckbox.indeterminate).toBe(true);
+    expect(headerCheckbox.checked).toBe(false);
+  });
+
+  it("only sends PATCH for tomes that actually changed", async () => {
+    const user = userEvent.setup();
+    const patchedIds: number[] = [];
+
+    const tomes = [
+      createMockTome({ downloaded: true, id: 10, number: 1 }),
+      createMockTome({ downloaded: false, id: 11, number: 2 }),
+      createMockTome({ downloaded: true, id: 12, number: 3 }),
+    ];
+
+    server.use(
+      http.get("/api/comic_series/1", () =>
+        HttpResponse.json(
+          createMockComicSeries({ id: 1, isOneShot: false, title: "Test", tomes }),
+        ),
+      ),
+      http.patch("/api/tomes/:id", async ({ params }) => {
+        patchedIds.push(Number(params.id));
+        return HttpResponse.json(createMockTome({ downloaded: true, id: Number(params.id) }));
+      }),
+    );
+
+    renderComicDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Tomes (3)")).toBeInTheDocument();
+    });
+
+    // Click "select all downloaded" — only tome 11 needs changing
+    const headerCheckbox = screen.getByRole("checkbox", { name: /tout cocher téléchargé/i });
+    await user.click(headerCheckbox);
+
+    await waitFor(() => {
+      expect(patchedIds).toHaveLength(1);
+    });
+    expect(patchedIds[0]).toBe(11);
+  });
+
   it("checkboxes have accessible labels", async () => {
     const tomes = [
       createMockTome({ id: 10, number: 3 }),

--- a/frontend/src/pages/ComicDetail.tsx
+++ b/frontend/src/pages/ComicDetail.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, BookOpen, Edit, ExternalLink, Trash2 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import ConfirmModal from "../components/ConfirmModal";
@@ -14,6 +14,39 @@ import { useUpdateTome } from "../hooks/useUpdateTome";
 import { ComicStatus, ComicStatusColor, ComicStatusLabel, ComicTypeLabel, ComicTypePlaceholder } from "../types/enums";
 import { getCoverSrc } from "../utils/coverUtils";
 import { countCoveredTomes } from "../utils/tomeUtils";
+
+type BooleanField = "bought" | "downloaded" | "onNas" | "read";
+
+const FIELD_LABELS: Record<BooleanField, string> = {
+  bought: "acheté",
+  downloaded: "téléchargé",
+  onNas: "NAS",
+  read: "lu",
+};
+
+function HeaderCheckbox({ field, onChange, tomes }: { field: BooleanField; onChange: () => void; tomes: Tome[] }) {
+  const ref = useRef<HTMLInputElement>(null);
+  const checkedCount = tomes.filter((t) => t[field]).length;
+  const allChecked = checkedCount === tomes.length;
+  const someChecked = checkedCount > 0 && !allChecked;
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.indeterminate = someChecked;
+    }
+  }, [someChecked]);
+
+  return (
+    <input
+      aria-label={`Tout cocher ${FIELD_LABELS[field]}`}
+      checked={allChecked}
+      className="h-4 w-4 cursor-pointer accent-primary-600"
+      onChange={onChange}
+      ref={ref}
+      type="checkbox"
+    />
+  );
+}
 
 function formatRelativeDate(isoDate: string): string {
   const date = new Date(isoDate);
@@ -83,6 +116,37 @@ export default function ComicDetail() {
       );
     },
     [updateTome],
+  );
+
+  const handleToggleAllTomes = useCallback(
+    (field: "bought" | "downloaded" | "onNas" | "read") => {
+      const allChecked = optimisticTomes.every((t) => t[field]);
+      const targetValue = !allChecked;
+
+      const tomesToUpdate = optimisticTomes.filter((t) => t[field] !== targetValue);
+      if (tomesToUpdate.length === 0) return;
+
+      // Optimistic update: batch all tomes at once
+      setOptimisticTomes((prev) =>
+        prev.map((t) => ({ ...t, [field]: targetValue })),
+      );
+
+      // Fire individual PATCH mutations for tomes that need changing
+      for (const tome of tomesToUpdate) {
+        updateTome.mutate(
+          { id: tome.id, [field]: targetValue },
+          {
+            onError: () => {
+              setOptimisticTomes((prev) =>
+                prev.map((t) => (t.id === tome.id ? { ...t, [field]: tome[field] } : t)),
+              );
+              toast.error("Erreur lors de la mise à jour du tome");
+            },
+          },
+        );
+      }
+    },
+    [optimisticTomes, updateTome],
   );
 
   if (isLoading) {
@@ -243,10 +307,14 @@ export default function ComicDetail() {
                 <tr>
                   <th className="px-4 py-2 text-left font-medium text-text-secondary">#</th>
                   <th className="px-4 py-2 text-left font-medium text-text-secondary">Titre</th>
-                  <th className="px-4 py-2 text-center font-medium text-text-secondary">Acheté</th>
-                  <th className="px-4 py-2 text-center font-medium text-text-secondary">Téléchargé</th>
-                  <th className="px-4 py-2 text-center font-medium text-text-secondary">Lu</th>
-                  <th className="px-4 py-2 text-center font-medium text-text-secondary">NAS</th>
+                  {(["bought", "downloaded", "read", "onNas"] as const).map((field) => (
+                    <th className="px-4 py-2 text-center font-medium text-text-secondary" key={field}>
+                      <div className="flex flex-col items-center gap-1">
+                        <span>{field === "bought" ? "Acheté" : field === "downloaded" ? "Téléchargé" : field === "read" ? "Lu" : "NAS"}</span>
+                        <HeaderCheckbox field={field} onChange={() => handleToggleAllTomes(field)} tomes={optimisticTomes} />
+                      </div>
+                    </th>
+                  ))}
                 </tr>
               </thead>
               <tbody className="divide-y divide-surface-border">


### PR DESCRIPTION
## Summary
- Ajoute une checkbox dans chaque en-tête de colonne booléenne (Acheté, Téléchargé, Lu, NAS) de la table des tomes
- Checked = tous cochés, indeterminate = certains cochés, unchecked = aucun
- Click envoie des PATCH uniquement pour les tomes dont la valeur change (optimistic update immédiat)

## Test Plan
- [x] 5 nouveaux tests d'intégration (header renders, select all, deselect all, indeterminate, only-changed PATCH)
- [x] 44 tests ComicDetail existants toujours verts
- [x] `make lint-front` OK
- [ ] Manuel : ouvrir une série avec plusieurs tomes, vérifier les checkboxes d'en-tête

fixes #302