### PR TITLE
chore: gitignore docs/superpowers/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ logs/
 .superpowers/
 .worktrees/
 docs/plans/
+docs/superpowers/
 .ddev/share-providers/
 .phpunit.cache/
 .playwright-mcp/


### PR DESCRIPTION
Exclut le dossier des specs de brainstorming du dépôt.