### PR TITLE
feat(frontend): sections repliables dans le formulaire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **ComicForm** : Sections repliables (Info générale, Publication, Média) — les champs restent dans le DOM pour que le lookup autofill fonctionne même replié
 - **ComicDetail** : Actions en masse sur la table des tomes — checkbox dans les en-têtes pour cocher/décocher tous les tomes par colonne (état indeterminate, PATCH optimiste)
 - **CoverSearchModal** : Indicateur de scroll (dégradé) en bas de la grille d'images
 - **EmptyState** : Animation fade-in + slide-up à l'apparition (respecte `prefers-reduced-motion`)

--- a/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
@@ -1648,6 +1648,108 @@ describe("ComicForm", () => {
     });
   });
 
+  describe("Collapsible sections", () => {
+    it("renders section headers for all four groups", () => {
+      renderCreateForm();
+
+      expect(screen.getByRole("button", { name: /Info générale/ })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Publication/ })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Média/ })).toBeInTheDocument();
+    });
+
+    it("sections are expanded by default", () => {
+      renderCreateForm();
+
+      // Fields in each section should be visible
+      expect(screen.getByLabelText("Titre *")).toBeVisible();
+      expect(screen.getByLabelText("Éditeur")).toBeVisible();
+      expect(screen.getByLabelText("URL de couverture")).toBeVisible();
+    });
+
+    it("collapses a section when clicking its header", async () => {
+      const user = userEvent.setup();
+      renderCreateForm();
+
+      const publicationHeader = screen.getByRole("button", { name: /Publication/ });
+      await user.click(publicationHeader);
+
+      // Publisher field should be hidden but still in DOM
+      const publisherInput = screen.getByLabelText("Éditeur");
+      expect(publisherInput).not.toBeVisible();
+    });
+
+    it("keeps collapsed section fields in DOM for lookup autofill", async () => {
+      const user = userEvent.setup();
+      renderCreateForm();
+
+      // Collapse all sections
+      await user.click(screen.getByRole("button", { name: /Publication/ }));
+      await user.click(screen.getByRole("button", { name: /Média/ }));
+
+      // Fields should still be in the DOM (unmount={false})
+      expect(screen.getByLabelText("Éditeur")).toBeInTheDocument();
+      expect(screen.getByLabelText("URL de couverture")).toBeInTheDocument();
+      expect(screen.getByLabelText("Description")).toBeInTheDocument();
+    });
+
+    it("lookup autofill fills fields in collapsed sections", async () => {
+      const user = userEvent.setup();
+
+      const lookupResult = createMockLookupResult({
+        authors: "Test Author",
+        description: "A great description",
+        publisher: "TestPub",
+        thumbnail: "https://example.com/cover.jpg",
+        title: "Lookup Title",
+      });
+
+      server.use(mockTitleLookup(lookupResult));
+
+      renderCreateForm();
+
+      // Collapse Publication and Média sections
+      await user.click(screen.getByRole("button", { name: /Publication/ }));
+      await user.click(screen.getByRole("button", { name: /Média/ }));
+
+      // Perform lookup
+      const lookupInput = screen.getByPlaceholderText("Titre de la série");
+      await user.type(lookupInput, "Lookup Title");
+
+      await waitFor(() => {
+        expect(screen.getByText("Lookup Title")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Lookup Title"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Appliquer")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Appliquer"));
+
+      // Fields in collapsed sections should still be filled
+      await waitFor(() => {
+        expect(screen.getByLabelText("Titre *")).toHaveValue("Lookup Title");
+      });
+      expect(screen.getByLabelText("Éditeur")).toHaveValue("TestPub");
+      expect(screen.getByLabelText("Description")).toHaveValue("A great description");
+      expect(screen.getByLabelText("URL de couverture")).toHaveValue("https://example.com/cover.jpg");
+    });
+
+    it("expands a collapsed section when clicking its header again", async () => {
+      const user = userEvent.setup();
+      renderCreateForm();
+
+      const publicationHeader = screen.getByRole("button", { name: /Publication/ });
+
+      // Collapse
+      await user.click(publicationHeader);
+      expect(screen.getByLabelText("Éditeur")).not.toBeVisible();
+
+      // Expand
+      await user.click(publicationHeader);
+      expect(screen.getByLabelText("Éditeur")).toBeVisible();
+    });
+  });
+
   describe("Navigation", () => {
     it("navigates back when clicking the back arrow", async () => {
       const user = userEvent.setup();

--- a/frontend/src/components/CollapsibleSection.tsx
+++ b/frontend/src/components/CollapsibleSection.tsx
@@ -1,0 +1,34 @@
+import { Disclosure, DisclosureButton, DisclosurePanel } from "@headlessui/react";
+import { ChevronDown } from "lucide-react";
+
+interface CollapsibleSectionProps {
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+  title: string;
+}
+
+export default function CollapsibleSection({
+  children,
+  defaultOpen = true,
+  title,
+}: CollapsibleSectionProps) {
+  return (
+    <Disclosure defaultOpen={defaultOpen}>
+      {({ open }) => (
+        <div>
+          <DisclosureButton className="flex w-full items-center gap-2 rounded-lg py-2 text-left text-sm font-semibold text-text-primary hover:text-primary-600">
+            <ChevronDown
+              className={`h-4 w-4 transition-transform ${open ? "" : "-rotate-90"}`}
+            />
+            {title}
+          </DisclosureButton>
+          <DisclosurePanel static>
+            <div className="space-y-5" hidden={!open}>
+              {children}
+            </div>
+          </DisclosurePanel>
+        </div>
+      )}
+    </Disclosure>
+  );
+}

--- a/frontend/src/pages/ComicForm.tsx
+++ b/frontend/src/pages/ComicForm.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, Image, Loader2 } from "lucide-react";
 import AuthorAutocomplete from "../components/AuthorAutocomplete";
+import CollapsibleSection from "../components/CollapsibleSection";
 import CoverSearchModal from "../components/CoverSearchModal";
 import DatePartialSelect from "../components/DatePartialSelect";
 import LookupSection from "../components/LookupSection";
@@ -135,187 +136,187 @@ export default function ComicForm() {
 
       {/* Form */}
       <form className="space-y-5" onSubmit={handleSubmit}>
-        {/* Title */}
-        <div>
-          <label className={formLabelClassName} htmlFor="title">
-            Titre *
-          </label>
-          <input
-            className={`w-full ${formInputClassName}`}
-            id="title"
-            onChange={(e) => update("title", e.target.value)}
-            required
-            value={form.title}
-          />
-        </div>
-
-        {/* Type + Status */}
-        <div className="grid grid-cols-2 gap-4">
-          <SelectListbox
-            buttonClassName={formListboxButtonClassName}
-            label="Type *"
-            onChange={(v) => update("type", v)}
-            options={typeOptions}
-            value={form.type}
-          />
-          <SelectListbox
-            buttonClassName={formListboxButtonClassName}
-            label="Statut *"
-            onChange={(v) => update("status", v)}
-            options={statusOptions}
-            value={form.status}
-          />
-        </div>
-
-        {/* One-shot toggle */}
-        <label className="flex items-center gap-2">
-          <input
-            checked={form.isOneShot}
-            className={formCheckboxClassName}
-            onChange={(e) => update("isOneShot", e.target.checked)}
-            type="checkbox"
-          />
-          <span className="text-sm font-medium text-text-secondary">One-shot (pas de tomes)</span>
-        </label>
-
-        {/* Publisher */}
-        <div>
-          <label className={formLabelClassName} htmlFor="publisher">
-            Éditeur
-          </label>
-          <input
-            className={`w-full ${formInputClassName}`}
-            id="publisher"
-            onChange={(e) => update("publisher", e.target.value)}
-            value={form.publisher}
-          />
-        </div>
-
-        {/* Published date */}
-        <DatePartialSelect
-          label="Date de parution"
-          onChange={(v) => update("publishedDate", v)}
-          value={form.publishedDate}
-        />
-
-        {/* Cover URL */}
-        <div>
-          <label className={formLabelClassName} htmlFor="coverUrl">
-            URL de couverture
-          </label>
-          <div className="flex gap-2">
-            <input
-              className={`min-w-0 flex-1 ${formInputClassName}`}
-              id="coverUrl"
-              onChange={(e) => update("coverUrl", e.target.value)}
-              placeholder="https://..."
-              type="url"
-              value={form.coverUrl}
-            />
-            <button
-              className="shrink-0 rounded-lg border border-surface-border px-3 py-2 text-sm text-text-secondary hover:bg-surface-tertiary disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={!isOnline}
-              onClick={() => setCoverSearchOpen(true)}
-              title="Rechercher une couverture"
-              type="button"
-            >
-              <Image className="h-4 w-4" />
-            </button>
-          </div>
-          {form.coverUrl && (
-            <img alt="Aperçu" className="mt-2 h-32 rounded-lg shadow" src={form.coverUrl} />
-          )}
-        </div>
-        <CoverSearchModal
-          defaultQuery={form.title}
-          onClose={() => setCoverSearchOpen(false)}
-          onSelect={(url) => {
-            update("coverUrl", url);
-            setCoverSearchOpen(false);
-          }}
-          open={coverSearchOpen}
-          type={form.type}
-        />
-
-        {/* Authors */}
-        <AuthorAutocomplete
-          addAuthor={addAuthor}
-          authorOptions={authorOptions}
-          authorSearch={authorSearch}
-          authors={form.authors}
-          removeAuthor={removeAuthor}
-          setAuthorSearch={setAuthorSearch}
-        />
-
-        {/* Description */}
-        <div>
-          <label className={formLabelClassName} htmlFor="description">
-            Description
-          </label>
-          <textarea
-            className={`w-full ${formInputClassName}`}
-            id="description"
-            onChange={(e) => update("description", e.target.value)}
-            rows={3}
-            value={form.description}
-          />
-        </div>
-
-        {/* Latest published issue + publication complete + default flags */}
-        <div className="flex flex-wrap items-end gap-x-6 gap-y-2">
+        {/* Info générale */}
+        <CollapsibleSection title="Info générale">
           <div>
-            <label className={formLabelClassName} htmlFor="latestPublishedIssue">
-              Dernier tome paru
+            <label className={formLabelClassName} htmlFor="title">
+              Titre *
             </label>
             <input
-              className={`w-32 ${formInputClassName}`}
-              id="latestPublishedIssue"
-              min="0"
-              onChange={(e) => update("latestPublishedIssue", e.target.value)}
-              type="number"
-              value={form.latestPublishedIssue}
+              className={`w-full ${formInputClassName}`}
+              id="title"
+              onChange={(e) => update("title", e.target.value)}
+              required
+              value={form.title}
             />
           </div>
-          <label className="flex items-center gap-2 pb-2">
+
+          <div className="grid grid-cols-2 gap-4">
+            <SelectListbox
+              buttonClassName={formListboxButtonClassName}
+              label="Type *"
+              onChange={(v) => update("type", v)}
+              options={typeOptions}
+              value={form.type}
+            />
+            <SelectListbox
+              buttonClassName={formListboxButtonClassName}
+              label="Statut *"
+              onChange={(v) => update("status", v)}
+              options={statusOptions}
+              value={form.status}
+            />
+          </div>
+
+          <label className="flex items-center gap-2">
             <input
-              checked={form.latestPublishedIssueComplete}
+              checked={form.isOneShot}
               className={formCheckboxClassName}
-              onChange={(e) => update("latestPublishedIssueComplete", e.target.checked)}
+              onChange={(e) => update("isOneShot", e.target.checked)}
               type="checkbox"
             />
-            <span className="text-sm font-medium text-text-secondary">Parution terminée</span>
+            <span className="text-sm font-medium text-text-secondary">One-shot (pas de tomes)</span>
           </label>
-          <div className="flex items-center gap-4 pb-2">
-            <span className="text-sm font-medium text-text-secondary">Flags par défaut :</span>
-            <label className="flex items-center gap-1.5">
-              <input
-                checked={form.defaultTomeBought}
-                className={formCheckboxClassName}
-                onChange={(e) => update("defaultTomeBought", e.target.checked)}
-                type="checkbox"
-              />
-              <span className="text-sm text-text-secondary">Achetés</span>
+        </CollapsibleSection>
+
+        {/* Publication */}
+        <CollapsibleSection title="Publication">
+          <div>
+            <label className={formLabelClassName} htmlFor="publisher">
+              Éditeur
             </label>
-            <label className="flex items-center gap-1.5">
-              <input
-                checked={form.defaultTomeDownloaded}
-                className={formCheckboxClassName}
-                onChange={(e) => update("defaultTomeDownloaded", e.target.checked)}
-                type="checkbox"
-              />
-              <span className="text-sm text-text-secondary">Téléchargés</span>
-            </label>
-            <label className="flex items-center gap-1.5">
-              <input
-                checked={form.defaultTomeRead}
-                className={formCheckboxClassName}
-                onChange={(e) => update("defaultTomeRead", e.target.checked)}
-                type="checkbox"
-              />
-              <span className="text-sm text-text-secondary">Lus</span>
-            </label>
+            <input
+              className={`w-full ${formInputClassName}`}
+              id="publisher"
+              onChange={(e) => update("publisher", e.target.value)}
+              value={form.publisher}
+            />
           </div>
-        </div>
+
+          <DatePartialSelect
+            label="Date de parution"
+            onChange={(v) => update("publishedDate", v)}
+            value={form.publishedDate}
+          />
+
+          <div className="flex flex-wrap items-end gap-x-6 gap-y-2">
+            <div>
+              <label className={formLabelClassName} htmlFor="latestPublishedIssue">
+                Dernier tome paru
+              </label>
+              <input
+                className={`w-32 ${formInputClassName}`}
+                id="latestPublishedIssue"
+                min="0"
+                onChange={(e) => update("latestPublishedIssue", e.target.value)}
+                type="number"
+                value={form.latestPublishedIssue}
+              />
+            </div>
+            <label className="flex items-center gap-2 pb-2">
+              <input
+                checked={form.latestPublishedIssueComplete}
+                className={formCheckboxClassName}
+                onChange={(e) => update("latestPublishedIssueComplete", e.target.checked)}
+                type="checkbox"
+              />
+              <span className="text-sm font-medium text-text-secondary">Parution terminée</span>
+            </label>
+            <div className="flex items-center gap-4 pb-2">
+              <span className="text-sm font-medium text-text-secondary">Flags par défaut :</span>
+              <label className="flex items-center gap-1.5">
+                <input
+                  checked={form.defaultTomeBought}
+                  className={formCheckboxClassName}
+                  onChange={(e) => update("defaultTomeBought", e.target.checked)}
+                  type="checkbox"
+                />
+                <span className="text-sm text-text-secondary">Achetés</span>
+              </label>
+              <label className="flex items-center gap-1.5">
+                <input
+                  checked={form.defaultTomeDownloaded}
+                  className={formCheckboxClassName}
+                  onChange={(e) => update("defaultTomeDownloaded", e.target.checked)}
+                  type="checkbox"
+                />
+                <span className="text-sm text-text-secondary">Téléchargés</span>
+              </label>
+              <label className="flex items-center gap-1.5">
+                <input
+                  checked={form.defaultTomeRead}
+                  className={formCheckboxClassName}
+                  onChange={(e) => update("defaultTomeRead", e.target.checked)}
+                  type="checkbox"
+                />
+                <span className="text-sm text-text-secondary">Lus</span>
+              </label>
+            </div>
+          </div>
+        </CollapsibleSection>
+
+        {/* Média */}
+        <CollapsibleSection title="Média">
+          <div>
+            <label className={formLabelClassName} htmlFor="coverUrl">
+              URL de couverture
+            </label>
+            <div className="flex gap-2">
+              <input
+                className={`min-w-0 flex-1 ${formInputClassName}`}
+                id="coverUrl"
+                onChange={(e) => update("coverUrl", e.target.value)}
+                placeholder="https://..."
+                type="url"
+                value={form.coverUrl}
+              />
+              <button
+                className="shrink-0 rounded-lg border border-surface-border px-3 py-2 text-sm text-text-secondary hover:bg-surface-tertiary disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={!isOnline}
+                onClick={() => setCoverSearchOpen(true)}
+                title="Rechercher une couverture"
+                type="button"
+              >
+                <Image className="h-4 w-4" />
+              </button>
+            </div>
+            {form.coverUrl && (
+              <img alt="Aperçu" className="mt-2 h-32 rounded-lg shadow" src={form.coverUrl} />
+            )}
+          </div>
+          <CoverSearchModal
+            defaultQuery={form.title}
+            onClose={() => setCoverSearchOpen(false)}
+            onSelect={(url) => {
+              update("coverUrl", url);
+              setCoverSearchOpen(false);
+            }}
+            open={coverSearchOpen}
+            type={form.type}
+          />
+
+          <AuthorAutocomplete
+            addAuthor={addAuthor}
+            authorOptions={authorOptions}
+            authorSearch={authorSearch}
+            authors={form.authors}
+            removeAuthor={removeAuthor}
+            setAuthorSearch={setAuthorSearch}
+          />
+
+          <div>
+            <label className={formLabelClassName} htmlFor="description">
+              Description
+            </label>
+            <textarea
+              className={`w-full ${formInputClassName}`}
+              id="description"
+              onChange={(e) => update("description", e.target.value)}
+              rows={3}
+              value={form.description}
+            />
+          </div>
+        </CollapsibleSection>
 
         {/* Tomes */}
         {!form.isOneShot && (


### PR DESCRIPTION
## Summary

- Ajoute un composant `CollapsibleSection` (Headless UI Disclosure + `DisclosurePanel static`) pour grouper les champs du formulaire en sections repliables
- Regroupe les champs de `ComicForm` en 3 sections : **Info générale** (titre, type, statut, one-shot), **Publication** (éditeur, date, dernier tome, flags), **Média** (couverture, auteurs, description)
- Les champs restent dans le DOM même repliés (`hidden` attribute) pour garantir le fonctionnement du lookup autofill
- La section Tomes n'est pas wrappée car `TomeTable` a déjà son propre header avec compteur

Fixes #311

## Test plan

- [x] 6 nouveaux tests : rendu des headers, collapse/expand, persistance DOM, lookup autofill en mode replié
- [x] 783 tests frontend passent
- [x] TypeScript clean (`tsc --noEmit`)