### PR TITLE
UX : navigation retour intelligente

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
+- **Navigation retour** : Le bouton retour redirige vers `/` au lieu de quitter l'app quand il n'y a pas d'historique in-app ; les redirections post-soumission remplacent l'entrée formulaire dans l'historique
 - **Suspense fallback** : Spinner centré (Loader2 animate-spin) au lieu du texte brut « Chargement… »
 - **ComicDetail** : Métadonnées affichées en grille clé-valeur (dl/dt/dd) au lieu de paragraphes séquentiels, description séparée dans sa propre section
 - **TomeTable** : Breakpoint carte/table relevé de `sm` (640px) à `md` (768px) — les tablettes et desktops étroits utilisent le layout carte dépliable au lieu de la table qui déborde

--- a/frontend/src/__tests__/integration/hooks/useGoBack.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useGoBack.test.tsx
@@ -1,0 +1,86 @@
+import { renderHook, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, useNavigate } from "react-router-dom";
+import { useGoBack } from "../../../hooks/useGoBack";
+
+// Mock useNavigate
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+describe("useGoBack", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it("navigates back when there is in-app history (idx > 0)", () => {
+    // Simulate in-app history
+    Object.defineProperty(window.history, "state", {
+      configurable: true,
+      value: { idx: 2 },
+      writable: true,
+    });
+
+    const { result } = renderHook(() => useGoBack(), { wrapper });
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
+  });
+
+  it("navigates to fallback (/) when there is no in-app history (idx === 0)", () => {
+    Object.defineProperty(window.history, "state", {
+      configurable: true,
+      value: { idx: 0 },
+      writable: true,
+    });
+
+    const { result } = renderHook(() => useGoBack(), { wrapper });
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/", { viewTransition: true });
+  });
+
+  it("navigates to fallback when history.state is null", () => {
+    Object.defineProperty(window.history, "state", {
+      configurable: true,
+      value: null,
+      writable: true,
+    });
+
+    const { result } = renderHook(() => useGoBack(), { wrapper });
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/", { viewTransition: true });
+  });
+
+  it("navigates to custom fallback path when provided", () => {
+    Object.defineProperty(window.history, "state", {
+      configurable: true,
+      value: { idx: 0 },
+      writable: true,
+    });
+
+    const { result } = renderHook(() => useGoBack("/trash"), { wrapper });
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/trash", { viewTransition: true });
+  });
+});

--- a/frontend/src/hooks/useComicForm.ts
+++ b/frontend/src/hooks/useComicForm.ts
@@ -201,7 +201,7 @@ export function useComicForm() {
           if (!data) return;
           if (syncFailure?.id) void resolveSyncFailure(syncFailure.id);
           toast.success("Série mise à jour");
-          navigate(`/comic/${id}`, { viewTransition: true });
+          navigate(`/comic/${id}`, { replace: true, viewTransition: true });
         },
         onError: (err) => toast.error(getErrorMessage(err)),
       });
@@ -211,7 +211,7 @@ export function useComicForm() {
           if (!created) return;
           if (syncFailure?.id) void resolveSyncFailure(syncFailure.id);
           toast.success("Série créée");
-          navigate(`/comic/${created.id}`, { viewTransition: true });
+          navigate(`/comic/${created.id}`, { replace: true, viewTransition: true });
         },
         onError: (err) => toast.error(getErrorMessage(err)),
       });
@@ -241,7 +241,6 @@ export function useComicForm() {
     isEdit,
     isOnline,
     isSaving,
-    navigate,
     resolveSyncFailure,
     syncFailure,
     update,

--- a/frontend/src/hooks/useGoBack.ts
+++ b/frontend/src/hooks/useGoBack.ts
@@ -1,0 +1,20 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+/**
+ * Retourne une fonction « retour intelligent » :
+ * - si l'utilisateur a un historique in-app (idx > 0), navigate(-1)
+ * - sinon (favori, lien partagé, onglet neuf), redirige vers `fallback`
+ */
+export function useGoBack(fallback = "/"): () => void {
+  const navigate = useNavigate();
+
+  return useCallback(() => {
+    const idx = (window.history.state as { idx?: number } | null)?.idx ?? 0;
+    if (idx > 0) {
+      navigate(-1);
+    } else {
+      navigate(fallback, { viewTransition: true });
+    }
+  }, [fallback, navigate]);
+}

--- a/frontend/src/pages/ComicDetail.tsx
+++ b/frontend/src/pages/ComicDetail.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, ArrowLeft, ArrowDown, ArrowUp, ArrowUpDown, BookOpen, Edit, ExternalLink, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
+import { useGoBack } from "../hooks/useGoBack";
 import { toast } from "sonner";
 import ComponentErrorBoundary from "../components/ComponentErrorBoundary";
 import CoverLightbox from "../components/CoverLightbox";
@@ -97,6 +98,7 @@ function formatRelativeDate(isoDate: string): string {
 
 export default function ComicDetail() {
   const { id } = useParams<{ id: string }>();
+  const goBack = useGoBack();
   const navigate = useNavigate();
   const { data: comic, isLoading } = useComic(id ? Number(id) : undefined);
   const deleteComic = useDeleteComic();
@@ -267,7 +269,7 @@ export default function ComicDetail() {
     <div className="mx-auto max-w-4xl space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <button aria-label="Retour" className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-text-muted hover:text-text-secondary" onClick={() => navigate(-1)} type="button">
+        <button aria-label="Retour" className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-text-muted hover:text-text-secondary" onClick={goBack} type="button">
           <ArrowLeft className="h-5 w-5" />
         </button>
         <h1 className="flex-1 text-xl font-bold text-text-primary">

--- a/frontend/src/pages/ComicForm.tsx
+++ b/frontend/src/pages/ComicForm.tsx
@@ -10,6 +10,7 @@ import SkeletonBox from "../components/SkeletonBox";
 import SyncFailureSection from "../components/SyncFailureSection";
 import TomeTable from "../components/TomeTable";
 import { useComicForm } from "../hooks/useComicForm";
+import { useGoBack } from "../hooks/useGoBack";
 import {
   formCheckboxClassName,
   formInputClassName,
@@ -19,6 +20,7 @@ import {
 import { statusOptions, typeOptions } from "../types/enums";
 
 export default function ComicForm() {
+  const goBack = useGoBack();
   const {
     addAuthor,
     applyLookup,
@@ -37,7 +39,6 @@ export default function ComicForm() {
     lookupMode,
     lookupResult,
     lookupTitle,
-    navigate,
     removeAuthor,
     resolveSyncFailure,
     selectCandidate,
@@ -100,7 +101,7 @@ export default function ComicForm() {
     <div className="mx-auto max-w-3xl space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <button aria-label="Retour" className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-text-muted hover:text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500" onClick={() => navigate(-1)} type="button">
+        <button aria-label="Retour" className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-text-muted hover:text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500" onClick={() => goBack()} type="button">
           <ArrowLeft className="h-5 w-5" />
         </button>
         <h1 className="text-xl font-bold text-text-primary">
@@ -338,7 +339,7 @@ export default function ComicForm() {
       <div className="sticky bottom-[var(--bottom-nav-h)] z-40 flex justify-center gap-3 border-t border-surface-border bg-surface-primary px-4 py-3">
         <button
           className="rounded-lg px-5 py-2.5 text-base font-medium text-text-secondary hover:bg-surface-tertiary"
-          onClick={() => navigate(-1)}
+          onClick={() => goBack()}
           type="button"
         >
           Annuler


### PR DESCRIPTION
## Summary
- Ajoute le hook `useGoBack` qui vérifie `window.history.state.idx > 0` avant `navigate(-1)` — sans historique in-app, redirige vers `/`
- Remplace `navigate(-1)` par `goBack()` dans ComicDetail et ComicForm (back button + Annuler)
- Les redirections post-soumission (create/edit) utilisent `replace: true` pour ne pas revenir au formulaire soumis

## Test plan
- [x] Tests unitaires `useGoBack` (4 cas : historique, pas d'historique, null, fallback custom)
- [x] Tests ComicDetail (154 tests) et ComicForm passent
- [x] `tsc --noEmit` passe
- [ ] CI passe

Fixes #307