### PR TITLE
feat(frontend): augmente les cibles tactiles à 44px minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
+- **ComicCard / ComicDetail / ComicForm** : Cibles tactiles augmentées à 44px minimum (menu 3-dot, flèche retour) pour conformité accessibilité mobile
 - **ComicDetail** : Réordonne la barre d'actions (Modifier → Amazon → Supprimer) et passe le bouton Supprimer en style outline rouge
 - **ComicDetail / Home** : Toast undo (5s) au lieu de modale de confirmation pour la suppression — permet d'annuler via le bouton « Annuler »
 - **ComicDetail** : Toasts de toggle de tomes regroupés — attend 1s après le dernier toggle, affiche un seul « N tomes mis à jour »

--- a/frontend/src/components/ComicCard.tsx
+++ b/frontend/src/components/ComicCard.tsx
@@ -107,7 +107,7 @@ export default memo(function ComicCard({ comic, onDelete, onMenuOpen }: ComicCar
               {/* Mobile: simple button → CardActionBar */}
               <button
                 aria-label="Actions"
-                className="shrink-0 rounded-lg p-1 text-text-muted hover:bg-surface-tertiary lg:hidden"
+                className="shrink-0 rounded-lg p-2.5 text-text-muted hover:bg-surface-tertiary lg:hidden"
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
@@ -123,7 +123,7 @@ export default memo(function ComicCard({ comic, onDelete, onMenuOpen }: ComicCar
               <Menu as="div" className="relative hidden shrink-0 lg:block">
                 <MenuButton
                   aria-label="Actions"
-                  className="rounded-lg p-1 text-text-muted hover:bg-surface-tertiary"
+                  className="rounded-lg p-2.5 text-text-muted hover:bg-surface-tertiary"
                   onClick={(e: React.MouseEvent) => {
                     e.preventDefault();
                     e.stopPropagation();

--- a/frontend/src/pages/ComicDetail.tsx
+++ b/frontend/src/pages/ComicDetail.tsx
@@ -221,7 +221,7 @@ export default function ComicDetail() {
     <div className="mx-auto max-w-4xl space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <button aria-label="Retour" className="text-text-muted hover:text-text-secondary" onClick={() => navigate(-1)} type="button">
+        <button aria-label="Retour" className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-text-muted hover:text-text-secondary" onClick={() => navigate(-1)} type="button">
           <ArrowLeft className="h-5 w-5" />
         </button>
         <h1 className="flex-1 text-xl font-bold text-text-primary">

--- a/frontend/src/pages/ComicForm.tsx
+++ b/frontend/src/pages/ComicForm.tsx
@@ -99,7 +99,7 @@ export default function ComicForm() {
     <div className="mx-auto max-w-3xl space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <button aria-label="Retour" className="rounded-lg text-text-muted hover:text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500" onClick={() => navigate(-1)} type="button">
+        <button aria-label="Retour" className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-text-muted hover:text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500" onClick={() => navigate(-1)} type="button">
           <ArrowLeft className="h-5 w-5" />
         </button>
         <h1 className="text-xl font-bold text-text-primary">


### PR DESCRIPTION
## Summary

- Augmente le padding du menu 3-dot sur `ComicCard` (`p-1` → `p-2.5`) pour atteindre 44px de cible tactile
- Ajoute `min-h-[44px] min-w-[44px]` sur les boutons retour de `ComicDetail` et `ComicForm`

fixes #316