### PR TITLE
feat(frontend): bannière tomes parus non ajoutés

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **ComicDetail** : Bannière d'alerte quand des tomes parus ne sont pas encore ajoutés, avec lien vers le formulaire d'édition
 - **TomeTable** : Colonnes triables avec indicateur de tri — cliquer sur un en-tête (#, Titre, Acheté, Téléchargé, Lu, NAS) trie les tomes, un second clic inverse l'ordre
 - **Home** : Pull-to-refresh sur la page d'accueil — geste tactile (tirer vers le bas) pour rafraîchir les données, avec indicateur visuel rotatif et `overscroll-behavior-y: contain` pour éviter le conflit avec le pull-to-refresh natif du navigateur
 - **TomeTable** : Cartes de tomes dépliables sur mobile — vue repliée `#N - Titre` avec chevron, déplier pour éditer (ISBN, checkboxes, supprimer). Les nouveaux tomes sont dépliés par défaut

--- a/frontend/src/__tests__/integration/pages/ComicDetail.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicDetail.test.tsx
@@ -1279,6 +1279,201 @@ describe("ComicDetail", () => {
     });
   });
 
+  describe("missing tomes banner", () => {
+    it("shows banner when latestPublishedIssue > covered tomes count", async () => {
+      const tomes = [
+        createMockTome({ id: 1, number: 1 }),
+        createMockTome({ id: 2, number: 2 }),
+      ];
+
+      server.use(
+        http.get("/api/comic_series/1", () =>
+          HttpResponse.json(
+            createMockComicSeries({
+              id: 1,
+              isOneShot: false,
+              latestPublishedIssue: 5,
+              title: "Missing Tomes",
+              tomes,
+            }),
+          ),
+        ),
+      );
+
+      renderComicDetail();
+
+      await waitFor(() => {
+        expect(screen.getByText(/3 tomes parus non ajoutés/)).toBeInTheDocument();
+      });
+    });
+
+    it("does not show banner when all published tomes are covered", async () => {
+      const tomes = [
+        createMockTome({ id: 1, number: 1 }),
+        createMockTome({ id: 2, number: 2 }),
+        createMockTome({ id: 3, number: 3 }),
+      ];
+
+      server.use(
+        http.get("/api/comic_series/1", () =>
+          HttpResponse.json(
+            createMockComicSeries({
+              id: 1,
+              isOneShot: false,
+              latestPublishedIssue: 3,
+              title: "All Covered",
+              tomes,
+            }),
+          ),
+        ),
+      );
+
+      renderComicDetail();
+
+      await waitFor(() => {
+        expect(screen.getByText("All Covered")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(/tomes? parus? non ajoutés?/)).not.toBeInTheDocument();
+    });
+
+    it("does not show banner when latestPublishedIssue is null", async () => {
+      const tomes = [
+        createMockTome({ id: 1, number: 1 }),
+      ];
+
+      server.use(
+        http.get("/api/comic_series/1", () =>
+          HttpResponse.json(
+            createMockComicSeries({
+              id: 1,
+              isOneShot: false,
+              latestPublishedIssue: null,
+              title: "No Published Info",
+              tomes,
+            }),
+          ),
+        ),
+      );
+
+      renderComicDetail();
+
+      await waitFor(() => {
+        expect(screen.getByText("No Published Info")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(/tomes? parus? non ajoutés?/)).not.toBeInTheDocument();
+    });
+
+    it("does not show banner for oneshot series", async () => {
+      server.use(
+        http.get("/api/comic_series/1", () =>
+          HttpResponse.json(
+            createMockComicSeries({
+              id: 1,
+              isOneShot: true,
+              latestPublishedIssue: 1,
+              title: "Oneshot Banner",
+              tomes: [],
+            }),
+          ),
+        ),
+      );
+
+      renderComicDetail();
+
+      await waitFor(() => {
+        expect(screen.getByText("Oneshot Banner")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(/tomes? parus? non ajoutés?/)).not.toBeInTheDocument();
+    });
+
+    it("accounts for tome ranges in missing count", async () => {
+      const tomes = [
+        createMockTome({ id: 1, number: 1, tomeEnd: 3 }), // covers 3
+        createMockTome({ id: 2, number: 4 }),               // covers 1
+      ];
+
+      server.use(
+        http.get("/api/comic_series/1", () =>
+          HttpResponse.json(
+            createMockComicSeries({
+              id: 1,
+              isOneShot: false,
+              latestPublishedIssue: 10,
+              title: "Range Banner",
+              tomes,
+            }),
+          ),
+        ),
+      );
+
+      renderComicDetail();
+
+      // 10 published - 4 covered = 6 missing
+      await waitFor(() => {
+        expect(screen.getByText(/6 tomes parus non ajoutés/)).toBeInTheDocument();
+      });
+    });
+
+    it("shows singular form for 1 missing tome", async () => {
+      const tomes = [
+        createMockTome({ id: 1, number: 1 }),
+        createMockTome({ id: 2, number: 2 }),
+      ];
+
+      server.use(
+        http.get("/api/comic_series/1", () =>
+          HttpResponse.json(
+            createMockComicSeries({
+              id: 1,
+              isOneShot: false,
+              latestPublishedIssue: 3,
+              title: "One Missing",
+              tomes,
+            }),
+          ),
+        ),
+      );
+
+      renderComicDetail();
+
+      await waitFor(() => {
+        expect(screen.getByText(/1 tome paru non ajouté/)).toBeInTheDocument();
+      });
+    });
+
+    it("links to the edit form", async () => {
+      const tomes = [
+        createMockTome({ id: 1, number: 1 }),
+      ];
+
+      server.use(
+        http.get("/api/comic_series/1", () =>
+          HttpResponse.json(
+            createMockComicSeries({
+              id: 1,
+              isOneShot: false,
+              latestPublishedIssue: 5,
+              title: "Link Banner",
+              tomes,
+            }),
+          ),
+        ),
+      );
+
+      renderComicDetail();
+
+      await waitFor(() => {
+        expect(screen.getByText(/tomes parus non ajoutés/)).toBeInTheDocument();
+      });
+
+      const link = screen.getByRole("link", { name: /ajouter/i });
+      expect(link).toHaveAttribute("href", "/comic/1/edit");
+    });
+  });
+
   it("shows undo toast after delete", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/pages/ComicDetail.tsx
+++ b/frontend/src/pages/ComicDetail.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, ArrowDown, ArrowUp, ArrowUpDown, BookOpen, Edit, ExternalLink, Trash2 } from "lucide-react";
+import { AlertTriangle, ArrowLeft, ArrowDown, ArrowUp, ArrowUpDown, BookOpen, Edit, ExternalLink, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
@@ -118,12 +118,17 @@ export default function ComicDetail() {
     [optimisticTomes, sort.key, sort.direction],
   );
 
-  const { boughtCount, downloadedCount, progressTotal, readCount } = useMemo(() => ({
-    boughtCount: countCoveredTomes(optimisticTomes, (t) => t.bought),
-    downloadedCount: countCoveredTomes(optimisticTomes, (t) => t.downloaded),
-    progressTotal: Math.max(comic?.latestPublishedIssue ?? 0, countCoveredTomes(optimisticTomes)),
-    readCount: countCoveredTomes(optimisticTomes, (t) => t.read),
-  }), [optimisticTomes, comic?.latestPublishedIssue]);
+  const { boughtCount, downloadedCount, missingTomesCount, progressTotal, readCount } = useMemo(() => {
+    const covered = countCoveredTomes(optimisticTomes);
+    const published = comic?.latestPublishedIssue ?? 0;
+    return {
+      boughtCount: countCoveredTomes(optimisticTomes, (t) => t.bought),
+      downloadedCount: countCoveredTomes(optimisticTomes, (t) => t.downloaded),
+      missingTomesCount: published > covered ? published - covered : 0,
+      progressTotal: Math.max(published, covered),
+      readCount: countCoveredTomes(optimisticTomes, (t) => t.read),
+    };
+  }, [optimisticTomes, comic?.latestPublishedIssue]);
 
   useEffect(() => {
     if (comic?.tomes) {
@@ -366,6 +371,25 @@ export default function ComicDetail() {
           <ProgressBar color="bg-primary-600" current={boughtCount} label="Achetés" total={progressTotal} />
           <ProgressBar color="bg-green-500" current={readCount} label="Lus" total={progressTotal} />
           <ProgressBar color="bg-blue-500" current={downloadedCount} label="Téléchargés" total={progressTotal} />
+        </div>
+      )}
+
+      {/* Bannière tomes manquants */}
+      {!comic.isOneShot && missingTomesCount > 0 && (
+        <div className="flex items-center gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-950/30 dark:text-amber-300">
+          <AlertTriangle className="h-5 w-5 shrink-0" />
+          <span>
+            {missingTomesCount === 1
+              ? "1 tome paru non ajouté"
+              : `${missingTomesCount} tomes parus non ajoutés`}
+          </span>
+          <Link
+            className="ml-auto shrink-0 font-medium text-amber-700 underline hover:text-amber-900 dark:text-amber-400 dark:hover:text-amber-200"
+            to={`/comic/${comic.id}/edit`}
+            viewTransition
+          >
+            Ajouter
+          </Link>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- Affiche une bannière d'alerte amber sur la page de détail quand `latestPublishedIssue > countCoveredTomes(tomes)`, indiquant le nombre de tomes manquants
- Lien "Ajouter" vers le formulaire d'édition (`/comic/:id/edit`)
- Gère le singulier/pluriel et les plages de tomes (tomeEnd)

## Test plan

- [x] 7 tests d'intégration : bannière affichée/masquée selon les cas, comptage avec ranges, forme singulière, lien correct
- [x] 833 tests passent, tsc --noEmit clean

Fixes #324