### PR TITLE
UX : ajuster le gap de la grille sur mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
+- **VirtualGrid** : Gap de la grille augmenté de `gap-3` (12px) à `gap-4` (16px) pour plus d'espace entre les cartes sur mobile
 - **ComicForm** : Aperçu couverture agrandi (`h-48` au lieu de `h-32`) et cliquable pour voir en plein écran via CoverLightbox
 - **Navigation retour** : Le bouton retour redirige vers `/` au lieu de quitter l'app quand il n'y a pas d'historique in-app ; les redirections post-soumission remplacent l'entrée formulaire dans l'historique
 - **Suspense fallback** : Spinner centré (Loader2 animate-spin) au lieu du texte brut « Chargement… »

--- a/frontend/src/components/VirtualGrid.tsx
+++ b/frontend/src/components/VirtualGrid.tsx
@@ -2,8 +2,8 @@ import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import type { ReactNode } from "react";
 import { useColumnCount } from "../hooks/useColumnCount";
 
-const GRID_CLASSES = "grid grid-cols-2 gap-x-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6";
-const ROW_GAP = 12; // Tailwind gap-3 = 0.75rem = 12px
+const GRID_CLASSES = "grid grid-cols-2 gap-x-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6";
+const ROW_GAP = 16; // Tailwind gap-4 = 1rem = 16px
 
 interface VirtualGridProps<T> {
   estimateRowHeight?: number;


### PR DESCRIPTION
## Summary
- Augmente le gap horizontal de `gap-x-3` à `gap-x-4` et le gap vertical (ROW_GAP) de 12px à 16px dans VirtualGrid
- Offre plus d'espace entre les cartes `rounded-xl` sur écrans 375px

## Test plan
- [x] 34 tests Home page passent (VirtualGrid intégré)
- [x] `tsc --noEmit` passe
- [ ] CI passe

Fixes #320