### PR TITLE
feat(frontend): breakpoint carte/table des tomes à md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **TomeTable** : Breakpoint carte/table relevé de `sm` (640px) à `md` (768px) — les tablettes et desktops étroits utilisent le layout carte dépliable au lieu de la table qui déborde
+
 ### Added
 
 - **TomeTable** : Cartes de tomes dépliables sur mobile — vue repliée `#N - Titre` avec chevron, déplier pour éditer (ISBN, checkboxes, supprimer). Les nouveaux tomes sont dépliés par défaut

--- a/frontend/src/components/TomeTable.tsx
+++ b/frontend/src/components/TomeTable.tsx
@@ -116,8 +116,8 @@ export default function TomeTable({ form, tomeManager }: TomeTableProps) {
           <span className="text-xs text-red-500">Max {maxBatchSize} tomes</span>
         )}
       </div>
-      {/* Mobile: collapsible card layout */}
-      <div className="space-y-2 sm:hidden" data-testid="tomes-cards">
+      {/* Mobile/tablet: collapsible card layout */}
+      <div className="space-y-2 md:hidden" data-testid="tomes-cards">
         {form.tomes
           .map((tome, i) => ({ tome, originalIndex: i }))
           .sort((a, b) => compareTomes(a.tome, b.tome))
@@ -251,7 +251,7 @@ export default function TomeTable({ form, tomeManager }: TomeTableProps) {
       </div>
 
       {/* Desktop: table layout */}
-      <div className="hidden overflow-x-auto rounded-lg border border-surface-border sm:block" data-testid="tomes-table">
+      <div className="hidden overflow-x-auto rounded-lg border border-surface-border md:block" data-testid="tomes-table">
         <table className="w-full text-sm">
           <thead className="bg-surface-tertiary">
             <tr>


### PR DESCRIPTION
## Summary

- Relève le breakpoint carte/table de `sm` (640px) à `md` (768px) dans `TomeTable.tsx`
- Les tablettes et desktops étroits utilisent désormais le layout carte dépliable au lieu de la table qui déborde

Fixes #318