### PR TITLE
feat(frontend): déplace les flags par défaut près des tomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 - **ComicDetail** : Lightbox plein écran au clic sur la couverture (ne s'active pas sur les placeholders)
 - **CoverSearchModal** : Indicateur de scroll (dégradé) en bas de la grille d'images
 - **EmptyState** : Animation fade-in + slide-up à l'apparition (respecte `prefers-reduced-motion`)
+- **ComicForm** : Flags par défaut des tomes déplacés près de la section Tomes et relabellés « État par défaut des nouveaux tomes » — masqués quand one-shot est coché
 
 ### Changed
 

--- a/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
@@ -1648,6 +1648,38 @@ describe("ComicForm", () => {
     });
   });
 
+  describe("Default tome flags", () => {
+    it("renders flags with label 'État par défaut des nouveaux tomes'", () => {
+      renderCreateForm();
+
+      expect(screen.getByText("État par défaut des nouveaux tomes")).toBeInTheDocument();
+      expect(screen.queryByText("Flags par défaut :")).not.toBeInTheDocument();
+    });
+
+    it("keeps default flags visible when Publication section is collapsed", async () => {
+      const user = userEvent.setup();
+      renderCreateForm();
+
+      // Collapse Publication section
+      await user.click(screen.getByRole("button", { name: /Publication/ }));
+
+      // Flags should still be visible (they are outside Publication)
+      expect(screen.getByText("État par défaut des nouveaux tomes")).toBeVisible();
+    });
+
+    it("hides default flags when oneshot is checked", async () => {
+      const user = userEvent.setup();
+      renderCreateForm();
+
+      expect(screen.getByText("État par défaut des nouveaux tomes")).toBeInTheDocument();
+
+      const checkbox = screen.getByRole("checkbox", { name: /One-shot/ });
+      await user.click(checkbox);
+
+      expect(screen.queryByText("État par défaut des nouveaux tomes")).not.toBeInTheDocument();
+    });
+  });
+
   describe("Collapsible sections", () => {
     it("renders section headers for all four groups", () => {
       renderCreateForm();

--- a/frontend/src/pages/ComicForm.tsx
+++ b/frontend/src/pages/ComicForm.tsx
@@ -222,36 +222,6 @@ export default function ComicForm() {
               />
               <span className="text-sm font-medium text-text-secondary">Parution terminée</span>
             </label>
-            <div className="flex items-center gap-4 pb-2">
-              <span className="text-sm font-medium text-text-secondary">Flags par défaut :</span>
-              <label className="flex items-center gap-1.5">
-                <input
-                  checked={form.defaultTomeBought}
-                  className={formCheckboxClassName}
-                  onChange={(e) => update("defaultTomeBought", e.target.checked)}
-                  type="checkbox"
-                />
-                <span className="text-sm text-text-secondary">Achetés</span>
-              </label>
-              <label className="flex items-center gap-1.5">
-                <input
-                  checked={form.defaultTomeDownloaded}
-                  className={formCheckboxClassName}
-                  onChange={(e) => update("defaultTomeDownloaded", e.target.checked)}
-                  type="checkbox"
-                />
-                <span className="text-sm text-text-secondary">Téléchargés</span>
-              </label>
-              <label className="flex items-center gap-1.5">
-                <input
-                  checked={form.defaultTomeRead}
-                  className={formCheckboxClassName}
-                  onChange={(e) => update("defaultTomeRead", e.target.checked)}
-                  type="checkbox"
-                />
-                <span className="text-sm text-text-secondary">Lus</span>
-              </label>
-            </div>
           </div>
         </CollapsibleSection>
 
@@ -320,10 +290,42 @@ export default function ComicForm() {
 
         {/* Tomes */}
         {!form.isOneShot && (
-          <TomeTable
-            form={form}
-            tomeManager={tomeManager}
-          />
+          <>
+            <div className="flex flex-wrap items-center gap-4">
+              <span className="text-sm font-medium text-text-secondary">État par défaut des nouveaux tomes</span>
+              <label className="flex items-center gap-1.5">
+                <input
+                  checked={form.defaultTomeBought}
+                  className={formCheckboxClassName}
+                  onChange={(e) => update("defaultTomeBought", e.target.checked)}
+                  type="checkbox"
+                />
+                <span className="text-sm text-text-secondary">Achetés</span>
+              </label>
+              <label className="flex items-center gap-1.5">
+                <input
+                  checked={form.defaultTomeDownloaded}
+                  className={formCheckboxClassName}
+                  onChange={(e) => update("defaultTomeDownloaded", e.target.checked)}
+                  type="checkbox"
+                />
+                <span className="text-sm text-text-secondary">Téléchargés</span>
+              </label>
+              <label className="flex items-center gap-1.5">
+                <input
+                  checked={form.defaultTomeRead}
+                  className={formCheckboxClassName}
+                  onChange={(e) => update("defaultTomeRead", e.target.checked)}
+                  type="checkbox"
+                />
+                <span className="text-sm text-text-secondary">Lus</span>
+              </label>
+            </div>
+            <TomeTable
+              form={form}
+              tomeManager={tomeManager}
+            />
+          </>
         )}
       </form>
 


### PR DESCRIPTION
## Summary

- Déplace les checkboxes « Achetés / Téléchargés / Lus » depuis la section Publication vers juste avant la table des tomes
- Relabellise en « État par défaut des nouveaux tomes »
- Masque les flags avec la section tomes quand one-shot est coché

## Test plan

- [x] 3 nouveaux tests : label correct, visible quand Publication repliée, masqué quand one-shot coché
- [x] 87 tests ComicForm passent
- [x] 804 tests frontend passent
- [x] TypeScript compile sans erreur

fixes #312