### PR TITLE
fix(backend): corrige le N+1 dans AuthorReleaseCheckerService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **N+1 AuthorReleaseCheckerService** : Pré-charge les séries des auteurs suivis via JOIN et remplace la comparaison de titres en PHP par une requête SQL
+
 ### Changed
 
 - **staleTime sur les queries statiques** : Les lookups ISBN/titre (24h) et la recherche d'auteurs (30min) ne refetchent plus inutilement

--- a/backend/src/Repository/AuthorRepository.php
+++ b/backend/src/Repository/AuthorRepository.php
@@ -19,12 +19,20 @@ class AuthorRepository extends ServiceEntityRepository
     }
 
     /**
+     * Retourne les auteurs suivis avec leurs séries pré-chargées (évite N+1).
+     *
      * @return list<Author>
      */
     public function findFollowed(): array
     {
         /** @var list<Author> $result */
-        $result = $this->findBy(['followedForNewSeries' => true], ['name' => 'ASC']);
+        $result = $this->createQueryBuilder('a')
+            ->leftJoin('a.comicSeries', 'cs')
+            ->addSelect('cs')
+            ->where('a.followedForNewSeries = true')
+            ->orderBy('a.name', 'ASC')
+            ->getQuery()
+            ->getResult();
 
         return $result;
     }

--- a/backend/src/Repository/ComicSeriesRepository.php
+++ b/backend/src/Repository/ComicSeriesRepository.php
@@ -347,6 +347,22 @@ class ComicSeriesRepository extends ServiceEntityRepository
     }
 
     /**
+     * Retourne tous les titres en minuscules (via SQL), sans charger les entités.
+     *
+     * @return list<string>
+     */
+    public function findAllTitlesLower(): array
+    {
+        /** @var list<array{title: string}> $rows */
+        $rows = $this->createQueryBuilder('c')
+            ->select('LOWER(c.title) AS title')
+            ->getQuery()
+            ->getScalarResult();
+
+        return \array_column($rows, 'title');
+    }
+
+    /**
      * Retourne toutes les séries avec leurs relations pour l'API PWA.
      *
      * Utilise un cache applicatif (15 min) pour éviter de requêter la base

--- a/backend/src/Service/Recommendation/AuthorReleaseCheckerService.php
+++ b/backend/src/Service/Recommendation/AuthorReleaseCheckerService.php
@@ -42,10 +42,7 @@ class AuthorReleaseCheckerService
             return;
         }
 
-        $allTitles = \array_map(
-            static fn ($s) => \mb_strtolower($s->title),
-            $this->comicSeriesRepository->findAllForApi(),
-        );
+        $allTitles = $this->comicSeriesRepository->findAllTitlesLower();
 
         foreach ($followedAuthors as $author) {
             try {

--- a/backend/tests/Integration/Repository/AuthorRepositoryTest.php
+++ b/backend/tests/Integration/Repository/AuthorRepositoryTest.php
@@ -8,6 +8,7 @@ use App\Entity\Author;
 use App\Repository\AuthorRepository;
 use App\Tests\Factory\EntityFactory;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\PersistentCollection;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -102,5 +103,47 @@ final class AuthorRepositoryTest extends KernelTestCase
         $names = \array_map(static fn (Author $a): string => $a->getName(), $authors);
         self::assertContains('Hergé', $names);
         self::assertContains('Franquin', $names);
+    }
+
+    // ---------------------------------------------------------------
+    // findFollowed
+    // ---------------------------------------------------------------
+
+    public function testFindFollowedReturnsOnlyFollowedAuthorsWithSeries(): void
+    {
+        $followed = EntityFactory::createAuthor('Urasawa');
+        $followed->setFollowedForNewSeries(true);
+
+        $series = EntityFactory::createComicSeries('Monster');
+        $followed->addComicSeries($series);
+
+        $notFollowed = EntityFactory::createAuthor('Oda');
+
+        $this->em->persist($followed);
+        $this->em->persist($notFollowed);
+        $this->em->persist($series);
+        $this->em->flush();
+        $this->em->clear();
+
+        $result = $this->repository->findFollowed();
+
+        self::assertCount(1, $result);
+        self::assertSame('Urasawa', $result[0]->getName());
+        // Vérifie que les séries sont pré-chargées (pas de lazy loading)
+        $collection = $result[0]->getComicSeries();
+        self::assertInstanceOf(PersistentCollection::class, $collection);
+        self::assertTrue($collection->isInitialized());
+        self::assertCount(1, $result[0]->getComicSeries());
+    }
+
+    public function testFindFollowedReturnsEmptyWhenNoneFollowed(): void
+    {
+        $author = EntityFactory::createAuthor('Toriyama');
+        $this->em->persist($author);
+        $this->em->flush();
+
+        $result = $this->repository->findFollowed();
+
+        self::assertSame([], $result);
     }
 }

--- a/backend/tests/Integration/Repository/ComicSeriesRepositoryTest.php
+++ b/backend/tests/Integration/Repository/ComicSeriesRepositoryTest.php
@@ -1217,4 +1217,29 @@ final class ComicSeriesRepositoryTest extends KernelTestCase
         self::assertCount(1, $result);
         self::assertSame('Already Looked', $result[0]->getTitle());
     }
+
+    // ---------------------------------------------------------------
+    // findAllTitlesLower
+    // ---------------------------------------------------------------
+
+    public function testFindAllTitlesLowerReturnsLowercaseTitles(): void
+    {
+        $this->em->persist(EntityFactory::createComicSeries('Astérix'));
+        $this->em->persist(EntityFactory::createComicSeries('ONE PIECE'));
+        $this->em->persist(EntityFactory::createComicSeries('Naruto'));
+        $this->em->flush();
+
+        $titles = $this->repository->findAllTitlesLower();
+
+        self::assertContains('astérix', $titles);
+        self::assertContains('one piece', $titles);
+        self::assertContains('naruto', $titles);
+    }
+
+    public function testFindAllTitlesLowerReturnsEmptyWhenNoSeries(): void
+    {
+        $titles = $this->repository->findAllTitlesLower();
+
+        self::assertSame([], $titles);
+    }
 }

--- a/backend/tests/Unit/Service/Recommendation/AuthorReleaseCheckerServiceTest.php
+++ b/backend/tests/Unit/Service/Recommendation/AuthorReleaseCheckerServiceTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Recommendation;
+
+use App\DTO\AuthorReleaseResult;
+use App\Enum\ComicType;
+use App\Repository\AuthorRepository;
+use App\Repository\ComicSeriesRepository;
+use App\Repository\UserRepository;
+use App\Service\Lookup\Gemini\GeminiClientPool;
+use App\Service\Lookup\Gemini\GeminiQueryService;
+use App\Service\Notification\NotifierInterface;
+use App\Service\Recommendation\AuthorReleaseCheckerService;
+use App\Tests\Factory\EntityFactory;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Tests unitaires pour AuthorReleaseCheckerService.
+ */
+final class AuthorReleaseCheckerServiceTest extends TestCase
+{
+    private AuthorRepository&Stub $authorRepository;
+    private ComicSeriesRepository&Stub $comicSeriesRepository;
+    private GeminiClientPool&Stub $geminiClientPool;
+    private UserRepository&Stub $userRepository;
+
+    protected function setUp(): void
+    {
+        $this->authorRepository = $this->createStub(AuthorRepository::class);
+        $this->comicSeriesRepository = $this->createStub(ComicSeriesRepository::class);
+        $this->geminiClientPool = $this->createStub(GeminiClientPool::class);
+        $this->userRepository = $this->createStub(UserRepository::class);
+    }
+
+    public function testCheckReturnsEmptyWhenNoFollowedAuthors(): void
+    {
+        $this->authorRepository->method('findFollowed')->willReturn([]);
+        $this->userRepository->method('findOneBy')->willReturn(EntityFactory::createUser());
+
+        $results = \iterator_to_array($this->buildService()->check());
+
+        self::assertSame([], $results);
+    }
+
+    public function testCheckReturnsEmptyWhenNoUser(): void
+    {
+        $this->userRepository->method('findOneBy')->willReturn(null);
+
+        $results = \iterator_to_array($this->buildService()->check());
+
+        self::assertSame([], $results);
+    }
+
+    public function testCheckYieldsNewSeriesFromGemini(): void
+    {
+        $user = EntityFactory::createUser();
+        $author = EntityFactory::createAuthor('Naoki Urasawa');
+        $author->setFollowedForNewSeries(true);
+
+        $series = EntityFactory::createComicSeries('Monster', type: ComicType::MANGA);
+        $author->addComicSeries($series);
+
+        $this->userRepository->method('findOneBy')->willReturn($user);
+        $this->authorRepository->method('findFollowed')->willReturn([$author]);
+        $this->comicSeriesRepository->method('findAllTitlesLower')->willReturn(['monster', '20th century boys']);
+        $this->stubGeminiResponse('[{"title": "Pluto", "type": "manga"}]');
+
+        $results = \iterator_to_array($this->buildService()->check(dryRun: true));
+
+        self::assertCount(1, $results);
+        self::assertInstanceOf(AuthorReleaseResult::class, $results[0]);
+        self::assertSame('Naoki Urasawa', $results[0]->authorName);
+        self::assertSame('Pluto', $results[0]->newSeriesTitle);
+        self::assertSame(ComicType::MANGA, $results[0]->type);
+    }
+
+    public function testCheckSkipsSeriesAlreadyInLibrary(): void
+    {
+        $user = EntityFactory::createUser();
+        $author = EntityFactory::createAuthor('Naoki Urasawa');
+        $author->setFollowedForNewSeries(true);
+
+        $this->userRepository->method('findOneBy')->willReturn($user);
+        $this->authorRepository->method('findFollowed')->willReturn([$author]);
+        $this->comicSeriesRepository->method('findAllTitlesLower')->willReturn(['pluto']);
+        $this->stubGeminiResponse('[{"title": "Pluto", "type": "manga"}]');
+
+        $results = \iterator_to_array($this->buildService()->check(dryRun: true));
+
+        self::assertSame([], $results);
+    }
+
+    public function testCheckCreatesNotificationWhenNotDryRun(): void
+    {
+        $user = EntityFactory::createUser();
+        $author = EntityFactory::createAuthor('Eiichiro Oda');
+        $author->setFollowedForNewSeries(true);
+
+        $this->userRepository->method('findOneBy')->willReturn($user);
+        $this->authorRepository->method('findFollowed')->willReturn([$author]);
+        $this->comicSeriesRepository->method('findAllTitlesLower')->willReturn([]);
+        $this->stubGeminiResponse('[{"title": "Wanted!", "type": "manga"}]');
+
+        $notifier = $this->createMock(NotifierInterface::class);
+        $notifier->expects(self::once())->method('create');
+
+        \iterator_to_array($this->buildService($notifier)->check(dryRun: false));
+    }
+
+    public function testCheckDoesNotNotifyInDryRun(): void
+    {
+        $user = EntityFactory::createUser();
+        $author = EntityFactory::createAuthor('Eiichiro Oda');
+        $author->setFollowedForNewSeries(true);
+
+        $this->userRepository->method('findOneBy')->willReturn($user);
+        $this->authorRepository->method('findFollowed')->willReturn([$author]);
+        $this->comicSeriesRepository->method('findAllTitlesLower')->willReturn([]);
+        $this->stubGeminiResponse('[{"title": "Wanted!", "type": "manga"}]');
+
+        $notifier = $this->createMock(NotifierInterface::class);
+        $notifier->expects(self::never())->method('create');
+
+        \iterator_to_array($this->buildService($notifier)->check(dryRun: true));
+    }
+
+    public function testCheckSkipsInvalidGeminiResults(): void
+    {
+        $user = EntityFactory::createUser();
+        $author = EntityFactory::createAuthor('Test');
+        $author->setFollowedForNewSeries(true);
+
+        $this->userRepository->method('findOneBy')->willReturn($user);
+        $this->authorRepository->method('findFollowed')->willReturn([$author]);
+        $this->comicSeriesRepository->method('findAllTitlesLower')->willReturn([]);
+        $this->stubGeminiResponse('[{"title": null, "type": "manga"}, {"type": "bd"}, {"title": "Valid", "type": "bd"}]');
+
+        $results = \iterator_to_array($this->buildService()->check(dryRun: true));
+
+        self::assertCount(1, $results);
+        self::assertSame('Valid', $results[0]->newSeriesTitle);
+    }
+
+    public function testCheckContinuesOnAuthorError(): void
+    {
+        $user = EntityFactory::createUser();
+        $author1 = EntityFactory::createAuthor('Error Author');
+        $author1->setFollowedForNewSeries(true);
+        $author2 = EntityFactory::createAuthor('Good Author');
+        $author2->setFollowedForNewSeries(true);
+
+        $this->userRepository->method('findOneBy')->willReturn($user);
+        $this->authorRepository->method('findFollowed')->willReturn([$author1, $author2]);
+        $this->comicSeriesRepository->method('findAllTitlesLower')->willReturn([]);
+
+        $callCount = 0;
+        $this->geminiClientPool->method('executeWithRetry')
+            ->willReturnCallback(static function () use (&$callCount): string {
+                ++$callCount;
+                if (1 === $callCount) {
+                    throw new \RuntimeException('API error');
+                }
+
+                return '[{"title": "New Series", "type": "bd"}]';
+            });
+
+        $results = \iterator_to_array($this->buildService()->check(dryRun: true));
+
+        self::assertCount(1, $results);
+        self::assertSame('Good Author', $results[0]->authorName);
+    }
+
+    private function buildService(?NotifierInterface $notifier = null): AuthorReleaseCheckerService
+    {
+        return new AuthorReleaseCheckerService(
+            $this->authorRepository,
+            $this->comicSeriesRepository,
+            new GeminiQueryService($this->geminiClientPool),
+            new NullLogger(),
+            $notifier ?? $this->createStub(NotifierInterface::class),
+            $this->userRepository,
+        );
+    }
+
+    /**
+     * Configure le stub GeminiClientPool pour retourner une réponse JSON.
+     */
+    private function stubGeminiResponse(string $json): void
+    {
+        $this->geminiClientPool->method('executeWithRetry')->willReturn($json);
+    }
+}


### PR DESCRIPTION
## Summary

- **Eager loading** : `findFollowed()` pré-charge les séries via `LEFT JOIN + addSelect` (élimine le N+1)
- **Comparaison SQL** : nouveau `findAllTitlesLower()` retourne les titres en minuscules via requête scalaire, remplace le chargement de toutes les entités + `mb_strtolower()` en PHP
- **8 tests unitaires + 4 tests d'intégration** ajoutés

Fixes #401

## Test plan

- [x] 1104 tests backend passent
- [x] PHPStan level 9 clean
- [x] PHP CS Fixer clean
- [x] Test d'intégration vérifie que `PersistentCollection::isInitialized()` est true (preuve de l'eager loading)