### PR TITLE
UX : compteur file d'attente offline dépliable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
+- **OfflineBanner** : Bouton dépliable pour voir la liste des opérations en attente (type + ressource) quand il y a des opérations en file d'attente
 - **EmptyState** : Icône enveloppée dans un conteneur arrondi avec fond dégradé primary pour plus de chaleur visuelle
 - **ComicDetail** : Barre d'actions inline sur desktop (`lg:static`) au lieu de sticky en bas — les boutons Modifier/Amazon/Supprimer s'intègrent dans le flux de la page
 - **ProgressBar** : Affiche le pourcentage à côté du compteur : « 8 / 12 (67%) »

--- a/frontend/src/__tests__/integration/components/OfflineBanner.test.tsx
+++ b/frontend/src/__tests__/integration/components/OfflineBanner.test.tsx
@@ -1,10 +1,13 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import OfflineBanner from "../../../components/OfflineBanner";
 import { renderWithProviders } from "../../helpers/test-utils";
+import type { QueueItem } from "../../../services/offlineQueue";
 
 // Mock the hooks used by OfflineBanner
 const mockUseOnlineStatus = vi.fn(() => true);
 const mockUsePendingQueueCount = vi.fn(() => 0);
+const mockGetAll = vi.fn<() => Promise<QueueItem[]>>(() => Promise.resolve([]));
 
 vi.mock("../../../hooks/useOnlineStatus", () => ({
   useOnlineStatus: () => mockUseOnlineStatus(),
@@ -12,6 +15,10 @@ vi.mock("../../../hooks/useOnlineStatus", () => ({
 
 vi.mock("../../../hooks/usePendingQueueCount", () => ({
   usePendingQueueCount: () => mockUsePendingQueueCount(),
+}));
+
+vi.mock("../../../services/offlineQueue", () => ({
+  getAll: () => mockGetAll(),
 }));
 
 describe("OfflineBanner", () => {
@@ -69,5 +76,42 @@ describe("OfflineBanner", () => {
     renderWithProviders(<OfflineBanner />);
 
     expect(screen.getByText("1 opération en attente de synchronisation")).toBeInTheDocument();
+  });
+
+  it("shows expand button when there are pending operations", () => {
+    mockUseOnlineStatus.mockReturnValue(false);
+    mockUsePendingQueueCount.mockReturnValue(2);
+
+    renderWithProviders(<OfflineBanner />);
+
+    expect(screen.getByLabelText("Voir les opérations en attente")).toBeInTheDocument();
+  });
+
+  it("does not show expand button when offline with no pending ops", () => {
+    mockUseOnlineStatus.mockReturnValue(false);
+    mockUsePendingQueueCount.mockReturnValue(0);
+
+    renderWithProviders(<OfflineBanner />);
+
+    expect(screen.queryByLabelText("Voir les opérations en attente")).not.toBeInTheDocument();
+  });
+
+  it("expands to show queue items when clicked", async () => {
+    const user = userEvent.setup();
+    mockUseOnlineStatus.mockReturnValue(false);
+    mockUsePendingQueueCount.mockReturnValue(2);
+    mockGetAll.mockResolvedValue([
+      { id: 1, operation: "create", payload: { title: "Naruto" }, resourceType: "comic_series", retryCount: 0, status: "pending", timestamp: Date.now(), url: "/api/comic_series" },
+      { id: 2, operation: "update", payload: { bought: true }, resourceType: "tome", retryCount: 0, status: "pending", timestamp: Date.now(), url: "/api/tomes/5" },
+    ] as QueueItem[]);
+
+    renderWithProviders(<OfflineBanner />);
+
+    await user.click(screen.getByLabelText("Voir les opérations en attente"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Création série")).toBeInTheDocument();
+      expect(screen.getByText("Mise à jour tome")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/OfflineBanner.tsx
+++ b/frontend/src/components/OfflineBanner.tsx
@@ -1,9 +1,26 @@
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import { usePendingQueueCount } from "../hooks/usePendingQueueCount";
 import { useOnlineStatus } from "../hooks/useOnlineStatus";
+import { getAll, type QueueItem } from "../services/offlineQueue";
+import { operationLabels, resourceLabels } from "../utils/syncLabels";
 
 export default function OfflineBanner() {
   const isOnline = useOnlineStatus();
   const pendingCount = usePendingQueueCount();
+  const [expanded, setExpanded] = useState(false);
+  const [queueItems, setQueueItems] = useState<QueueItem[]>([]);
+
+  const loadQueue = useCallback(async () => {
+    const items = await getAll();
+    setQueueItems(items);
+  }, []);
+
+  useEffect(() => {
+    if (expanded && pendingCount > 0) {
+      void loadQueue();
+    }
+  }, [expanded, loadQueue, pendingCount]);
 
   if (isOnline && pendingCount === 0) return null;
 
@@ -13,9 +30,33 @@ export default function OfflineBanner() {
       : "Mode hors ligne"
     : `${pendingCount} opération${pendingCount > 1 ? "s" : ""} en attente de synchronisation`;
 
+  const Chevron = expanded ? ChevronUp : ChevronDown;
+
   return (
-    <div className="fixed top-0 left-0 right-0 z-50 bg-amber-500 py-1 text-center text-xs font-medium text-amber-950">
-      {message}
+    <div className="fixed top-0 left-0 right-0 z-50 bg-amber-500 text-amber-950">
+      <div className="flex items-center justify-center gap-2 py-1 text-xs font-medium">
+        <span>{message}</span>
+        {pendingCount > 0 && (
+          <button
+            aria-label="Voir les opérations en attente"
+            className="rounded p-0.5 hover:bg-amber-600/30"
+            onClick={() => setExpanded((v) => !v)}
+            type="button"
+          >
+            <Chevron className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+      {expanded && queueItems.length > 0 && (
+        <ul className="border-t border-amber-600/30 px-4 py-1.5 text-xs">
+          {queueItems.map((item) => (
+            <li className="py-0.5" key={item.id}>
+              {operationLabels[item.operation] ?? item.operation}{" "}
+              {resourceLabels[item.resourceType] ?? item.resourceType}
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Ajoute un bouton chevron dans l'OfflineBanner quand il y a des opérations en attente
- Au clic, déplie une liste montrant chaque opération (ex: « Création série », « Mise à jour tome »)
- Utilise `getAll()` de la file IndexedDB et les labels existants de `syncLabels.ts`

## Test plan
- [x] 9 tests OfflineBanner passent (3 nouveaux : expand button, no expand, expand list)
- [x] `tsc --noEmit` passe
- [ ] CI passe

Fixes #328