### PR TITLE
perf(frontend): limite les invalidations de cache et le polling inutile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Invalidation des caches** : Le pull-to-refresh et la synchro offline n'invalident plus que les données comics au lieu de tous les caches TanStack Query
+- **Polling des notifications** : Arrête le polling en arrière-plan quand l'onglet est inactif
+- **Polling de la queue offline** : Arrête le polling quand l'app est online et la queue est vide (au lieu de toutes les 2s en permanence)
+- **Listener de synchro SW** : Le handler est stable via useRef, évite les ré-enregistrements inutiles
+
 ## [v2.20.0] - 2026-03-22
 
 ### Added

--- a/frontend/src/__tests__/integration/components/Layout.test.tsx
+++ b/frontend/src/__tests__/integration/components/Layout.test.tsx
@@ -307,7 +307,7 @@ describe("Layout", () => {
       expect(toast.error).not.toHaveBeenCalled();
     });
 
-    it("invalidates queries after sync success", () => {
+    it("does not call invalidateQueries on sync success (handled by useSyncStatus)", () => {
       const queryClient = createTestQueryClient();
       const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -329,7 +329,7 @@ describe("Layout", () => {
         </Routes>,
       );
 
-      expect(invalidateSpy).toHaveBeenCalled();
+      expect(invalidateSpy).not.toHaveBeenCalled();
     });
 
     it("does not fire toast twice for the same status (duplicate prevention)", () => {

--- a/frontend/src/__tests__/integration/hooks/usePendingQueueCount.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/usePendingQueueCount.test.tsx
@@ -69,4 +69,22 @@ describe("usePendingQueueCount", () => {
 
     expect(result.current).toBe(0);
   });
+
+  it("stops polling when online and queue is empty", async () => {
+    vi.mocked(getPendingCount).mockResolvedValue(0);
+
+    renderHook(() => usePendingQueueCount(), {
+      wrapper: createWrapper(),
+    });
+
+    // Wait for initial fetch
+    await waitFor(() => expect(getPendingCount).toHaveBeenCalledTimes(1));
+
+    // Record call count after initial, then wait 3s (more than the 2s interval)
+    vi.mocked(getPendingCount).mockClear();
+    await new Promise((r) => setTimeout(r, 3000));
+
+    // Should NOT have been called again since online + count=0
+    expect(getPendingCount).not.toHaveBeenCalled();
+  }, 10_000);
 });

--- a/frontend/src/__tests__/integration/hooks/useSyncStatus.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useSyncStatus.test.tsx
@@ -189,4 +189,42 @@ describe("useSyncStatus", () => {
     expect(result.current.syncedCount).toBe(0);
     expect(result.current.error).toBeNull();
   });
+
+  it("does not re-register the SW listener on re-render", () => {
+    const { rerender } = renderHook(() => useSyncStatus(), { wrapper: createWrapper() });
+
+    const initialCallCount = addEventListenerSpy.mock.calls.length;
+
+    // Re-render multiple times
+    rerender();
+    rerender();
+    rerender();
+
+    // addEventListener should not have been called again
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(initialCallCount);
+  });
+
+  it("invalidates only comics queries on sync-complete with count > 0", () => {
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+    }
+
+    renderHook(() => useSyncStatus(), { wrapper: Wrapper });
+
+    act(() => {
+      messageHandler?.({ data: { count: 2, type: "sync-complete" } } as MessageEvent);
+    });
+
+    // Should invalidate comics.all and comics.detailPrefix, not everything
+    expect(invalidateSpy).toHaveBeenCalledTimes(2);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["comics"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["comic"] });
+  });
 });

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,3 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { LogOut, Moon, Search, Sun, Wrench, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Link, Outlet, useNavigate } from "react-router-dom";
@@ -23,7 +22,6 @@ export default function Layout() {
 
   // Sync feedback toasts
   const { error, status, syncedCount } = useSyncStatus();
-  const queryClient = useQueryClient();
   const prevStatus = useRef(status);
 
   useEffect(() => {
@@ -32,11 +30,10 @@ export default function Layout() {
 
     if (status === "success" && syncedCount > 0) {
       toast.success(`${syncedCount} opération${syncedCount > 1 ? "s" : ""} synchronisée${syncedCount > 1 ? "s" : ""}`);
-      void queryClient.invalidateQueries();
     } else if (status === "error" && error) {
       toast.error(`Erreur de synchronisation : ${error}`);
     }
-  }, [error, queryClient, status, syncedCount]);
+  }, [error, status, syncedCount]);
 
   return (
     <div className="flex min-h-screen flex-col bg-surface-secondary">

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -10,6 +10,7 @@ export function useUnreadCount() {
     queryFn: () => apiFetch<{ count: number }>(endpoints.notifications.unreadCount),
     queryKey: queryKeys.notifications.unreadCount,
     refetchInterval: 60_000,
+    refetchIntervalInBackground: false,
   });
 }
 

--- a/frontend/src/hooks/usePendingQueueCount.ts
+++ b/frontend/src/hooks/usePendingQueueCount.ts
@@ -1,12 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "../queryKeys";
 import { getPendingCount } from "../services/offlineQueue";
+import { useOnlineStatus } from "./useOnlineStatus";
 
 export function usePendingQueueCount(): number {
+  const isOnline = useOnlineStatus();
   const { data } = useQuery({
     queryFn: getPendingCount,
     queryKey: queryKeys.offline.queueCount,
-    refetchInterval: 2000,
+    refetchInterval: (query) => {
+      const count = query.state.data ?? 0;
+      // Poll every 2s when offline or queue has items; stop otherwise
+      if (!isOnline || count > 0) return 2000;
+      return false;
+    },
   });
 
   return data ?? 0;

--- a/frontend/src/hooks/useSyncStatus.ts
+++ b/frontend/src/hooks/useSyncStatus.ts
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { queryKeys } from "../queryKeys";
 
 export type SyncStatus = "error" | "idle" | "success" | "syncing";
@@ -18,6 +18,10 @@ export function useSyncStatus() {
     syncedCount: 0,
   });
 
+  // Stable ref to avoid re-registering SW listener on queryClient change
+  const queryClientRef = useRef(queryClient);
+  queryClientRef.current = queryClient;
+
   const handleMessage = useCallback((event: MessageEvent) => {
     const { data } = event;
     if (!data?.type) return;
@@ -29,15 +33,15 @@ export function useSyncStatus() {
       case "sync-complete":
         setState({ error: null, status: "success", syncedCount: data.count ?? 0 });
         if ((data.count ?? 0) > 0) {
-          void queryClient.invalidateQueries({ queryKey: queryKeys.comics.all });
-          void queryClient.invalidateQueries({ queryKey: queryKeys.comics.detailPrefix });
+          void queryClientRef.current.invalidateQueries({ queryKey: queryKeys.comics.all });
+          void queryClientRef.current.invalidateQueries({ queryKey: queryKeys.comics.detailPrefix });
         }
         break;
       case "sync-error":
         setState((prev) => ({ ...prev, error: data.error ?? "Erreur inconnue", status: "error" }));
         break;
     }
-  }, [queryClient]);
+  }, []);
 
   useEffect(() => {
     const sw = navigator.serviceWorker;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -18,6 +18,7 @@ import { useDeleteComic } from "../hooks/useDeleteComic";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { usePullToRefresh } from "../hooks/usePullToRefresh";
 import { useRestoreComic } from "../hooks/useTrash";
+import { queryKeys } from "../queryKeys";
 import type { ComicSeries } from "../types/api";
 import { searchComics } from "../utils/searchComics";
 import { sortComics } from "../utils/sortComics";
@@ -90,7 +91,11 @@ export default function Home() {
   const restoreComic = useRestoreComic();
   const queryClient = useQueryClient();
   const handleRefresh = useCallback(
-    () => queryClient.invalidateQueries().then(() => undefined),
+    () =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.comics.all }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.comics.detailPrefix }),
+      ]).then(() => undefined),
     [queryClient],
   );
   const { isRefreshing, pullDistance } = usePullToRefresh({ onRefresh: handleRefresh });


### PR DESCRIPTION
## Summary

- **Scope invalidateQueries** : le pull-to-refresh (Home) et la synchro offline (Layout) n'invalident plus que `comics.all` + `comics.detailPrefix` au lieu de tous les caches TanStack Query
- **Polling notifications** : ajout de `refetchIntervalInBackground: false` pour arrêter le polling quand l'onglet est inactif
- **Polling queue offline** : adaptatif — 2s quand offline ou queue non vide, désactivé sinon (était 2s en permanence)
- **Handler SW stable** : `useSyncStatus` utilise `useRef` pour le queryClient, supprimant la dépendance du `useCallback` et évitant les ré-enregistrements du listener

## Test plan

- [x] 883 tests frontend passent
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Tests TDD ajoutés pour les 3 changements principaux (Layout, usePendingQueueCount, useSyncStatus)

fixes #399