### PR TITLE
UX : recherche globale depuis le header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Layout** : Recherche globale dans le header — icône loupe qui ouvre un champ de recherche, Enter navigue vers la page d'accueil avec le paramètre `?search=`, Escape ferme
 - **Breadcrumb** : Fil d'Ariane « Outils / Nom de la page » dans les sous-pages Tools (Import, Lookup, Merge, Purge) avec lien retour et `aria-current="page"`
 - **ComponentErrorBoundary** : Error boundaries au niveau composant autour de TomeTable, VirtualGrid et LookupSection avec bouton « Réessayer » contextuel — le boundary app-level reste en dernier recours
 - **ComicDetail** : Bannière d'alerte quand des tomes parus ne sont pas encore ajoutés, avec lien vers le formulaire d'édition

--- a/frontend/src/__tests__/integration/components/Layout.test.tsx
+++ b/frontend/src/__tests__/integration/components/Layout.test.tsx
@@ -176,6 +176,57 @@ describe("Layout", () => {
     expect(homeLink).toHaveAttribute("href", "/");
   });
 
+  describe("global search", () => {
+    it("renders search button in header", () => {
+      renderLayout();
+      expect(screen.getByLabelText("Rechercher")).toBeInTheDocument();
+    });
+
+    it("opens search input when clicking search button", async () => {
+      const user = userEvent.setup();
+      renderLayout();
+
+      await user.click(screen.getByLabelText("Rechercher"));
+
+      expect(screen.getByPlaceholderText("Rechercher…")).toBeInTheDocument();
+    });
+
+    it("navigates to /?search=value on Enter", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <Routes>
+          <Route element={<Layout />} path="/">
+            <Route element={<div>Home Content</div>} index />
+          </Route>
+          <Route element={<Layout />} path="/tools">
+            <Route element={<div>Tools Content</div>} index />
+          </Route>
+        </Routes>,
+        { initialEntries: ["/tools"] },
+      );
+
+      await user.click(screen.getByLabelText("Rechercher"));
+      await user.type(screen.getByPlaceholderText("Rechercher…"), "naruto{Enter}");
+
+      await waitFor(() => {
+        expect(screen.getByText("Home Content")).toBeInTheDocument();
+      });
+    });
+
+    it("closes search input on Escape", async () => {
+      const user = userEvent.setup();
+      renderLayout();
+
+      await user.click(screen.getByLabelText("Rechercher"));
+      expect(screen.getByPlaceholderText("Rechercher…")).toBeInTheDocument();
+
+      await user.keyboard("{Escape}");
+
+      expect(screen.queryByPlaceholderText("Rechercher…")).not.toBeInTheDocument();
+    });
+  });
+
   describe("sync feedback toasts", () => {
     // The useEffect uses a prevStatus ref initialized to the first status value.
     // To trigger the effect, we must render with "idle" first, then change the mock

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { LogOut, Moon, Sun, Wrench } from "lucide-react";
-import { useEffect, useRef } from "react";
-import { Link, Outlet } from "react-router-dom";
+import { LogOut, Moon, Search, Sun, Wrench, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Link, Outlet, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { useAuth } from "../hooks/useAuth";
 import { useDarkMode } from "../hooks/useDarkMode";
@@ -14,6 +14,10 @@ import SyncErrorBanner from "./SyncErrorBanner";
 export default function Layout() {
   const { logout } = useAuth();
   const { isDark, toggle } = useDarkMode();
+  const navigate = useNavigate();
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState("");
+  const searchInputRef = useRef<HTMLInputElement>(null);
   useServiceWorker();
 
   // Sync feedback toasts
@@ -45,6 +49,54 @@ export default function Layout() {
           <span className="text-lg font-bold text-text-primary">Bibliothèque</span>
         </Link>
         <div className="flex items-center gap-1">
+          {searchOpen ? (
+            <form
+              className="flex items-center gap-1"
+              onSubmit={(e) => {
+                e.preventDefault();
+                const q = searchValue.trim();
+                if (q) {
+                  navigate(`/?search=${encodeURIComponent(q)}`, { viewTransition: true });
+                }
+                setSearchOpen(false);
+                setSearchValue("");
+              }}
+            >
+              <input
+                autoFocus
+                className="w-36 rounded-lg border border-surface-border bg-surface-secondary px-2.5 py-1.5 text-sm text-text-primary placeholder:text-text-muted focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 sm:w-48"
+                onChange={(e) => setSearchValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    setSearchOpen(false);
+                    setSearchValue("");
+                  }
+                }}
+                placeholder="Rechercher…"
+                ref={searchInputRef}
+                type="search"
+                value={searchValue}
+              />
+              <button
+                aria-label="Fermer la recherche"
+                className="rounded-lg p-2 text-text-secondary hover:bg-surface-tertiary"
+                onClick={() => { setSearchOpen(false); setSearchValue(""); }}
+                type="button"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </form>
+          ) : (
+            <button
+              aria-label="Rechercher"
+              className="rounded-lg p-2 text-text-secondary hover:bg-surface-tertiary"
+              onClick={() => setSearchOpen(true)}
+              title="Rechercher"
+              type="button"
+            >
+              <Search className="h-5 w-5" />
+            </button>
+          )}
           <Link
             aria-label="Outils"
             className="rounded-lg p-2 text-text-secondary hover:bg-surface-tertiary"


### PR DESCRIPTION
## Summary
- Ajoute une icône loupe dans le header qui ouvre un champ de recherche inline
- Enter navigue vers `/?search=<valeur>` (réutilise le filtre existant de la page d'accueil)
- Escape ou le bouton X ferme le champ de recherche
- Accessible depuis toutes les pages authentifiées

## Test plan
- [x] 4 tests global search (render, open, navigate, close)
- [x] 21 tests Layout passent
- [x] `tsc --noEmit` passe
- [ ] CI passe

Fixes #310