### PR TITLE
chore: ajoute le placeholder VITE_VAPID_PUBLIC_KEY

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,2 @@
 VITE_GOOGLE_CLIENT_ID=change_this_in_env_local
+VITE_VAPID_PUBLIC_KEY=change_this_in_env_local


### PR DESCRIPTION
Ajoute le placeholder pour la clé publique VAPID dans frontend/.env