### PR TITLE
UX : spinner centré pour le fallback Suspense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
+- **Suspense fallback** : Spinner centré (Loader2 animate-spin) au lieu du texte brut « Chargement… »
 - **ComicDetail** : Métadonnées affichées en grille clé-valeur (dl/dt/dd) au lieu de paragraphes séquentiels, description séparée dans sa propre section
 - **TomeTable** : Breakpoint carte/table relevé de `sm` (640px) à `md` (768px) — les tablettes et desktops étroits utilisent le layout carte dépliable au lieu de la table qui déborde
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { WifiOff } from "lucide-react";
+import { Loader2, WifiOff } from "lucide-react";
 import { lazy, Suspense, useEffect } from "react";
 import type { ComponentType } from "react";
 import { ErrorBoundary } from "react-error-boundary";
@@ -64,7 +64,12 @@ const Tools = lazyWithRetry(() => import("./pages/Tools"));
 const Trash = lazyWithRetry(() => import("./pages/Trash"));
 
 function Loading() {
-  return <div className="py-12 text-center text-text-muted">Chargement…</div>;
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center" role="status">
+      <Loader2 className="h-8 w-8 animate-spin text-primary-600" />
+      <span className="sr-only">Chargement…</span>
+    </div>
+  );
 }
 
 function ScrollToTop() {

--- a/frontend/src/__tests__/integration/App.test.tsx
+++ b/frontend/src/__tests__/integration/App.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
 import { ErrorBoundary } from "react-error-boundary";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { Suspense, useEffect } from "react";
@@ -39,6 +40,17 @@ function OfflineFallback() {
       >
         Retour
       </button>
+    </div>
+  );
+}
+
+// --- Loading (replicated from App.tsx) ----------------------------------------
+
+function Loading() {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center" role="status">
+      <Loader2 className="h-8 w-8 animate-spin text-primary-600" />
+      <span className="sr-only">Chargement…</span>
     </div>
   );
 }
@@ -109,7 +121,7 @@ describe("lazyWithRetry", () => {
 
     render(
       <MemoryRouter>
-        <Suspense fallback={<div>Chargement...</div>}>
+        <Suspense fallback={<Loading />}>
           <FailingPage />
         </Suspense>
       </MemoryRouter>,
@@ -318,7 +330,7 @@ describe("Route rendering", () => {
     return render(
       <QueryClientProvider client={qc}>
         <MemoryRouter initialEntries={[route]}>
-          <Suspense fallback={<div>Chargement...</div>}>
+          <Suspense fallback={<Loading />}>
             <Routes>
               <Route
                 element={<LoginPage />}
@@ -381,7 +393,7 @@ describe("Route rendering", () => {
 });
 
 describe("Suspense fallback", () => {
-  it("shows 'Chargement...' while lazy pages load", async () => {
+  it("shows a centered spinner while lazy pages load", async () => {
     let resolveImport: (mod: { default: ComponentType }) => void;
     const importPromise = new Promise<{ default: ComponentType }>((resolve) => {
       resolveImport = resolve;
@@ -392,14 +404,15 @@ describe("Suspense fallback", () => {
 
     render(
       <MemoryRouter>
-        <Suspense fallback={<div>Chargement...</div>}>
+        <Suspense fallback={<Loading />}>
           <LazyPage />
         </Suspense>
       </MemoryRouter>,
     );
 
-    // Should show fallback while loading
-    expect(screen.getByText("Chargement...")).toBeInTheDocument();
+    // Should show spinner fallback while loading
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText("Chargement…")).toBeInTheDocument();
 
     // Resolve the import
     resolveImport!({ default: () => <div>Loaded Page</div> });


### PR DESCRIPTION
## Summary
- Remplace le texte brut « Chargement… » par un spinner `Loader2` centré (`animate-spin`) avec texte accessible `sr-only`
- Met à jour le test Suspense fallback pour vérifier le `role="status"` et le spinner

## Test plan
- [x] Test unitaire `App.test.tsx` — Suspense fallback vérifie le spinner
- [x] `tsc --noEmit` passe
- [ ] CI passe

Fixes #303