### PR TITLE
UX : champ URL Amazon dans le formulaire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **ComicForm** : Champ URL Amazon dans la section Publication — peuple `amazonUrl` utilisé par le bouton Amazon de ComicDetail
 - **Layout** : Recherche globale dans le header — icône loupe qui ouvre un champ de recherche, Enter navigue vers la page d'accueil avec le paramètre `?search=`, Escape ferme
 - **Breadcrumb** : Fil d'Ariane « Outils / Nom de la page » dans les sous-pages Tools (Import, Lookup, Merge, Purge) avec lien retour et `aria-current="page"`
 - **ComponentErrorBoundary** : Error boundaries au niveau composant autour de TomeTable, VirtualGrid et LookupSection avec bouton « Réessayer » contextuel — le boundary app-level reste en dernier recours

--- a/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
@@ -661,6 +661,66 @@ describe("ComicForm", () => {
     });
   });
 
+  describe("Amazon URL field", () => {
+    it("renders and accepts URL input in Publication section", async () => {
+      const user = userEvent.setup();
+      renderCreateForm();
+
+      const field = screen.getByLabelText("URL Amazon");
+      expect(field).toBeInTheDocument();
+
+      await user.type(field, "https://www.amazon.fr/dp/B08N5WRWNW");
+      expect(field).toHaveValue("https://www.amazon.fr/dp/B08N5WRWNW");
+    });
+
+    it("includes amazonUrl in create payload", async () => {
+      const user = userEvent.setup();
+      let capturedPayload: Record<string, unknown> | null = null;
+
+      server.use(
+        http.post("/api/comic_series", async ({ request }) => {
+          capturedPayload = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(
+            createMockComicSeries({ id: 99, title: "Amazon Test" }),
+            { status: 201 },
+          );
+        }),
+      );
+
+      renderCreateForm();
+
+      await user.type(screen.getByLabelText("Titre *"), "Amazon Test");
+      await user.type(screen.getByLabelText("URL Amazon"), "https://www.amazon.fr/dp/B08N5WRWNW");
+      await user.click(screen.getByText("Créer"));
+
+      await waitFor(() => {
+        expect(capturedPayload).not.toBeNull();
+      });
+
+      expect(capturedPayload!.amazonUrl).toBe("https://www.amazon.fr/dp/B08N5WRWNW");
+    });
+
+    it("populates amazonUrl from existing comic in edit mode", async () => {
+      server.use(
+        http.get("/api/comic_series/1", () =>
+          HttpResponse.json(
+            createMockComicSeries({
+              amazonUrl: "https://www.amazon.fr/dp/EXISTING",
+              id: 1,
+              title: "Edit Amazon",
+            }),
+          ),
+        ),
+      );
+
+      renderEditForm();
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("URL Amazon")).toHaveValue("https://www.amazon.fr/dp/EXISTING");
+      });
+    });
+  });
+
   describe("Author management", () => {
     it("creates new author during submit via POST /api/authors", async () => {
       const user = userEvent.setup();

--- a/frontend/src/hooks/useComicForm.ts
+++ b/frontend/src/hooks/useComicForm.ts
@@ -28,6 +28,7 @@ export interface TomeFormData {
 }
 
 export interface FormData {
+  amazonUrl: string;
   authors: Author[];
   coverUrl: string;
   defaultTomeBought: boolean;
@@ -53,6 +54,7 @@ export function compareTomes(a: TomeFormData, b: TomeFormData): number {
 function buildInitialForm(comic?: ComicSeries): FormData {
   if (comic) {
     return {
+      amazonUrl: comic.amazonUrl ?? "",
       authors: comic.authors,
       coverUrl: comic.coverUrl ?? "",
       defaultTomeBought: comic.defaultTomeBought,
@@ -82,6 +84,7 @@ function buildInitialForm(comic?: ComicSeries): FormData {
     };
   }
   return {
+    amazonUrl: "",
     authors: [],
     coverUrl: "",
     defaultTomeBought: false,
@@ -177,6 +180,7 @@ export function useComicForm() {
 
     const basePayload: CreateComicPayload = {
       ...(pendingAuthors.length > 0 ? { _pendingAuthors: pendingAuthors } : {}),
+      amazonUrl: form.amazonUrl || null,
       authors: authorIris,
       coverUrl: form.coverUrl || null,
       defaultTomeBought: form.defaultTomeBought,

--- a/frontend/src/hooks/useCreateComic.ts
+++ b/frontend/src/hooks/useCreateComic.ts
@@ -21,7 +21,7 @@ export function useCreateComic() {
         const tempSeries: ComicSeries = {
           "@id": `/api/comic_series/${tempId}`,
           _syncPending: true,
-          amazonUrl: null,
+          amazonUrl: variables.amazonUrl ?? null,
           authors: [],
           coverImage: null,
           coverUrl: variables.coverUrl ?? null,

--- a/frontend/src/pages/ComicForm.tsx
+++ b/frontend/src/pages/ComicForm.tsx
@@ -230,6 +230,20 @@ export default function ComicForm() {
               <span className="text-sm font-medium text-text-secondary">Parution terminée</span>
             </label>
           </div>
+
+          <div>
+            <label className={formLabelClassName} htmlFor="amazonUrl">
+              URL Amazon
+            </label>
+            <input
+              className={`w-full ${formInputClassName}`}
+              id="amazonUrl"
+              onChange={(e) => update("amazonUrl", e.target.value)}
+              placeholder="https://www.amazon.fr/dp/..."
+              type="url"
+              value={form.amazonUrl}
+            />
+          </div>
         </CollapsibleSection>
 
         {/* Média */}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -163,6 +163,7 @@ export interface BatchLookupSummary {
 
 export interface CreateComicPayload {
   _pendingAuthors?: string[];
+  amazonUrl: string | null;
   authors: string[];
   coverUrl: string | null;
   defaultTomeBought: boolean;


### PR DESCRIPTION
## Summary
- Ajoute le champ `amazonUrl` dans la section Publication de ComicForm
- Ajout à `FormData`, `buildInitialForm`, `CreateComicPayload`, et payload de soumission
- L'optimistic update de `useCreateComic` utilise la valeur du payload

## Test plan
- [x] 3 tests Amazon URL field (render, payload, edit populate)
- [x] `tsc --noEmit` passe
- [ ] CI passe

Fixes #315