### PR TITLE
UX : fil d'Ariane dans les sous-pages Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Breadcrumb** : Fil d'Ariane « Outils / Nom de la page » dans les sous-pages Tools (Import, Lookup, Merge, Purge) avec lien retour et `aria-current="page"`
 - **ComponentErrorBoundary** : Error boundaries au niveau composant autour de TomeTable, VirtualGrid et LookupSection avec bouton « Réessayer » contextuel — le boundary app-level reste en dernier recours
 - **ComicDetail** : Bannière d'alerte quand des tomes parus ne sont pas encore ajoutés, avec lien vers le formulaire d'édition
 - **TomeTable** : Colonnes triables avec indicateur de tri — cliquer sur un en-tête (#, Titre, Acheté, Téléchargé, Lu, NAS) trie les tomes, un second clic inverse l'ordre

--- a/frontend/src/__tests__/integration/components/Breadcrumb.test.tsx
+++ b/frontend/src/__tests__/integration/components/Breadcrumb.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Breadcrumb from "../../../components/Breadcrumb";
+
+describe("Breadcrumb", () => {
+  it("renders parent link and current page label", () => {
+    render(
+      <MemoryRouter>
+        <Breadcrumb
+          items={[
+            { href: "/tools", label: "Outils" },
+            { label: "Import Excel" },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole("link", { name: "Outils" });
+    expect(link).toHaveAttribute("href", "/tools");
+    expect(screen.getByText("Import Excel")).toBeInTheDocument();
+  });
+
+  it("renders separator between items", () => {
+    render(
+      <MemoryRouter>
+        <Breadcrumb
+          items={[
+            { href: "/tools", label: "Outils" },
+            { label: "Purge" },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("/")).toBeInTheDocument();
+  });
+
+  it("renders aria navigation landmark", () => {
+    render(
+      <MemoryRouter>
+        <Breadcrumb
+          items={[
+            { href: "/tools", label: "Outils" },
+            { label: "Lookup" },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("navigation", { name: "Fil d'Ariane" })).toBeInTheDocument();
+  });
+
+  it("renders last item as aria-current=page", () => {
+    render(
+      <MemoryRouter>
+        <Breadcrumb
+          items={[
+            { href: "/tools", label: "Outils" },
+            { label: "Fusion" },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Fusion")).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/frontend/src/__tests__/integration/pages/ImportTool.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ImportTool.test.tsx
@@ -11,7 +11,7 @@ describe("ImportTool", () => {
   it("renders the page title and tabs", () => {
     renderWithProviders(<ImportTool />);
 
-    expect(screen.getByText("Import Excel")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Import Excel" })).toBeInTheDocument();
     expect(screen.getByText("Excel suivi")).toBeInTheDocument();
     expect(screen.getByText("Livres")).toBeInTheDocument();
   });

--- a/frontend/src/__tests__/integration/pages/LookupTool.test.tsx
+++ b/frontend/src/__tests__/integration/pages/LookupTool.test.tsx
@@ -15,7 +15,7 @@ describe("LookupTool", () => {
 
     renderWithProviders(<LookupTool />);
 
-    expect(screen.getByText("Lookup métadonnées")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Lookup métadonnées" })).toBeInTheDocument();
   });
 
   it("displays the preview count", async () => {

--- a/frontend/src/__tests__/integration/pages/MergeSeries.test.tsx
+++ b/frontend/src/__tests__/integration/pages/MergeSeries.test.tsx
@@ -79,7 +79,7 @@ describe("MergeSeries", () => {
   it("renders with two tabs", () => {
     renderWithProviders(<MergeSeries />);
 
-    expect(screen.getByText("Fusion de séries")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Fusion de séries" })).toBeInTheDocument();
     expect(screen.getByText("Détection automatique")).toBeInTheDocument();
     expect(screen.getByText("Sélection manuelle")).toBeInTheDocument();
   });

--- a/frontend/src/__tests__/integration/pages/PurgeTool.test.tsx
+++ b/frontend/src/__tests__/integration/pages/PurgeTool.test.tsx
@@ -11,7 +11,7 @@ describe("PurgeTool", () => {
   it("renders the page title and days input", () => {
     renderWithProviders(<PurgeTool />);
 
-    expect(screen.getByText("Purge de la corbeille")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Purge de la corbeille" })).toBeInTheDocument();
     expect(screen.getByRole("spinbutton")).toBeInTheDocument();
   });
 

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -1,0 +1,34 @@
+import { Link } from "react-router-dom";
+
+interface BreadcrumbItem {
+  href?: string;
+  label: string;
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[];
+}
+
+export default function Breadcrumb({ items }: BreadcrumbProps) {
+  return (
+    <nav aria-label="Fil d'Ariane" className="mb-1 text-sm text-text-muted">
+      <ol className="flex items-center gap-1.5">
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1;
+          return (
+            <li className="flex items-center gap-1.5" key={item.label}>
+              {index > 0 && <span aria-hidden="true">/</span>}
+              {item.href && !isLast ? (
+                <Link className="hover:text-text-secondary hover:underline" to={item.href} viewTransition>
+                  {item.label}
+                </Link>
+              ) : (
+                <span aria-current={isLast ? "page" : undefined}>{item.label}</span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/frontend/src/pages/ImportTool.tsx
+++ b/frontend/src/pages/ImportTool.tsx
@@ -8,6 +8,7 @@ import {
 import { CheckCircle, Loader2, Upload } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import Breadcrumb from "../components/Breadcrumb";
 import FileDropZone from "../components/FileDropZone";
 import { useImportBooks, useImportExcel } from "../hooks/useImport";
 import type { ImportBooksResult, ImportExcelResult } from "../types/api";
@@ -182,6 +183,7 @@ function BooksTab() {
 export default function ImportTool() {
   return (
     <div className="mx-auto max-w-4xl px-4 py-6">
+      <Breadcrumb items={[{ href: "/tools", label: "Outils" }, { label: "Import Excel" }]} />
       <h1 className="text-xl font-bold text-text-primary">Import Excel</h1>
 
       <TabGroup className="mt-4">

--- a/frontend/src/pages/LookupTool.tsx
+++ b/frontend/src/pages/LookupTool.tsx
@@ -1,6 +1,7 @@
 import { CheckCircle, Loader2, Search, Square } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import Breadcrumb from "../components/Breadcrumb";
 import ProgressLog from "../components/ProgressLog";
 import {
   useBatchLookup,
@@ -32,6 +33,7 @@ export default function LookupTool() {
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-6">
+      <Breadcrumb items={[{ href: "/tools", label: "Outils" }, { label: "Lookup métadonnées" }]} />
       <h1 className="text-xl font-bold text-text-primary">
         Lookup métadonnées
       </h1>

--- a/frontend/src/pages/MergeSeries.tsx
+++ b/frontend/src/pages/MergeSeries.tsx
@@ -10,6 +10,7 @@ import { Loader2, Merge, Search as SearchIcon } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
+import Breadcrumb from "../components/Breadcrumb";
 import EmptyState from "../components/EmptyState";
 import SelectListbox from "../components/SelectListbox";
 import MergeGroupCard from "../components/MergeGroupCard";
@@ -148,6 +149,7 @@ export default function MergeSeries() {
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-6">
+      <Breadcrumb items={[{ href: "/tools", label: "Outils" }, { label: "Fusion de séries" }]} />
       <h1 className="text-xl font-bold text-text-primary">
         Fusion de séries
       </h1>

--- a/frontend/src/pages/PurgeTool.tsx
+++ b/frontend/src/pages/PurgeTool.tsx
@@ -1,6 +1,7 @@
 import { Loader2, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import Breadcrumb from "../components/Breadcrumb";
 import ConfirmModal from "../components/ConfirmModal";
 import EmptyState from "../components/EmptyState";
 import { useExecutePurge, usePurgePreview } from "../hooks/usePurge";
@@ -26,6 +27,7 @@ export default function PurgeTool() {
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-6">
+      <Breadcrumb items={[{ href: "/tools", label: "Outils" }, { label: "Purge de la corbeille" }]} />
       <h1 className="text-xl font-bold text-text-primary">
         Purge de la corbeille
       </h1>


### PR DESCRIPTION
## Summary
- Ajoute un composant `Breadcrumb` réutilisable avec `<nav aria-label>`, lien retour `viewTransition`, et `aria-current="page"` sur l'item actif
- Intégré dans les 4 sous-pages Tools : Import Excel, Lookup métadonnées, Fusion de séries, Purge de la corbeille
- Tests adaptés pour utiliser `getByRole("heading")` au lieu de `getByText` (doublon breadcrumb/h1)

## Test plan
- [x] 4 tests Breadcrumb (lien, séparateur, aria landmark, aria-current)
- [x] 32 tests pages (ImportTool, LookupTool, MergeSeries, PurgeTool) passent
- [x] `tsc --noEmit` passe
- [ ] CI passe

Fixes #308