### PR TITLE
fix(docker): corrige la parité dev/prod et le scheduler

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -33,3 +33,9 @@ web_extra_daemons:
   - name: vite
     command: bash -c 'cd /var/www/html/frontend && npm install && npm run dev'
     directory: /var/www/html/frontend
+  - name: messenger-worker
+    command: bash -c 'cd /var/www/html/backend && php bin/console messenger:consume async --limit=500 --time-limit=3600'
+    directory: /var/www/html/backend
+  - name: scheduler
+    command: bash -c 'cd /var/www/html/backend && php bin/console messenger:consume scheduler_default --time-limit=3600'
+    directory: /var/www/html/backend

--- a/.ddev/nginx_full/nginx-site.conf
+++ b/.ddev/nginx_full/nginx-site.conf
@@ -13,9 +13,19 @@ server {
 
     index index.php index.htm index.html;
 
+    # Aligné sur la prod (12M)
+    client_max_body_size 12M;
+
     sendfile off;
     error_log /dev/stdout info;
     access_log /var/log/nginx/access.log;
+
+    # En-têtes de sécurité (même politique que la prod, adaptée pour Vite HMR)
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; font-src 'self' https://fonts.gstatic.com; frame-src https://accounts.google.com; img-src 'self' data: https:; connect-src 'self' https: ws: wss:;" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
 
     # ──────────────────────────────────────────────
     # API : /api/* → PHP-FPM (Symfony)

--- a/backend/docker/worker/supervisord.conf
+++ b/backend/docker/worker/supervisord.conf
@@ -12,7 +12,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:scheduler]
-command=gosu www-data php /var/www/html/backend/bin/console schedule:run
+command=gosu www-data php /var/www/html/backend/bin/console messenger:consume scheduler_default --time-limit=3600
 autostart=true
 autorestart=true
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
## Summary
- **Fix prod scheduler** : `schedule:run` n'existe pas dans Symfony 7.x → remplacé par `messenger:consume scheduler_default`. Les 7 tâches planifiées (auto-enrich, check-new-releases, download-covers, detect-missing-tomes, check-author-releases, purge-deleted, purge-notifications) ne s'exécutaient pas en production.
- **DDEV messenger worker + scheduler** : ajoute les daemons pour consommer les messages async en dev (même comportement qu'en prod)
- **DDEV nginx** : `client_max_body_size 12M` (aligné sur prod) + en-têtes de sécurité (CSP, X-Frame-Options, Referrer-Policy, Permissions-Policy) adaptés pour Vite HMR

## Test plan
- [x] `ddev restart` — les 3 daemons démarrent sans erreur
- [x] `ddev exec supervisorctl status` — messenger-worker, scheduler, vite tous RUNNING
- [ ] Créer une série → vérifier que l'enrichissement async se déclenche en dev
- [ ] Vérifier que le HMR Vite fonctionne toujours (pas bloqué par CSP)
- [ ] Déployer en prod → vérifier les logs du scheduler (`docker logs bibliotheque-worker`)