### PR TITLE
chore(release): v2.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
+- **À acheter** : Affichage des tomes manquants en tranches (T.1-3, T.5) au lieu d'une liste (T.1, T.2, T.3, T.5)
 - **Service/** : Réorganisation en sous-domaines (ComicSeries, Cover, Notification, Recommendation, Lookup/{Contract,Gemini,Provider,Util})
 - **GeminiQueryService** : Extraction du pattern dupliqué query+parse Gemini (DRY)
 - **NotifierInterface** : Découplage des services de recommandation de NotificationService

--- a/frontend/src/__tests__/integration/pages/ToBuy.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ToBuy.test.tsx
@@ -55,13 +55,13 @@ describe("ToBuy", () => {
     expect(screen.getByText("Rien à acheter")).toBeInTheDocument();
   });
 
-  it("shows buying series with unbought tomes", () => {
+  it("shows buying series with unbought tomes as ranges", () => {
     const series = makeSeries(1, "One Piece", {
-      unboughtTomeNumbers: [2, 3],
+      unboughtTomeNumbers: [2, 3, 4, 7, 8, 10],
     });
     renderWithComics([series]);
     expect(screen.getByText("One Piece")).toBeInTheDocument();
-    expect(screen.getByText("Prochain : T.2, T.3")).toBeInTheDocument();
+    expect(screen.getByText("Prochain : T.2-4, T.7-8, T.10")).toBeInTheDocument();
   });
 
   it("excludes finished series", () => {

--- a/frontend/src/__tests__/unit/utils/toBuyUtils.test.tsx
+++ b/frontend/src/__tests__/unit/utils/toBuyUtils.test.tsx
@@ -1,5 +1,5 @@
 import type { ComicSeries } from "../../../types/api";
-import { filterSeriesToBuy, getNextTomesToBuy } from "../../../utils/toBuyUtils";
+import { filterSeriesToBuy, formatTomeRanges, getNextTomesToBuy } from "../../../utils/toBuyUtils";
 
 function makeSeries(overrides: Partial<ComicSeries> = {}): ComicSeries {
   return {
@@ -48,6 +48,32 @@ describe("getNextTomesToBuy", () => {
   it("returns empty array when series has no tomes", () => {
     const series = makeSeries({ unboughtTomeNumbers: [] });
     expect(getNextTomesToBuy(series)).toEqual([]);
+  });
+});
+
+describe("formatTomeRanges", () => {
+  it("returns empty string for empty array", () => {
+    expect(formatTomeRanges([])).toBe("");
+  });
+
+  it("formats a single tome", () => {
+    expect(formatTomeRanges([5])).toBe("T.5");
+  });
+
+  it("formats consecutive tomes as a range", () => {
+    expect(formatTomeRanges([1, 2, 3])).toBe("T.1-3");
+  });
+
+  it("formats mixed ranges and singles", () => {
+    expect(formatTomeRanges([1, 2, 3, 5, 7, 8, 9])).toBe("T.1-3, T.5, T.7-9");
+  });
+
+  it("formats two consecutive tomes as a range", () => {
+    expect(formatTomeRanges([4, 5])).toBe("T.4-5");
+  });
+
+  it("formats all singles", () => {
+    expect(formatTomeRanges([1, 3, 5])).toBe("T.1, T.3, T.5");
   });
 });
 

--- a/frontend/src/pages/ToBuy.tsx
+++ b/frontend/src/pages/ToBuy.tsx
@@ -8,7 +8,7 @@ import VirtualGrid from "../components/VirtualGrid";
 import { useComics } from "../hooks/useComics";
 import { useDebounce } from "../hooks/useDebounce";
 import { searchComics } from "../utils/searchComics";
-import { filterSeriesToBuy, getNextTomesToBuy } from "../utils/toBuyUtils";
+import { filterSeriesToBuy, formatTomeRanges, getNextTomesToBuy } from "../utils/toBuyUtils";
 
 export default function ToBuy() {
   const { data, isFetching, isLoading } = useComics();
@@ -25,7 +25,7 @@ export default function ToBuy() {
     const sorted = [...searched].sort((a, b) => a.title.localeCompare(b.title, "fr"));
     return sorted.map((comic) => ({
       comic,
-      nextTomes: getNextTomesToBuy(comic).map((n) => `T.${n}`).join(", "),
+      nextTomes: formatTomeRanges(getNextTomesToBuy(comic)),
     }));
   }, [allComics, debouncedSearch]);
 

--- a/frontend/src/utils/toBuyUtils.ts
+++ b/frontend/src/utils/toBuyUtils.ts
@@ -4,6 +4,31 @@ export function getNextTomesToBuy(series: ComicSeries): number[] {
   return [...series.unboughtTomeNumbers].sort((a, b) => a - b);
 }
 
+/**
+ * Formate une liste de numéros de tomes en tranches lisibles.
+ * Ex: [1,2,3,5,7,8,9] → "T.1-3, T.5, T.7-9"
+ */
+export function formatTomeRanges(numbers: number[]): string {
+  if (numbers.length === 0) return "";
+
+  const ranges: string[] = [];
+  let start = numbers[0];
+  let end = numbers[0];
+
+  for (let i = 1; i < numbers.length; i++) {
+    if (numbers[i] === end + 1) {
+      end = numbers[i];
+    } else {
+      ranges.push(start === end ? `T.${start}` : `T.${start}-${end}`);
+      start = numbers[i];
+      end = numbers[i];
+    }
+  }
+  ranges.push(start === end ? `T.${start}` : `T.${start}-${end}`);
+
+  return ranges.join(", ");
+}
+
 export function filterSeriesToBuy(series: ComicSeries[]): ComicSeries[] {
   return series.filter(
     (s) => s.status === "buying" && !s.isOneShot && s.unboughtTomeNumbers.length > 0,


### PR DESCRIPTION
## Summary
- **À acheter** : Affichage des tomes manquants en tranches (T.1-3, T.5) au lieu d'une liste
- **Service/** : Réorganisation en sous-domaines
- **GeminiQueryService** : Extraction du pattern query+parse (DRY)
- **NotifierInterface** : Découplage des services de recommandation

## Test plan
- [x] Tests unitaires `formatTomeRanges` (6 cas)
- [x] Test d'intégration ToBuy mis à jour