### PR TITLE
perf(frontend): réduit les refetch inutiles et les re-renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
+- **staleTime sur les queries statiques** : Les lookups ISBN/titre (24h) et la recherche d'auteurs (30min) ne refetchent plus inutilement
+- **Memoization FilterChips** : Le composant `Chip` est wrappé dans `React.memo()` pour éviter les re-renders inutiles
+- **Layout shift couverture** : L'aperçu de couverture dans le formulaire a une largeur explicite pour éviter le décalage au chargement
 - **Invalidation des caches** : Le pull-to-refresh et la synchro offline n'invalident plus que les données comics au lieu de tous les caches TanStack Query
 - **Polling des notifications** : Arrête le polling en arrière-plan quand l'onglet est inactif
 - **Polling de la queue offline** : Arrête le polling quand l'app est online et la queue est vide (au lieu de toutes les 2s en permanence)

--- a/frontend/src/components/FilterChips.tsx
+++ b/frontend/src/components/FilterChips.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { ComicStatus, ComicStatusShortLabel, ComicType, ComicTypeLabel } from "../types/enums";
 
 interface FilterChipsProps {
@@ -22,7 +23,7 @@ const statusChips: ChipDef[] = Object.values(ComicStatus).map((value) => ({
   value,
 }));
 
-function Chip({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) {
+const Chip = memo(function Chip({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) {
   return (
     <button
       aria-pressed={active}
@@ -37,7 +38,7 @@ function Chip({ active, label, onClick }: { active: boolean; label: string; onCl
       {label}
     </button>
   );
-}
+});
 
 export default function FilterChips({ onStatusChange, onTypeChange, status, type }: FilterChipsProps) {
   return (

--- a/frontend/src/hooks/useAuthors.ts
+++ b/frontend/src/hooks/useAuthors.ts
@@ -4,6 +4,8 @@ import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { Author, HydraCollection } from "../types/api";
 
+const STALE_TIME_30MIN = 30 * 60 * 1000;
+
 export function useAuthors(search: string = "") {
   const params = search ? `?name=${encodeURIComponent(search)}` : "";
 
@@ -11,5 +13,6 @@ export function useAuthors(search: string = "") {
     enabled: search.length >= 1,
     queryFn: () => apiFetch<HydraCollection<Author>>(`${endpoints.authors}${params}`),
     queryKey: queryKeys.authors.search(search),
+    staleTime: STALE_TIME_30MIN,
   });
 }

--- a/frontend/src/hooks/useLookup.ts
+++ b/frontend/src/hooks/useLookup.ts
@@ -4,6 +4,8 @@ import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { LookupCandidatesResponse, LookupResult } from "../types/api";
 
+const STALE_TIME_24H = 24 * 60 * 60 * 1000;
+
 export function useLookupIsbn(isbn: string, type?: string) {
   const params = new URLSearchParams({ isbn });
   if (type) params.set("type", type);
@@ -12,6 +14,7 @@ export function useLookupIsbn(isbn: string, type?: string) {
     enabled: isbn.length >= 10,
     queryFn: () => apiFetch<LookupResult>(`${endpoints.lookup.isbn}?${params}`),
     queryKey: queryKeys.lookup.isbn(isbn, type),
+    staleTime: STALE_TIME_24H,
   });
 }
 
@@ -23,6 +26,7 @@ export function useLookupTitle(title: string, type?: string) {
     enabled: title.length >= 2,
     queryFn: () => apiFetch<LookupResult>(`${endpoints.lookup.title}?${params}`),
     queryKey: queryKeys.lookup.title(title, type),
+    staleTime: STALE_TIME_24H,
   });
 }
 
@@ -34,6 +38,7 @@ export function useLookupTitleCandidates(title: string, type?: string, limit = 5
     enabled: title.length >= 2,
     queryFn: () => apiFetch<LookupCandidatesResponse>(`${endpoints.lookup.title}?${params}`),
     queryKey: queryKeys.lookup.titleCandidates(title, type, limit),
+    staleTime: STALE_TIME_24H,
   });
 }
 

--- a/frontend/src/pages/ComicForm.tsx
+++ b/frontend/src/pages/ComicForm.tsx
@@ -275,7 +275,7 @@ export default function ComicForm() {
               <>
                 <img
                   alt="Aperçu"
-                  className="mt-2 h-48 cursor-pointer rounded-lg shadow"
+                  className="mt-2 h-48 w-36 cursor-pointer rounded-lg object-cover shadow"
                   onClick={() => setLightboxOpen(true)}
                   src={form.coverUrl}
                 />


### PR DESCRIPTION
## Summary
- **staleTime** sur les lookups ISBN/titre (24h) et la recherche d'auteurs (30min) pour éviter les refetch de données statiques
- **React.memo()** sur le composant `Chip` (FilterChips) pour éviter les re-renders inutiles lors du toggle d'un filtre
- **Largeur explicite** (`w-36 object-cover`) sur l'aperçu de couverture dans le formulaire pour éviter le layout shift

## Test plan
- [x] 883 tests passent (vitest run)
- [x] TypeScript clean (tsc --noEmit)
- [x] Vérifier visuellement l'aperçu de couverture dans le formulaire de création/édition

Fixes #400