### PR TITLE
chore(release): v2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+## [v2.14.0] - 2026-03-20
+
 ### Changed
 
 - **NotFound** : Page 404 plus chaleureuse avec icône BookX dans un conteneur dégradé, grand « 404 » stylisé, et sous-titre thématique « disparu de la collection »
@@ -20,6 +22,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 - **Suspense fallback** : Spinner centré (Loader2 animate-spin) au lieu du texte brut « Chargement… »
 - **ComicDetail** : Métadonnées affichées en grille clé-valeur (dl/dt/dd) au lieu de paragraphes séquentiels, description séparée dans sa propre section
 - **TomeTable** : Breakpoint carte/table relevé de `sm` (640px) à `md` (768px) — les tablettes et desktops étroits utilisent le layout carte dépliable au lieu de la table qui déborde
+- **TomeTable** : Checkbox « Acheté » en accès rapide sur la ligne repliable du tome, champ titre sur sa propre ligne pour éviter le débordement sur mobile
 
 ### Added
 


### PR DESCRIPTION
## Summary
- CHANGELOG: passage de [Unreleased] à [v2.14.0] - 2026-03-20

## Test plan
- [x] CHANGELOG uniquement, pas de changement de code