### PR TITLE
perf(backend): rend le téléchargement de couverture asynchrone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Téléchargement de couverture asynchrone** : Le téléchargement de couverture lors d'un changement de `coverUrl` est désormais traité via Symfony Messenger au lieu de bloquer la requête API
+
 ### Fixed
 
 - **N+1 AuthorReleaseCheckerService** : Pré-charge les séries des auteurs suivis via JOIN et remplace la comparaison de titres en PHP par une requête SQL

--- a/backend/config/packages/messenger.yaml
+++ b/backend/config/packages/messenger.yaml
@@ -2,6 +2,7 @@ framework:
     messenger:
         failure_transport: failed
         routing:
+            App\Message\DownloadCoverMessage: async
             App\Message\EnrichSeriesMessage: async
         transports:
             async:

--- a/backend/src/EventListener/CoverUrlChangeListener.php
+++ b/backend/src/EventListener/CoverUrlChangeListener.php
@@ -5,23 +5,20 @@ declare(strict_types=1);
 namespace App\EventListener;
 
 use App\Entity\ComicSeries;
-use App\Service\Cover\CoverDownloader;
+use App\Message\DownloadCoverMessage;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Events;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
- * Télécharge automatiquement la couverture quand coverUrl change sur une ComicSeries.
- *
- * Utilise preUpdate pour accéder au changeset et modifier l'entité avant le flush.
+ * Dispatche un message asynchrone pour télécharger la couverture quand coverUrl change.
  */
 #[AsDoctrineListener(event: Events::preUpdate)]
 final readonly class CoverUrlChangeListener
 {
     public function __construct(
-        private CoverDownloader $coverDownloader,
-        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
     ) {
     }
 
@@ -44,12 +41,12 @@ final readonly class CoverUrlChangeListener
             return;
         }
 
-        if ($this->coverDownloader->downloadAndStore($entity, $newUrl)) {
-            // Recalculer le changeset pour inclure coverFile/coverImage
-            $this->entityManager->getUnitOfWork()->recomputeSingleEntityChangeSet(
-                $this->entityManager->getClassMetadata(ComicSeries::class),
-                $entity,
-            );
+        $seriesId = $entity->getId();
+
+        if (null === $seriesId) {
+            return;
         }
+
+        $this->messageBus->dispatch(new DownloadCoverMessage($seriesId, $newUrl));
     }
 }

--- a/backend/src/Message/DownloadCoverMessage.php
+++ b/backend/src/Message/DownloadCoverMessage.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+/**
+ * Message pour le téléchargement asynchrone d'une couverture.
+ */
+final readonly class DownloadCoverMessage
+{
+    public function __construct(
+        public int $seriesId,
+        public string $coverUrl,
+    ) {
+    }
+}

--- a/backend/src/MessageHandler/DownloadCoverHandler.php
+++ b/backend/src/MessageHandler/DownloadCoverHandler.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Message\DownloadCoverMessage;
+use App\Repository\ComicSeriesRepository;
+use App\Service\Cover\CoverDownloader;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Handler pour le téléchargement asynchrone d'une couverture.
+ */
+#[AsMessageHandler]
+final readonly class DownloadCoverHandler
+{
+    public function __construct(
+        private ComicSeriesRepository $comicSeriesRepository,
+        private CoverDownloader $coverDownloader,
+        private EntityManagerInterface $entityManager,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(DownloadCoverMessage $message): void
+    {
+        $series = $this->comicSeriesRepository->find($message->seriesId);
+
+        if (null === $series) {
+            $this->logger->warning('Série {id} non trouvée pour téléchargement de couverture', [
+                'id' => $message->seriesId,
+            ]);
+
+            return;
+        }
+
+        if ($this->coverDownloader->downloadAndStore($series, $message->coverUrl)) {
+            $this->entityManager->flush();
+
+            $this->logger->info('Couverture téléchargée pour "{title}"', [
+                'title' => $series->getTitle(),
+            ]);
+        } else {
+            $this->logger->warning('Échec du téléchargement de couverture pour "{title}"', [
+                'title' => $series->getTitle(),
+                'url' => $message->coverUrl,
+            ]);
+        }
+    }
+}

--- a/backend/tests/Unit/EventListener/CoverUrlChangeListenerTest.php
+++ b/backend/tests/Unit/EventListener/CoverUrlChangeListenerTest.php
@@ -6,97 +6,89 @@ namespace App\Tests\Unit\EventListener;
 
 use App\Entity\ComicSeries;
 use App\EventListener\CoverUrlChangeListener;
-use App\Service\Cover\CoverDownloader;
+use App\Message\DownloadCoverMessage;
 use App\Tests\Factory\EntityFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
-use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * Tests unitaires pour CoverUrlChangeListener.
  */
 final class CoverUrlChangeListenerTest extends TestCase
 {
-    private CoverDownloader&MockObject $coverDownloader;
-    private CoverUrlChangeListener $listener;
     private EntityManagerInterface&MockObject $entityManager;
+    private CoverUrlChangeListener $listener;
+    private MessageBusInterface&MockObject $messageBus;
 
     protected function setUp(): void
     {
-        $this->coverDownloader = $this->createMock(CoverDownloader::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
-        $this->listener = new CoverUrlChangeListener($this->coverDownloader, $this->entityManager);
+        $this->messageBus = $this->createMock(MessageBusInterface::class);
+        $this->listener = new CoverUrlChangeListener($this->messageBus);
     }
 
-    public function testDownloadsWhenCoverUrlChanges(): void
+    public function testDispatchesMessageWhenCoverUrlChanges(): void
     {
-        $series = EntityFactory::createComicSeries('Test');
+        $series = $this->createSeriesWithId(42);
 
         $changeSet = ['coverUrl' => ['https://old.com/cover.jpg', 'https://new.com/cover.jpg']];
         $args = new PreUpdateEventArgs($series, $this->entityManager, $changeSet);
 
-        $this->coverDownloader->expects(self::once())
-            ->method('downloadAndStore')
-            ->with($series, 'https://new.com/cover.jpg')
-            ->willReturn(true);
-
-        $uow = $this->createMock(UnitOfWork::class);
-        $uow->expects(self::once())->method('recomputeSingleEntityChangeSet');
-        $this->entityManager->method('getUnitOfWork')->willReturn($uow);
-        $this->entityManager->method('getClassMetadata')->willReturn(
-            new ClassMetadata(ComicSeries::class)
-        );
+        $this->messageBus->expects(self::once())
+            ->method('dispatch')
+            ->with(self::callback(
+                static fn ($msg) => $msg instanceof DownloadCoverMessage
+                    && 42 === $msg->seriesId
+                    && 'https://new.com/cover.jpg' === $msg->coverUrl,
+            ))
+            ->willReturn(new Envelope(new DownloadCoverMessage(42, 'https://new.com/cover.jpg')));
 
         $this->listener->preUpdate($args);
     }
 
-    public function testDownloadsWhenCoverUrlSetFromNull(): void
+    public function testDispatchesMessageWhenCoverUrlSetFromNull(): void
     {
-        $series = EntityFactory::createComicSeries('Test');
+        $series = $this->createSeriesWithId(10);
 
         $changeSet = ['coverUrl' => [null, 'https://new.com/cover.jpg']];
         $args = new PreUpdateEventArgs($series, $this->entityManager, $changeSet);
 
-        $this->coverDownloader->expects(self::once())
-            ->method('downloadAndStore')
-            ->with($series, 'https://new.com/cover.jpg')
-            ->willReturn(true);
-
-        $uow = $this->createMock(UnitOfWork::class);
-        $uow->expects(self::once())->method('recomputeSingleEntityChangeSet');
-        $this->entityManager->method('getUnitOfWork')->willReturn($uow);
-        $this->entityManager->method('getClassMetadata')->willReturn(
-            new ClassMetadata(ComicSeries::class)
-        );
+        $this->messageBus->expects(self::once())
+            ->method('dispatch')
+            ->with(self::callback(
+                static fn ($msg) => $msg instanceof DownloadCoverMessage
+                    && 10 === $msg->seriesId
+                    && 'https://new.com/cover.jpg' === $msg->coverUrl,
+            ))
+            ->willReturn(new Envelope(new DownloadCoverMessage(10, 'https://new.com/cover.jpg')));
 
         $this->listener->preUpdate($args);
     }
 
-    public function testDoesNotDownloadWhenCoverUrlCleared(): void
+    public function testDoesNotDispatchWhenCoverUrlCleared(): void
     {
         $series = EntityFactory::createComicSeries('Test');
 
         $changeSet = ['coverUrl' => ['https://old.com/cover.jpg', null]];
         $args = new PreUpdateEventArgs($series, $this->entityManager, $changeSet);
 
-        $this->coverDownloader->expects(self::never())
-            ->method('downloadAndStore');
+        $this->messageBus->expects(self::never())->method('dispatch');
 
         $this->listener->preUpdate($args);
     }
 
-    public function testDoesNotDownloadWhenCoverUrlUnchanged(): void
+    public function testDoesNotDispatchWhenCoverUrlUnchanged(): void
     {
         $series = EntityFactory::createComicSeries('Test');
 
         $changeSet = ['title' => ['Old Title', 'New Title']];
         $args = new PreUpdateEventArgs($series, $this->entityManager, $changeSet);
 
-        $this->coverDownloader->expects(self::never())
-            ->method('downloadAndStore');
+        $this->messageBus->expects(self::never())->method('dispatch');
 
         $this->listener->preUpdate($args);
     }
@@ -108,22 +100,40 @@ final class CoverUrlChangeListenerTest extends TestCase
         $changeSet = ['coverUrl' => [null, 'https://new.com/cover.jpg']];
         $args = new PreUpdateEventArgs($entity, $this->entityManager, $changeSet);
 
-        $this->coverDownloader->expects(self::never())
-            ->method('downloadAndStore');
+        $this->messageBus->expects(self::never())->method('dispatch');
 
         $this->listener->preUpdate($args);
     }
 
-    public function testDoesNotDownloadWhenCoverUrlSameValue(): void
+    public function testDoesNotDispatchWhenCoverUrlSameValue(): void
     {
         $series = EntityFactory::createComicSeries('Test');
 
         $changeSet = ['coverUrl' => ['https://same.com/cover.jpg', 'https://same.com/cover.jpg']];
         $args = new PreUpdateEventArgs($series, $this->entityManager, $changeSet);
 
-        $this->coverDownloader->expects(self::never())
-            ->method('downloadAndStore');
+        $this->messageBus->expects(self::never())->method('dispatch');
 
         $this->listener->preUpdate($args);
+    }
+
+    public function testDoesNotDispatchWhenSeriesHasNoId(): void
+    {
+        $series = EntityFactory::createComicSeries('Test');
+
+        $changeSet = ['coverUrl' => [null, 'https://new.com/cover.jpg']];
+        $args = new PreUpdateEventArgs($series, $this->entityManager, $changeSet);
+
+        $this->messageBus->expects(self::never())->method('dispatch');
+
+        $this->listener->preUpdate($args);
+    }
+
+    private function createSeriesWithId(int $id): ComicSeries&MockObject
+    {
+        $series = $this->createMock(ComicSeries::class);
+        $series->method('getId')->willReturn($id);
+
+        return $series;
     }
 }

--- a/backend/tests/Unit/Message/DownloadCoverMessageTest.php
+++ b/backend/tests/Unit/Message/DownloadCoverMessageTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Message;
+
+use App\Message\DownloadCoverMessage;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires pour le message de téléchargement de couverture asynchrone.
+ */
+final class DownloadCoverMessageTest extends TestCase
+{
+    public function testMessageHoldsSeriesIdAndUrl(): void
+    {
+        $message = new DownloadCoverMessage(42, 'https://example.com/cover.jpg');
+
+        self::assertSame(42, $message->seriesId);
+        self::assertSame('https://example.com/cover.jpg', $message->coverUrl);
+    }
+}

--- a/backend/tests/Unit/MessageHandler/DownloadCoverHandlerTest.php
+++ b/backend/tests/Unit/MessageHandler/DownloadCoverHandlerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MessageHandler;
+
+use App\Entity\ComicSeries;
+use App\Message\DownloadCoverMessage;
+use App\MessageHandler\DownloadCoverHandler;
+use App\Repository\ComicSeriesRepository;
+use App\Service\Cover\CoverDownloader;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Tests unitaires pour le handler de téléchargement de couverture asynchrone.
+ */
+final class DownloadCoverHandlerTest extends TestCase
+{
+    private MockObject&ComicSeriesRepository $comicSeriesRepository;
+    private MockObject&CoverDownloader $coverDownloader;
+    private DownloadCoverHandler $handler;
+    private MockObject&EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $this->comicSeriesRepository = $this->createMock(ComicSeriesRepository::class);
+        $this->coverDownloader = $this->createMock(CoverDownloader::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $this->handler = new DownloadCoverHandler(
+            $this->comicSeriesRepository,
+            $this->coverDownloader,
+            $this->entityManager,
+            new NullLogger(),
+        );
+    }
+
+    /**
+     * Teste que le handler télécharge et persiste la couverture.
+     */
+    public function testDownloadsAndFlushes(): void
+    {
+        $series = new ComicSeries();
+        $series->setTitle('Test');
+
+        $this->comicSeriesRepository->expects(self::once())
+            ->method('find')
+            ->with(42)
+            ->willReturn($series);
+
+        $this->coverDownloader->expects(self::once())
+            ->method('downloadAndStore')
+            ->with($series, 'https://example.com/cover.jpg')
+            ->willReturn(true);
+
+        $this->entityManager->expects(self::once())->method('flush');
+
+        ($this->handler)(new DownloadCoverMessage(42, 'https://example.com/cover.jpg'));
+    }
+
+    /**
+     * Teste que le handler ne flush pas si le téléchargement échoue.
+     */
+    public function testDoesNotFlushOnDownloadFailure(): void
+    {
+        $series = new ComicSeries();
+        $series->setTitle('Test');
+
+        $this->comicSeriesRepository->expects(self::once())
+            ->method('find')
+            ->with(42)
+            ->willReturn($series);
+
+        $this->coverDownloader->expects(self::once())
+            ->method('downloadAndStore')
+            ->with($series, 'https://example.com/cover.jpg')
+            ->willReturn(false);
+
+        $this->entityManager->expects(self::never())->method('flush');
+
+        ($this->handler)(new DownloadCoverMessage(42, 'https://example.com/cover.jpg'));
+    }
+
+    /**
+     * Teste que le handler ignore les séries introuvables.
+     */
+    public function testSkipsIfSeriesNotFound(): void
+    {
+        $this->comicSeriesRepository->expects(self::once())
+            ->method('find')
+            ->with(999)
+            ->willReturn(null);
+
+        $this->coverDownloader->expects(self::never())->method('downloadAndStore');
+        $this->entityManager->expects(self::never())->method('flush');
+
+        ($this->handler)(new DownloadCoverMessage(999, 'https://example.com/cover.jpg'));
+    }
+}

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -70,6 +70,7 @@ Reference for implementing features without exploring the codebase.
 | `JwtTokenVersionListener` | JWT create: adds tokenVersion. JWT decode: validates version match |
 | `EnrichOnCreateListener` | ComicSeriesCreatedEvent → dispatches `EnrichSeriesMessage` (async). `disable()`/`enable()` for batch imports |
 | `ReEnrichOnUpdateListener` | ComicSeriesUpdatedEvent → re-dispatches `EnrichSeriesMessage` if cover/description/publisher still null (cooldown 24h) |
+| `CoverUrlChangeListener` | preUpdate: dispatches `DownloadCoverMessage` (async) when `coverUrl` changes on ComicSeries |
 | `PlaceholderSecretChecker` | kernel.request (priority 255): blocks prod if placeholder secrets |
 
 ## Controllers (`backend/src/Controller/`)
@@ -96,6 +97,13 @@ Reference for implementing features without exploring the codebase.
 | `EnrichmentProposalRejectProcessor` | Reject proposal → log |
 | `NotificationPreferenceInitializer` | AP4 provider: creates default prefs (IN_APP) on first GET |
 | `TrashCollectionProvider` | GET `/api/trash` |
+
+## Messages & Handlers (`backend/src/Message/`, `backend/src/MessageHandler/`)
+
+| Message | Handler | Purpose |
+|---------|---------|---------|
+| `DownloadCoverMessage(seriesId, coverUrl)` | `DownloadCoverHandler` | Télécharge et stocke la couverture en WebP (async via Messenger) |
+| `EnrichSeriesMessage(seriesId)` | `EnrichSeriesHandler` | Enrichissement automatique via lookup providers (async via Messenger) |
 
 ## Services (`backend/src/Service/`)
 
@@ -237,7 +245,7 @@ Reference for implementing features without exploring the codebase.
 | `liip_imagine.yaml` | `cover_thumbnail` 300x450 webp, `cover_medium` 600x900 webp |
 | `security.yaml` | JWT firewall `/api/` (stateless). Public: `POST /api/login/google` |
 | `vich_uploader.yaml` | `comic_covers` → `public/uploads/covers` |
-| `messenger.yaml` | Doctrine transport (`doctrine://default`), `EnrichSeriesMessage` → async, failed transport, retry ×3. Test: `in-memory://` |
+| `messenger.yaml` | Doctrine transport (`doctrine://default`), `DownloadCoverMessage` + `EnrichSeriesMessage` → async, failed transport, retry ×3. Test: `in-memory://` |
 | `secrets/prod/` | Vault: `APP_SECRET` + `JWT_PASSPHRASE` + `VAPID_PUBLIC_KEY` + `VAPID_PRIVATE_KEY`. Decrypt key gitignored. |
 
 ### Backend Tests (`backend/tests/`)


### PR DESCRIPTION
## Summary

- **CoverUrlChangeListener** dispatche désormais un `DownloadCoverMessage` via Symfony Messenger au lieu d'appeler `CoverDownloader::downloadAndStore()` en synchrone dans le `preUpdate` Doctrine
- Nouveau message `DownloadCoverMessage(seriesId, coverUrl)` + handler `DownloadCoverHandler` qui effectue le téléchargement en arrière-plan
- `EnrichmentProposalAcceptProcessor` et `DownloadCoversCommand` restent synchrones (actions utilisateur/batch)

## Test plan

- [x] 1109 tests passent (0 échecs)
- [x] PHP CS Fixer : aucune correction
- [x] PHPStan level 9 : aucune erreur
- [x] 11 nouveaux tests unitaires (message, handler, listener)

Fixes #402