### PR TITLE
UX : aperçu couverture plus grand dans le formulaire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
+- **ComicForm** : Aperçu couverture agrandi (`h-48` au lieu de `h-32`) et cliquable pour voir en plein écran via CoverLightbox
 - **Navigation retour** : Le bouton retour redirige vers `/` au lieu de quitter l'app quand il n'y a pas d'historique in-app ; les redirections post-soumission remplacent l'entrée formulaire dans l'historique
 - **Suspense fallback** : Spinner centré (Loader2 animate-spin) au lieu du texte brut « Chargement… »
 - **ComicDetail** : Métadonnées affichées en grille clé-valeur (dl/dt/dd) au lieu de paragraphes séquentiels, description séparée dans sa propre section

--- a/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
@@ -629,6 +629,23 @@ describe("ComicForm", () => {
       const preview = screen.getByAltText("Aperçu");
       expect(preview).toHaveAttribute("src", "https://example.com/cover.jpg");
     });
+
+    it("cover preview is clickable and opens lightbox", async () => {
+      const user = userEvent.setup();
+      renderCreateForm();
+
+      await user.type(screen.getByLabelText("URL de couverture"), "https://example.com/cover.jpg");
+
+      const preview = screen.getByAltText("Aperçu");
+      expect(preview).toHaveClass("cursor-pointer");
+
+      await user.click(preview);
+
+      // CoverLightbox uses a dialog
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+    });
   });
 
   describe("Latest published issue field", () => {

--- a/frontend/src/pages/ComicForm.tsx
+++ b/frontend/src/pages/ComicForm.tsx
@@ -1,7 +1,9 @@
 import { ArrowLeft, Image, Loader2 } from "lucide-react";
+import { useState } from "react";
 import AuthorAutocomplete from "../components/AuthorAutocomplete";
 import CollapsibleSection from "../components/CollapsibleSection";
 import ComponentErrorBoundary from "../components/ComponentErrorBoundary";
+import CoverLightbox from "../components/CoverLightbox";
 import CoverSearchModal from "../components/CoverSearchModal";
 import DatePartialSelect from "../components/DatePartialSelect";
 import LookupSection from "../components/LookupSection";
@@ -21,6 +23,7 @@ import { statusOptions, typeOptions } from "../types/enums";
 
 export default function ComicForm() {
   const goBack = useGoBack();
+  const [lightboxOpen, setLightboxOpen] = useState(false);
   const {
     addAuthor,
     applyLookup,
@@ -255,7 +258,20 @@ export default function ComicForm() {
               </button>
             </div>
             {form.coverUrl && (
-              <img alt="Aperçu" className="mt-2 h-32 rounded-lg shadow" src={form.coverUrl} />
+              <>
+                <img
+                  alt="Aperçu"
+                  className="mt-2 h-48 cursor-pointer rounded-lg shadow"
+                  onClick={() => setLightboxOpen(true)}
+                  src={form.coverUrl}
+                />
+                <CoverLightbox
+                  onClose={() => setLightboxOpen(false)}
+                  open={lightboxOpen}
+                  src={form.coverUrl}
+                  title={form.title || "Aperçu"}
+                />
+              </>
             )}
           </div>
           <CoverSearchModal


### PR DESCRIPTION
## Summary
- Agrandit l'aperçu couverture de `h-32` à `h-48` dans ComicForm
- Rend l'aperçu cliquable pour ouvrir le CoverLightbox en plein écran

## Test plan
- [x] Test cover preview existant passe
- [x] Nouveau test : clic ouvre le dialog lightbox
- [x] `tsc --noEmit` passe
- [ ] CI passe

Fixes #314