### PR TITLE
Exécute app:warm-thumbnails automatiquement au déploiement

### DIFF
--- a/scripts/nas-update.sh
+++ b/scripts/nas-update.sh
@@ -110,6 +110,10 @@ if try_deploy; then
     # Migrations
     docker compose --env-file "$ENV_FILE" exec -T php php bin/console doctrine:migrations:migrate -n --env=prod 2>&1 | tee -a "$LOG_FILE"
     log "Migrations exécutées."
+
+    # Miniatures de couverture (LiipImagine)
+    docker compose --env-file "$ENV_FILE" exec -T -u www-data php php bin/console app:warm-thumbnails --env=prod 2>&1 | tee -a "$LOG_FILE"
+    log "Miniatures de couverture générées."
     log "=== Mise à jour terminée (${TARGET_TAG}) ==="
     exit 0
 fi


### PR DESCRIPTION
## Summary

- Ajoute `app:warm-thumbnails` dans `nas-update.sh` après les migrations, pour que les miniatures LiipImagine soient générées automatiquement à chaque déploiement

## Test plan

- [ ] Vérifier que le prochain déploiement exécute la commande (logs NAS)

#370