### PR TITLE
UX : page 404 plus chaleureuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
+- **NotFound** : Page 404 plus chaleureuse avec icône BookX dans un conteneur dégradé, grand « 404 » stylisé, et sous-titre thématique « disparu de la collection »
 - **OfflineBanner** : Bouton dépliable pour voir la liste des opérations en attente (type + ressource) quand il y a des opérations en file d'attente
 - **EmptyState** : Icône enveloppée dans un conteneur arrondi avec fond dégradé primary pour plus de chaleur visuelle
 - **ComicDetail** : Barre d'actions inline sur desktop (`lg:static`) au lieu de sticky en bas — les boutons Modifier/Amazon/Supprimer s'intègrent dans le flux de la page

--- a/frontend/src/__tests__/integration/pages/NotFound.test.tsx
+++ b/frontend/src/__tests__/integration/pages/NotFound.test.tsx
@@ -3,11 +3,12 @@ import NotFound from "../../../pages/NotFound";
 import { renderWithProviders } from "../../helpers/test-utils";
 
 describe("NotFound", () => {
-  it("renders 404 message", () => {
+  it("renders 404 message with themed subtitle", () => {
     renderWithProviders(<NotFound />);
 
     expect(screen.getByText("404")).toBeInTheDocument();
     expect(screen.getByText("Page introuvable")).toBeInTheDocument();
+    expect(screen.getByText(/Cette page semble avoir disparu/)).toBeInTheDocument();
   });
 
   it("has a link back to home", () => {
@@ -16,5 +17,11 @@ describe("NotFound", () => {
     const link = screen.getByText("Retour à l'accueil");
     expect(link).toBeInTheDocument();
     expect(link.closest("a")).toHaveAttribute("href", "/");
+  });
+
+  it("renders a themed icon", () => {
+    renderWithProviders(<NotFound />);
+
+    expect(screen.getByTestId("not-found-icon")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,12 +1,24 @@
+import { BookX } from "lucide-react";
 import { Link } from "react-router-dom";
 
 export default function NotFound() {
   return (
-    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 text-center">
-      <h1 className="text-6xl font-bold text-text-muted">404</h1>
-      <p className="text-lg text-text-secondary">Page introuvable</p>
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 px-4 text-center">
+      <div
+        className="flex h-24 w-24 items-center justify-center rounded-2xl bg-gradient-to-br from-primary-100 to-primary-200 dark:from-primary-950/40 dark:to-primary-900/30"
+        data-testid="not-found-icon"
+      >
+        <BookX className="h-12 w-12 text-primary-500 dark:text-primary-400" strokeWidth={1.5} />
+      </div>
+      <div>
+        <h1 className="text-7xl font-extrabold tracking-tight text-text-muted/30">404</h1>
+        <p className="mt-2 text-xl font-semibold text-text-primary">Page introuvable</p>
+        <p className="mt-1 text-sm text-text-muted">
+          Cette page semble avoir disparu de la collection.
+        </p>
+      </div>
       <Link
-        className="rounded-lg bg-primary-600 px-4 py-2 text-white hover:bg-primary-700"
+        className="rounded-lg bg-primary-600 px-5 py-2.5 text-base font-medium text-white hover:bg-primary-700"
         to="/"
         viewTransition
       >


### PR DESCRIPTION
## Summary
- Redesign de la page 404 avec icône `BookX` dans un conteneur dégradé primary
- Grand « 404 » en `text-7xl font-extrabold` semi-transparent
- Sous-titre thématique : « Cette page semble avoir disparu de la collection »
- Support dark mode

## Test plan
- [x] 3 tests NotFound passent (message, lien, icône)
- [x] `tsc --noEmit` passe
- [ ] CI passe

Fixes #329