### PR TITLE
feat(frontend): métadonnées en grille clé-valeur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
+- **ComicDetail** : Métadonnées affichées en grille clé-valeur (dl/dt/dd) au lieu de paragraphes séquentiels, description séparée dans sa propre section
 - **TomeTable** : Breakpoint carte/table relevé de `sm` (640px) à `md` (768px) — les tablettes et desktops étroits utilisent le layout carte dépliable au lieu de la table qui déborde
 
 ### Added

--- a/frontend/src/__tests__/integration/pages/ComicDetail.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicDetail.test.tsx
@@ -129,7 +129,7 @@ describe("ComicDetail", () => {
     renderComicDetail();
 
     await waitFor(() => {
-      expect(screen.getByText(/Akira Toriyama, Eiichiro Oda/)).toBeInTheDocument();
+      expect(screen.getByText("Akira Toriyama, Eiichiro Oda")).toBeInTheDocument();
     });
   });
 
@@ -424,7 +424,7 @@ describe("ComicDetail", () => {
     await waitFor(() => {
       expect(screen.getByText("No Authors")).toBeInTheDocument();
     });
-    expect(screen.queryByText("Auteurs :")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auteurs")).not.toBeInTheDocument();
   });
 
   it("renders published date when available", async () => {
@@ -441,7 +441,7 @@ describe("ComicDetail", () => {
     await waitFor(() => {
       expect(screen.getByText("With Date")).toBeInTheDocument();
     });
-    expect(screen.getByText("Parution :")).toBeInTheDocument();
+    expect(screen.getByText("Parution")).toBeInTheDocument();
     expect(screen.getByText("15 mars 2020")).toBeInTheDocument();
   });
 
@@ -459,7 +459,7 @@ describe("ComicDetail", () => {
     await waitFor(() => {
       expect(screen.getByText("No Date")).toBeInTheDocument();
     });
-    expect(screen.queryByText("Parution :")).not.toBeInTheDocument();
+    expect(screen.queryByText("Parution")).not.toBeInTheDocument();
   });
 
   it("does not render publisher section when publisher is null", async () => {
@@ -476,10 +476,80 @@ describe("ComicDetail", () => {
     await waitFor(() => {
       expect(screen.getByText("No Publisher")).toBeInTheDocument();
     });
-    expect(screen.queryByText("Éditeur :")).not.toBeInTheDocument();
+    expect(screen.queryByText("Éditeur")).not.toBeInTheDocument();
   });
 
-  it("does not render description when description is null", async () => {
+  it("renders metadata in a definition list grid", async () => {
+    server.use(
+      http.get("/api/comic_series/1", () =>
+        HttpResponse.json(
+          createMockComicSeries({
+            authors: [createMockAuthor({ name: "Toriyama" })],
+            id: 1,
+            publisher: "Glénat",
+            publishedDate: "2020-03-15",
+            title: "Grid Test",
+          }),
+        ),
+      ),
+    );
+
+    renderComicDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Grid Test")).toBeInTheDocument();
+    });
+
+    // Metadata should be in a <dl> element
+    const dl = document.querySelector("dl");
+    expect(dl).toBeInTheDocument();
+
+    // Labels should be <dt> elements
+    const dtElements = dl!.querySelectorAll("dt");
+    const dtTexts = Array.from(dtElements).map((dt) => dt.textContent);
+    expect(dtTexts).toContain("Auteurs");
+    expect(dtTexts).toContain("Éditeur");
+    expect(dtTexts).toContain("Parution");
+
+    // Values should be <dd> elements
+    const ddElements = dl!.querySelectorAll("dd");
+    const ddTexts = Array.from(ddElements).map((dd) => dd.textContent);
+    expect(ddTexts).toContain("Toriyama");
+    expect(ddTexts).toContain("Glénat");
+    expect(ddTexts).toContain("15 mars 2020");
+  });
+
+  it("renders description in a separate section below metadata", async () => {
+    server.use(
+      http.get("/api/comic_series/1", () =>
+        HttpResponse.json(
+          createMockComicSeries({
+            authors: [createMockAuthor({ name: "Author" })],
+            description: "Un manga épique",
+            id: 1,
+            title: "Desc Section",
+          }),
+        ),
+      ),
+    );
+
+    renderComicDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Desc Section")).toBeInTheDocument();
+    });
+
+    // Description should NOT be inside the <dl>
+    const dl = document.querySelector("dl");
+    expect(dl).toBeInTheDocument();
+    expect(dl!.textContent).not.toContain("Un manga épique");
+
+    // Description should be in its own section with a heading
+    expect(screen.getByText("Description")).toBeInTheDocument();
+    expect(screen.getByText("Un manga épique")).toBeInTheDocument();
+  });
+
+  it("does not render description section when description is null", async () => {
     server.use(
       http.get("/api/comic_series/1", () =>
         HttpResponse.json(
@@ -493,9 +563,7 @@ describe("ComicDetail", () => {
     await waitFor(() => {
       expect(screen.getByText("No Desc")).toBeInTheDocument();
     });
-    // Only type/status badges + title should be present, no description paragraph
-    const paragraphs = document.querySelectorAll("p.leading-relaxed");
-    expect(paragraphs.length).toBe(0);
+    expect(screen.queryByText("Description")).not.toBeInTheDocument();
   });
 
   it("shows placeholder cover when both coverUrl and coverImage are null", async () => {
@@ -836,10 +904,10 @@ describe("ComicDetail", () => {
     renderComicDetail();
 
     await waitFor(() => {
-      expect(screen.getByText("Nouveaux tomes :")).toBeInTheDocument();
+      expect(screen.getByText("Nouveaux tomes")).toBeInTheDocument();
     });
 
-    expect(screen.getByText(/achetés, téléchargés/)).toBeInTheDocument();
+    expect(screen.getByText("achetés, téléchargés")).toBeInTheDocument();
   });
 
   it("shows latestPublishedIssueUpdatedAt as relative date", async () => {

--- a/frontend/src/pages/ComicDetail.tsx
+++ b/frontend/src/pages/ComicDetail.tsx
@@ -263,46 +263,59 @@ export default function ComicDetail() {
             )}
           </div>
 
-          {comic.authors.length > 0 && (
-            <p className="text-sm text-text-secondary">
-              <span className="font-medium">Auteurs :</span>{" "}
-              {comic.authors.map((a) => a.name).join(", ")}
-            </p>
-          )}
-          {comic.publisher && (
-            <p className="text-sm text-text-secondary">
-              <span className="font-medium">Éditeur :</span> {comic.publisher}
-            </p>
-          )}
-          {comic.publishedDate && (
-            <p className="text-sm text-text-secondary">
-              <span className="font-medium">Parution :</span>{" "}
-              {new Date(comic.publishedDate).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}
-            </p>
-          )}
-          {comic.latestPublishedIssue != null && (
-            <p className="text-sm text-text-secondary">
-              <span className="font-medium">Tomes parus :</span> {comic.latestPublishedIssue}
-              {comic.latestPublishedIssueComplete && " (terminée)"}
-              {comic.latestPublishedIssueUpdatedAt && (
-                <span className="ml-2 text-text-muted">
-                  (mis à jour {formatRelativeDate(comic.latestPublishedIssueUpdatedAt)})
-                </span>
-              )}
-            </p>
-          )}
-          {(comic.defaultTomeBought || comic.defaultTomeDownloaded || comic.defaultTomeRead) && (
-            <p className="text-sm text-text-secondary">
-              <span className="font-medium">Nouveaux tomes :</span>{" "}
-              {[
-                comic.defaultTomeBought && "achetés",
-                comic.defaultTomeDownloaded && "téléchargés",
-                comic.defaultTomeRead && "lus",
-              ].filter(Boolean).join(", ")}
-            </p>
-          )}
+          <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+            {comic.authors.length > 0 && (
+              <>
+                <dt className="font-medium text-text-secondary">Auteurs</dt>
+                <dd className="text-text-secondary">{comic.authors.map((a) => a.name).join(", ")}</dd>
+              </>
+            )}
+            {comic.publisher && (
+              <>
+                <dt className="font-medium text-text-secondary">Éditeur</dt>
+                <dd className="text-text-secondary">{comic.publisher}</dd>
+              </>
+            )}
+            {comic.publishedDate && (
+              <>
+                <dt className="font-medium text-text-secondary">Parution</dt>
+                <dd className="text-text-secondary">
+                  {new Date(comic.publishedDate).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}
+                </dd>
+              </>
+            )}
+            {comic.latestPublishedIssue != null && (
+              <>
+                <dt className="font-medium text-text-secondary">Tomes parus</dt>
+                <dd className="text-text-secondary">
+                  {comic.latestPublishedIssue}
+                  {comic.latestPublishedIssueComplete && " (terminée)"}
+                  {comic.latestPublishedIssueUpdatedAt && (
+                    <span className="ml-2 text-text-muted">
+                      (mis à jour {formatRelativeDate(comic.latestPublishedIssueUpdatedAt)})
+                    </span>
+                  )}
+                </dd>
+              </>
+            )}
+            {(comic.defaultTomeBought || comic.defaultTomeDownloaded || comic.defaultTomeRead) && (
+              <>
+                <dt className="font-medium text-text-secondary">Nouveaux tomes</dt>
+                <dd className="text-text-secondary">
+                  {[
+                    comic.defaultTomeBought && "achetés",
+                    comic.defaultTomeDownloaded && "téléchargés",
+                    comic.defaultTomeRead && "lus",
+                  ].filter(Boolean).join(", ")}
+                </dd>
+              </>
+            )}
+          </dl>
           {comic.description && (
-            <p className="text-sm leading-relaxed text-text-secondary">{comic.description}</p>
+            <div>
+              <h3 className="text-sm font-medium text-text-secondary">Description</h3>
+              <p className="mt-1 text-sm leading-relaxed text-text-secondary">{comic.description}</p>
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Remplace les `<p>` séquentiels de métadonnées par une grille `<dl>` 2 colonnes (label à gauche, valeur à droite)
- Sépare la description dans sa propre section en dessous de la grille
- Tests mis à jour pour valider la structure `dl`/`dt`/`dd`

Fixes #321

## Test plan
- [x] Tests unitaires : 49 tests ComicDetail passent
- [x] Suite complète : 819 tests passent
- [x] TypeScript : `tsc --noEmit` clean