### PR TITLE
fix(scanner): corrige le bouton Scanner ISBN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Scanner ISBN** : Corrige le bouton « Scanner » qui ne fonctionnait pas — le conteneur vidéo n'était jamais monté car l'état `scanning` était vérifié après le `ref`
+
 ## [v2.14.2] - 2026-03-20
 
 ### Fixed

--- a/frontend/src/__tests__/integration/components/BarcodeScanner.test.tsx
+++ b/frontend/src/__tests__/integration/components/BarcodeScanner.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Html5Qrcode } from "html5-qrcode";
 import { toast } from "sonner";
@@ -16,186 +16,171 @@ vi.mock("sonner", async () => {
   };
 });
 
-// Mock html5-qrcode since it relies on browser APIs not available in jsdom
+let mockStart: ReturnType<typeof vi.fn>;
+let mockStop: ReturnType<typeof vi.fn>;
+
 vi.mock("html5-qrcode", () => ({
-  Html5Qrcode: vi.fn().mockImplementation(() => ({
-    start: vi.fn().mockRejectedValue(new Error("Camera not available")),
-    stop: vi.fn().mockResolvedValue(undefined),
-  })),
+  Html5Qrcode: vi.fn(),
 }));
 
-// Known jsdom limitations — NOT coverage gaps:
-// - stopScanner path: the "Scanner actif" UI (with the X button that calls stopScanner) is only
-//   rendered when scanning=true, but startScanner does an early-return when containerRef.current
-//   is null (jsdom never renders the scanner div before setScanning(true) is called). So the stop
-//   button is never reachable via UI interactions in jsdom.
-// - toast.error("Impossible d'accéder à la caméra"): triggered inside the catch block of
-//   scanner.start(), which is only reached after Html5Qrcode successfully creates its DOM
-//   container and then the camera API rejects. In jsdom, startScanner exits before reaching
-//   Html5Qrcode instantiation because containerRef.current is null.
-// These paths are covered by manual/browser testing and are not broken — jsdom simply cannot
-// simulate the real DOM lifecycle that Html5QrcodeScanner requires.
+beforeEach(() => {
+  mockStop = vi.fn().mockResolvedValue(undefined);
+  mockStart = vi.fn().mockResolvedValue(undefined);
+
+  vi.mocked(Html5Qrcode).mockImplementation(function () {
+    return { start: mockStart, stop: mockStop } as unknown as InstanceType<typeof Html5Qrcode>;
+  });
+});
 
 describe("BarcodeScanner", () => {
   it("renders the scanner button", () => {
-    const onScan = vi.fn();
-
-    renderWithProviders(<BarcodeScanner onScan={onScan} />);
+    renderWithProviders(<BarcodeScanner onScan={vi.fn()} />);
 
     expect(screen.getByText("Scanner")).toBeInTheDocument();
   });
 
   it("shows scanner UI when button is clicked", async () => {
     const user = userEvent.setup();
+
+    renderWithProviders(<BarcodeScanner onScan={vi.fn()} />);
+
+    await user.click(screen.getByText("Scanner"));
+
+    expect(screen.getByText("Scanner actif")).toBeInTheDocument();
+    expect(screen.getByLabelText("Fermer le scanner")).toBeInTheDocument();
+  });
+
+  it("starts Html5Qrcode after clicking scanner button", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<BarcodeScanner onScan={vi.fn()} />);
+
+    await user.click(screen.getByText("Scanner"));
+
+    await waitFor(() => {
+      expect(Html5Qrcode).toHaveBeenCalledWith("barcode-scanner");
+      expect(mockStart).toHaveBeenCalledWith(
+        { facingMode: "environment" },
+        { fps: 10, qrbox: { width: 250, height: 100 } },
+        expect.any(Function),
+        expect.any(Function),
+      );
+    });
+  });
+
+  it("stops scanner and returns to button when X is clicked", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<BarcodeScanner onScan={vi.fn()} />);
+
+    await user.click(screen.getByText("Scanner"));
+    expect(screen.getByText("Scanner actif")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Fermer le scanner"));
+
+    expect(mockStop).toHaveBeenCalled();
+    expect(screen.getByText("Scanner")).toBeInTheDocument();
+  });
+
+  it("calls onScan with cleaned ISBN-13 and stops scanner", async () => {
+    const user = userEvent.setup();
     const onScan = vi.fn();
+    let decodedTextCallback: ((text: string) => void) | null = null;
+
+    mockStart.mockImplementation((_camera: unknown, _config: unknown, onSuccess: (text: string) => void) => {
+      decodedTextCallback = onSuccess;
+      return Promise.resolve();
+    });
 
     renderWithProviders(<BarcodeScanner onScan={onScan} />);
 
     await user.click(screen.getByText("Scanner"));
 
-    // Since camera fails in jsdom, it should fall back to non-scanning state
-    // The component shows "Scanner actif" briefly before the error
-    // and then falls back to the button again after toast.error
-    // Wait for the async error to resolve
-    await vi.waitFor(() => {
-      expect(screen.getByText("Scanner")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(decodedTextCallback).not.toBeNull();
     });
+
+    act(() => decodedTextCallback!("978-2-505-08067-3"));
+
+    expect(onScan).toHaveBeenCalledWith("9782505080673");
+    expect(mockStop).toHaveBeenCalled();
   });
 
-  it("has a camera icon in the button", () => {
+  it("calls onScan with cleaned ISBN-10", async () => {
+    const user = userEvent.setup();
     const onScan = vi.fn();
+    let decodedTextCallback: ((text: string) => void) | null = null;
+
+    mockStart.mockImplementation((_camera: unknown, _config: unknown, onSuccess: (text: string) => void) => {
+      decodedTextCallback = onSuccess;
+      return Promise.resolve();
+    });
 
     renderWithProviders(<BarcodeScanner onScan={onScan} />);
 
-    const button = screen.getByText("Scanner");
-    expect(button).toBeInTheDocument();
-    expect(button.tagName).toBe("BUTTON");
+    await user.click(screen.getByText("Scanner"));
+
+    await waitFor(() => {
+      expect(decodedTextCallback).not.toBeNull();
+    });
+
+    act(() => decodedTextCallback!("123456789X"));
+
+    expect(onScan).toHaveBeenCalledWith("123456789X");
   });
 
-  describe("with scanner container pre-rendered", () => {
-    // The component uses conditional rendering: containerRef is only mounted when scanning=true.
-    // Since startScanner checks containerRef.current before setting scanning to true,
-    // we need to mock the ref to simulate the scanner being already active.
-    // Instead, we test the callback logic by pre-setting scanning state via the mock.
+  it("ignores barcodes that are not ISBN-10 or ISBN-13", async () => {
+    const user = userEvent.setup();
+    const onScan = vi.fn();
     let decodedTextCallback: ((text: string) => void) | null = null;
-    let mockStop: ReturnType<typeof vi.fn>;
 
-    beforeEach(() => {
-      decodedTextCallback = null;
-      mockStop = vi.fn().mockResolvedValue(undefined);
-
-      // This mock captures the decodedText callback when start is called.
-      // The component's startScanner early-returns because containerRef is null in jsdom,
-      // but we test via a component that pre-mounts the container.
-      vi.mocked(Html5Qrcode).mockImplementation(() => ({
-        start: vi.fn().mockImplementation((_camera: unknown, _config: unknown, onSuccess: (text: string) => void) => {
-          decodedTextCallback = onSuccess;
-          return Promise.resolve();
-        }),
-        stop: mockStop,
-      }) as unknown as InstanceType<typeof Html5Qrcode>);
+    mockStart.mockImplementation((_camera: unknown, _config: unknown, onSuccess: (text: string) => void) => {
+      decodedTextCallback = onSuccess;
+      return Promise.resolve();
     });
 
-    it("ISBN sanitization removes hyphens and non-digits", () => {
-      // Test the sanitization regex used in the component: decodedText.replace(/[^0-9X]/gi, "")
-      const isbn = "978-1-234-56789-0".replace(/[^0-9X]/gi, "");
-      expect(isbn).toBe("9781234567890");
-      expect(isbn.length).toBe(13);
+    renderWithProviders(<BarcodeScanner onScan={onScan} />);
+
+    await user.click(screen.getByText("Scanner"));
+
+    await waitFor(() => {
+      expect(decodedTextCallback).not.toBeNull();
     });
 
-    it("accepts 10-digit ISBN", () => {
-      const isbn = "123456789X".replace(/[^0-9X]/gi, "");
-      expect(isbn.length).toBe(10);
+    act(() => decodedTextCallback!("123456789012"));
+
+    expect(onScan).not.toHaveBeenCalled();
+    expect(mockStop).not.toHaveBeenCalled();
+  });
+
+  it("shows toast and returns to button when camera access fails", async () => {
+    const user = userEvent.setup();
+    mockStart.mockRejectedValue(new Error("Camera not available"));
+
+    renderWithProviders(<BarcodeScanner onScan={vi.fn()} />);
+
+    await user.click(screen.getByText("Scanner"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Impossible d'accéder à la caméra");
     });
 
-    it("rejects 12-digit barcode (only 10 or 13 accepted)", () => {
-      const isbn = "123456789012".replace(/[^0-9X]/gi, "");
-      expect(isbn.length).toBe(12);
-      // 12 !== 10 && 12 !== 13, so it should be rejected
-      expect(isbn.length === 10 || isbn.length === 13).toBe(false);
+    expect(screen.getByText("Scanner")).toBeInTheDocument();
+  });
+
+  it("stops scanner on unmount", async () => {
+    const user = userEvent.setup();
+
+    const { unmount } = renderWithProviders(<BarcodeScanner onScan={vi.fn()} />);
+
+    await user.click(screen.getByText("Scanner"));
+
+    await waitFor(() => {
+      expect(mockStart).toHaveBeenCalled();
     });
 
-    it("calls stop on cleanup via useEffect", () => {
-      const onScan = vi.fn();
-      const mockStopCleanup = vi.fn().mockResolvedValue(undefined);
+    unmount();
 
-      vi.mocked(Html5Qrcode).mockImplementation(() => ({
-        start: vi.fn().mockResolvedValue(undefined),
-        stop: mockStopCleanup,
-      }) as unknown as InstanceType<typeof Html5Qrcode>);
-
-      const { unmount } = renderWithProviders(<BarcodeScanner onScan={onScan} />);
-
-      unmount();
-
-      // The useEffect cleanup calls scannerRef.current?.stop()
-      // Since scannerRef is only assigned when startScanner creates the Html5Qrcode instance,
-      // and containerRef.current is null in jsdom, scannerRef.current stays null.
-      // stop() should NOT be called since scanner was never initialized.
-      expect(mockStopCleanup).not.toHaveBeenCalled();
-    });
-
-    it("returns to scanner button when camera access fails", async () => {
-      const user = userEvent.setup();
-      const onScan = vi.fn();
-
-      // Reset to default mock that rejects
-      vi.mocked(Html5Qrcode).mockImplementation(() => ({
-        start: vi.fn().mockRejectedValue(new Error("Camera not available")),
-        stop: vi.fn().mockResolvedValue(undefined),
-      }) as unknown as InstanceType<typeof Html5Qrcode>);
-
-      renderWithProviders(<BarcodeScanner onScan={onScan} />);
-
-      await user.click(screen.getByText("Scanner"));
-
-      // Scanner button should remain/re-appear since containerRef is null
-      await waitFor(() => {
-        expect(screen.getByText("Scanner")).toBeInTheDocument();
-      });
-    });
-
-    it("shows toast error when camera access fails", async () => {
-      // containerRef.current is null in jsdom because the scanner div is only
-      // rendered when scanning=true, but startScanner checks the ref before
-      // calling setScanning. We test the error path by extracting the logic:
-      // if Html5Qrcode.start rejects, toast.error is called.
-      // Since we can't reach that code path via the UI in jsdom, we verify
-      // the toast mock integration works by confirming the component's
-      // early-return behavior and testing the error message constant.
-      const onScan = vi.fn();
-
-      vi.mocked(Html5Qrcode).mockImplementation(() => ({
-        start: vi.fn().mockRejectedValue(new Error("Camera not available")),
-        stop: vi.fn().mockResolvedValue(undefined),
-      }) as unknown as InstanceType<typeof Html5Qrcode>);
-
-      renderWithProviders(<BarcodeScanner onScan={onScan} />);
-
-      // Verify the component renders without errors and has the expected structure
-      expect(screen.getByText("Scanner")).toBeInTheDocument();
-
-      // The error toast message is "Impossible d'accéder à la caméra" —
-      // verified by reading the source. In a real browser with camera APIs,
-      // clicking Scanner would trigger this toast on camera denial.
-    });
-
-    it("does not call stop on cleanup when scanner was never started", () => {
-      const onScan = vi.fn();
-      const mockStopActive = vi.fn().mockResolvedValue(undefined);
-
-      vi.mocked(Html5Qrcode).mockImplementation(() => ({
-        start: vi.fn().mockResolvedValue(undefined),
-        stop: mockStopActive,
-      }) as unknown as InstanceType<typeof Html5Qrcode>);
-
-      const { unmount } = renderWithProviders(<BarcodeScanner onScan={onScan} />);
-
-      unmount();
-
-      // scannerRef.current is null (scanner never initialized in jsdom),
-      // so stop should not be called. This verifies the optional chaining works.
-      expect(mockStopActive).not.toHaveBeenCalled();
-    });
+    expect(mockStop).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/BarcodeScanner.tsx
+++ b/frontend/src/components/BarcodeScanner.tsx
@@ -1,6 +1,6 @@
 import { Html5Qrcode } from "html5-qrcode";
 import { Camera, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 interface BarcodeScannerProps {
@@ -10,52 +10,59 @@ interface BarcodeScannerProps {
 export default function BarcodeScanner({ onScan }: BarcodeScannerProps) {
   const [scanning, setScanning] = useState(false);
   const scannerRef = useRef<Html5Qrcode | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const onScanRef = useRef(onScan);
+  onScanRef.current = onScan;
 
-  useEffect(() => {
-    return () => {
-      scannerRef.current?.stop().catch(() => {});
-    };
+  const stopScanner = useCallback(() => {
+    scannerRef.current?.stop().catch(() => {});
+    scannerRef.current = null;
+    setScanning(false);
   }, []);
 
-  const startScanner = async () => {
-    if (!containerRef.current) return;
+  useEffect(() => {
+    if (!scanning) return;
 
-    setScanning(true);
-    const scanner = new Html5Qrcode(containerRef.current.id);
+    const container = document.getElementById("barcode-scanner");
+    if (!container) return;
+
+    const scanner = new Html5Qrcode("barcode-scanner");
     scannerRef.current = scanner;
 
-    try {
-      await scanner.start(
+    scanner
+      .start(
         { facingMode: "environment" },
         { fps: 10, qrbox: { width: 250, height: 100 } },
         (decodedText) => {
           const isbn = decodedText.replace(/[^0-9X]/gi, "");
           if (isbn.length === 10 || isbn.length === 13) {
             scanner.stop().catch(() => {});
+            scannerRef.current = null;
             setScanning(false);
-            onScan(isbn);
+            onScanRef.current(isbn);
           }
         },
         () => {},
-      );
-    } catch {
-      setScanning(false);
-      toast.error("Impossible d'accéder à la caméra");
-    }
-  };
+      )
+      .catch(() => {
+        scannerRef.current = null;
+        setScanning(false);
+        toast.error("Impossible d'accéder à la caméra");
+      });
 
-  const stopScanner = () => {
-    scannerRef.current?.stop().catch(() => {});
-    setScanning(false);
-  };
+    return () => {
+      if (scannerRef.current === scanner) {
+        scanner.stop().catch(() => {});
+        scannerRef.current = null;
+      }
+    };
+  }, [scanning]);
 
   return (
     <div>
       {!scanning ? (
         <button
           className="flex items-center gap-2 rounded-lg bg-surface-tertiary px-3 py-2 text-sm font-medium text-text-secondary hover:bg-surface-border"
-          onClick={startScanner}
+          onClick={() => setScanning(true)}
           type="button"
         >
           <Camera className="h-4 w-4" />
@@ -77,7 +84,6 @@ export default function BarcodeScanner({ onScan }: BarcodeScannerProps) {
           <div
             className="overflow-hidden rounded-lg"
             id="barcode-scanner"
-            ref={containerRef}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary

- **Corrige le bouton « Scanner »** qui ne faisait rien au clic — le conteneur vidéo n'était jamais monté car `startScanner` vérifiait `containerRef.current` (toujours `null`) avant de passer `scanning` à `true`
- **Déplace l'initialisation** du scanner dans un `useEffect` déclenché par le changement d'état `scanning`, garantissant que le `<div>` est monté avant de créer l'instance `Html5Qrcode`
- **Réécrit les tests** pour couvrir le cycle complet : ouverture, scan ISBN-13/10, rejet des codes invalides, fermeture, erreur caméra et nettoyage au démontage

## Test plan

- [ ] Ouvrir le formulaire d'ajout sur mobile (Chrome Android)
- [ ] Passer en mode ISBN, cliquer « Scanner »
- [ ] Vérifier que la caméra s'ouvre et que « Scanner actif » s'affiche
- [ ] Scanner un code-barres ISBN → le champ ISBN se remplit et le lookup se déclenche
- [ ] Cliquer ✕ → retour au bouton Scanner
- [ ] Refuser l'accès caméra → toast d'erreur affiché

fixes #367