### PR TITLE
UX : icônes d'états vides stylisées

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
+- **EmptyState** : Icône enveloppée dans un conteneur arrondi avec fond dégradé primary pour plus de chaleur visuelle
 - **ComicDetail** : Barre d'actions inline sur desktop (`lg:static`) au lieu de sticky en bas — les boutons Modifier/Amazon/Supprimer s'intègrent dans le flux de la page
 - **ProgressBar** : Affiche le pourcentage à côté du compteur : « 8 / 12 (67%) »
 - **VirtualGrid** : Gap de la grille augmenté de `gap-3` (12px) à `gap-4` (16px) pour plus d'espace entre les cartes sur mobile

--- a/frontend/src/__tests__/integration/components/EmptyState.test.tsx
+++ b/frontend/src/__tests__/integration/components/EmptyState.test.tsx
@@ -65,6 +65,16 @@ describe("EmptyState", () => {
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
+  it("wraps icon in a styled container", () => {
+    renderWithProviders(
+      <EmptyState icon={Heart} title="Liste vide" />,
+    );
+
+    const iconWrapper = screen.getByTestId("empty-state-icon-wrapper");
+    expect(iconWrapper).toBeInTheDocument();
+    expect(iconWrapper.className).toContain("rounded-2xl");
+  });
+
   it("has fade-in-up animation class", () => {
     renderWithProviders(
       <EmptyState icon={Heart} title="Liste vide" />,

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -22,11 +22,16 @@ export default function EmptyState({
 
   return (
     <div className="flex animate-fade-in-up flex-col items-center justify-center py-16 text-center motion-reduce:animate-none">
-      <Icon
-        className="mb-4 h-16 w-16 text-text-muted/40"
-        data-testid="empty-state-icon"
-        strokeWidth={1.5}
-      />
+      <div
+        className="mb-4 flex h-20 w-20 items-center justify-center rounded-2xl bg-gradient-to-br from-primary-100 to-primary-200 dark:from-primary-950/40 dark:to-primary-900/30"
+        data-testid="empty-state-icon-wrapper"
+      >
+        <Icon
+          className="h-10 w-10 text-primary-500 dark:text-primary-400"
+          data-testid="empty-state-icon"
+          strokeWidth={1.5}
+        />
+      </div>
       <h2 className="text-lg font-semibold text-text-primary">{title}</h2>
       {description && (
         <p className="mt-1 text-sm text-text-muted" data-testid="empty-state-description">


### PR DESCRIPTION
## Summary
- Enveloppe l'icône EmptyState dans un conteneur `rounded-2xl` avec fond dégradé primary
- Support dark mode (`dark:from-primary-950/40 dark:to-primary-900/30`)
- Icône plus petite (`h-10 w-10`) mais avec couleur primary au lieu de `text-muted/40`

## Test plan
- [x] 7 tests EmptyState passent (dont nouveau test icon wrapper)
- [ ] CI passe

Fixes #326