### PR TITLE
feat(frontend): limite la hauteur de la couverture sur mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 - **CoverSearchModal** : Indicateur de scroll (dégradé) en bas de la grille d'images
 - **EmptyState** : Animation fade-in + slide-up à l'apparition (respecte `prefers-reduced-motion`)
 - **ComicForm** : Flags par défaut des tomes déplacés près de la section Tomes et relabellés « État par défaut des nouveaux tomes » — masqués quand one-shot est coché
+- **ComicDetail** : Couverture limitée en hauteur sur mobile (`max-h-64`) pour éviter qu'elle occupe tout l'écran — layout desktop inchangé
 
 ### Changed
 

--- a/frontend/src/__tests__/integration/pages/ComicDetail.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicDetail.test.tsx
@@ -1019,6 +1019,28 @@ describe("ComicDetail", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
+  it("limits cover height on mobile with max-h-64", async () => {
+    server.use(
+      http.get("/api/comic_series/1", () =>
+        HttpResponse.json(
+          createMockComicSeries({
+            coverUrl: "https://example.com/cover.jpg",
+            id: 1,
+            title: "Mobile Cover",
+          }),
+        ),
+      ),
+    );
+
+    renderComicDetail();
+
+    await waitFor(() => {
+      const img = screen.getByAltText("Mobile Cover");
+      expect(img.className).toContain("max-h-64");
+      expect(img.className).toContain("md:max-h-none");
+    });
+  });
+
   it("renders delete button with outline/ghost red style instead of solid red", async () => {
     server.use(
       http.get("/api/comic_series/1", () =>

--- a/frontend/src/pages/ComicDetail.tsx
+++ b/frontend/src/pages/ComicDetail.tsx
@@ -236,7 +236,7 @@ export default function ComicDetail() {
         <div className="w-full md:w-48">
           <img
             alt={comic.title}
-            className={`w-full rounded-lg shadow${coverSrc ? " cursor-pointer" : ""}`}
+            className={`w-full max-h-64 md:max-h-none object-contain rounded-lg shadow${coverSrc ? " cursor-pointer" : ""}`}
             onClick={coverSrc ? () => setLightboxOpen(true) : undefined}
             src={coverSrc ?? ComicTypePlaceholder[comic.type]}
           />


### PR DESCRIPTION
## Summary

- Ajoute `max-h-64 md:max-h-none object-contain` sur la couverture dans la page détail pour limiter la hauteur sur mobile
- Layout desktop côte à côte inchangé

Fixes #317

## Test plan

- [x] Test vérifie la présence des classes `max-h-64` et `md:max-h-none`
- [x] 809 tests frontend passent
- [x] TypeScript clean