### PR TITLE
feat(frontend): pull-to-refresh sur la page d'accueil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Home** : Pull-to-refresh sur la page d'accueil — geste tactile (tirer vers le bas) pour rafraîchir les données, avec indicateur visuel rotatif et `overscroll-behavior-y: contain` pour éviter le conflit avec le pull-to-refresh natif du navigateur
 - **TomeTable** : Cartes de tomes dépliables sur mobile — vue repliée `#N - Titre` avec chevron, déplier pour éditer (ISBN, checkboxes, supprimer). Les nouveaux tomes sont dépliés par défaut
 - **FilterChips** : Chips de filtre rapide (type + statut) scrollables horizontalement au-dessus de la grille sur la page d'accueil — complètent les dropdowns existants
 - **ComicForm** : Sections repliables (Info générale, Publication, Média) — les champs restent dans le DOM pour que le lookup autofill fonctionne même replié

--- a/frontend/src/__tests__/integration/hooks/usePullToRefresh.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/usePullToRefresh.test.tsx
@@ -1,0 +1,166 @@
+import { act, renderHook } from "@testing-library/react";
+import { usePullToRefresh } from "../../../hooks/usePullToRefresh";
+
+function createTouchEvent(type: string, clientY: number): TouchEvent {
+  return new TouchEvent(type, {
+    touches: type === "touchend" ? [] : [{ clientY } as Touch],
+    changedTouches: [{ clientY } as Touch],
+    bubbles: true,
+    cancelable: true,
+  });
+}
+
+describe("usePullToRefresh", () => {
+  let onRefresh: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onRefresh = vi.fn().mockResolvedValue(undefined);
+    // Scroll at top by default
+    Object.defineProperty(window, "scrollY", { configurable: true, value: 0, writable: true });
+  });
+
+  it("calls onRefresh after pull exceeding threshold", async () => {
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh }));
+
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchstart", 100));
+    });
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchmove", 200));
+    });
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchend", 200));
+    });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    // Should show refreshing state
+    expect(result.current.isRefreshing).toBe(true);
+  });
+
+  it("does not call onRefresh if pull is below threshold", () => {
+    renderHook(() => usePullToRefresh({ onRefresh }));
+
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchstart", 100));
+    });
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchmove", 120));
+    });
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchend", 120));
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger when not scrolled to top", () => {
+    Object.defineProperty(window, "scrollY", { configurable: true, value: 100, writable: true });
+
+    renderHook(() => usePullToRefresh({ onRefresh }));
+
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchstart", 100));
+    });
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchmove", 250));
+    });
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchend", 250));
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("returns pullDistance during pull", () => {
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh }));
+
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchstart", 100));
+    });
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchmove", 160));
+    });
+
+    expect(result.current.pullDistance).toBe(60);
+  });
+
+  it("resets pullDistance on touchend below threshold", () => {
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh }));
+
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchstart", 100));
+    });
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchmove", 120));
+    });
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchend", 120));
+    });
+
+    expect(result.current.pullDistance).toBe(0);
+  });
+
+  it("does not trigger on upward swipe", () => {
+    renderHook(() => usePullToRefresh({ onRefresh }));
+
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchstart", 200));
+    });
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchmove", 100));
+    });
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchend", 100));
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("resets isRefreshing after onRefresh resolves", async () => {
+    let resolve: () => void;
+    const slowRefresh = vi.fn(
+      () => new Promise<void>((r) => { resolve = r; }),
+    );
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh: slowRefresh }));
+
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchstart", 100));
+    });
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchmove", 200));
+    });
+    act(() => {
+      window.dispatchEvent(createTouchEvent("touchend", 200));
+    });
+
+    expect(result.current.isRefreshing).toBe(true);
+
+    await act(async () => {
+      resolve!();
+    });
+
+    expect(result.current.isRefreshing).toBe(false);
+  });
+
+  it("cleans up event listeners on unmount", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    const { unmount } = renderHook(() => usePullToRefresh({ onRefresh }));
+
+    const addedTypes = addSpy.mock.calls.map(([type]) => type).sort();
+    expect(addedTypes).toContain("touchend");
+    expect(addedTypes).toContain("touchmove");
+    expect(addedTypes).toContain("touchstart");
+
+    unmount();
+
+    const removedTypes = removeSpy.mock.calls.map(([type]) => type).sort();
+    expect(removedTypes).toContain("touchend");
+    expect(removedTypes).toContain("touchmove");
+    expect(removedTypes).toContain("touchstart");
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});

--- a/frontend/src/hooks/usePullToRefresh.ts
+++ b/frontend/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UsePullToRefreshOptions {
+  onRefresh: () => Promise<void>;
+  threshold?: number;
+}
+
+interface UsePullToRefreshReturn {
+  isRefreshing: boolean;
+  pullDistance: number;
+}
+
+const DEFAULT_THRESHOLD = 80;
+
+export function usePullToRefresh({
+  onRefresh,
+  threshold = DEFAULT_THRESHOLD,
+}: UsePullToRefreshOptions): UsePullToRefreshReturn {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [pullDistance, setPullDistance] = useState(0);
+  const startY = useRef<number | null>(null);
+  const isTracking = useRef(false);
+  const pullDistanceRef = useRef(0);
+  const onRefreshRef = useRef(onRefresh);
+  onRefreshRef.current = onRefresh;
+
+  const handleTouchStart = useCallback((e: TouchEvent) => {
+    if (window.scrollY > 0) return;
+    startY.current = e.touches[0].clientY;
+    isTracking.current = true;
+  }, []);
+
+  const handleTouchMove = useCallback((e: TouchEvent) => {
+    if (!isTracking.current || startY.current === null) return;
+    const delta = e.touches[0].clientY - startY.current;
+    if (delta > 0) {
+      pullDistanceRef.current = delta;
+      setPullDistance(delta);
+    }
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
+    if (!isTracking.current) return;
+    isTracking.current = false;
+    const distance = pullDistanceRef.current;
+
+    if (distance >= threshold) {
+      setIsRefreshing(true);
+      setPullDistance(0);
+      pullDistanceRef.current = 0;
+      onRefreshRef.current().finally(() => {
+        setIsRefreshing(false);
+      });
+    } else {
+      setPullDistance(0);
+      pullDistanceRef.current = 0;
+    }
+
+    startY.current = null;
+  }, [threshold]);
+
+  useEffect(() => {
+    window.addEventListener("touchstart", handleTouchStart, { passive: true });
+    window.addEventListener("touchmove", handleTouchMove, { passive: true });
+    window.addEventListener("touchend", handleTouchEnd);
+
+    return () => {
+      window.removeEventListener("touchstart", handleTouchStart);
+      window.removeEventListener("touchmove", handleTouchMove);
+      window.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, [handleTouchEnd, handleTouchMove, handleTouchStart]);
+
+  return { isRefreshing, pullDistance };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,6 +5,11 @@
   --bottom-nav-h: 3.5rem;
 }
 
+/* Empêcher le pull-to-refresh natif du navigateur (PWA) */
+body {
+  overscroll-behavior-y: contain;
+}
+
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,4 +1,5 @@
-import { BookOpen, Filter, Heart, Loader2, Search } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { BookOpen, Filter, Heart, Loader2, RefreshCw, Search } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
@@ -13,6 +14,7 @@ import { useComics } from "../hooks/useComics";
 import { useDebounce } from "../hooks/useDebounce";
 import { useDeleteComic } from "../hooks/useDeleteComic";
 import { useMediaQuery } from "../hooks/useMediaQuery";
+import { usePullToRefresh } from "../hooks/usePullToRefresh";
 import { useRestoreComic } from "../hooks/useTrash";
 import type { ComicSeries } from "../types/api";
 import { searchComics } from "../utils/searchComics";
@@ -84,6 +86,12 @@ export default function Home() {
   const { data, isFetching, isLoading } = useComics();
   const deleteComic = useDeleteComic();
   const restoreComic = useRestoreComic();
+  const queryClient = useQueryClient();
+  const handleRefresh = useCallback(
+    () => queryClient.invalidateQueries().then(() => undefined),
+    [queryClient],
+  );
+  const { isRefreshing, pullDistance } = usePullToRefresh({ onRefresh: handleRefresh });
   const allComics = data?.member ?? [];
 
   const handleDelete = useCallback((c: ComicSeries) => {
@@ -128,8 +136,24 @@ export default function Home() {
     );
   }, [setSearchParams]);
 
+  const pullIndicatorHeight = isRefreshing ? 48 : Math.min(pullDistance, 80);
+  const pullProgress = Math.min(pullDistance / 80, 1);
+
   return (
     <div className="space-y-4">
+      {(pullDistance > 0 || isRefreshing) && (
+        <div
+          aria-label={isRefreshing ? "Actualisation en cours" : "Tirer pour actualiser"}
+          className="flex items-center justify-center overflow-hidden transition-[height] duration-200"
+          data-testid="pull-to-refresh-indicator"
+          style={{ height: pullIndicatorHeight }}
+        >
+          <RefreshCw
+            className={`h-5 w-5 text-primary-500 ${isRefreshing ? "animate-spin" : ""}`}
+            style={{ opacity: pullProgress, transform: `rotate(${pullProgress * 360}deg)` }}
+          />
+        </div>
+      )}
       <h1 className="text-xl font-bold text-text-primary">Ma bibliothèque</h1>
       {/* Search bar + filter button (mobile) + count */}
       <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

- Ajoute un hook `usePullToRefresh` avec gestion tactile (touchstart/touchmove/touchend) et seuil configurable (80px par défaut)
- Intègre le pull-to-refresh sur la page Home avec indicateur visuel rotatif (icône RefreshCw) et invalidation de toutes les queries TanStack
- Ajoute `overscroll-behavior-y: contain` sur body pour éviter le conflit avec le pull-to-refresh natif du navigateur PWA

## Test plan

- [x] 8 tests unitaires pour `usePullToRefresh` (seuil, scroll position, nettoyage listeners, état refreshing)
- [x] 34 tests d'intégration Home passent (aucune régression)
- [x] 817/817 tests frontend passent
- [x] TypeScript : aucune erreur
- [ ] Tester manuellement le geste sur mobile/PWA

fixes #319