### PR TITLE
perf(backend): améliore la stratégie de cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
+- **Invalidation de cache granulaire** : L'invalidation du cache API ne se déclenche plus lors de la mise à jour de champs internes (`lookupCompletedAt`, `mergeCheckedAt`, `newReleasesCheckedAt`)
+- **TTL cache API** : Augmenté de 15 à 30 minutes (l'invalidation explicite garantit la fraîcheur)
+- **Cache-Control HTTP** : Ajout de `max-age=300` sur les réponses GET `/api/comic_series` pour que le navigateur serve depuis son cache pendant 5 minutes
 - **Index EnrichmentProposal** : Ajout d'un index explicite sur `comic_series_id` pour accélérer les requêtes de propositions d'enrichissement
 - **Téléchargement de couverture asynchrone** : Le téléchargement de couverture lors d'un changement de `coverUrl` est désormais traité via Symfony Messenger au lieu de bloquer la requête API
 

--- a/backend/config/packages/cache.yaml
+++ b/backend/config/packages/cache.yaml
@@ -18,7 +18,7 @@ framework:
         pools:
             comic_series_api.cache:
                 adapter: cache.adapter.filesystem
-                default_lifetime: 900 # 15 minutes
+                default_lifetime: 1800 # 30 minutes
             gemini.cache:
                 adapter: cache.adapter.filesystem
                 default_lifetime: 2592000 # 30 jours

--- a/backend/src/EventListener/ComicSeriesCacheInvalidator.php
+++ b/backend/src/EventListener/ComicSeriesCacheInvalidator.php
@@ -20,6 +20,10 @@ use Symfony\Contracts\Cache\CacheInterface;
  *
  * Écoute les événements Doctrine postPersist, postUpdate et postRemove
  * sur ComicSeries, Tome et Author pour supprimer le cache.
+ *
+ * Pour ComicSeries en postUpdate, seuls les champs publics (visibles dans l'API)
+ * déclenchent l'invalidation. Les champs internes (lookupCompletedAt, mergeCheckedAt,
+ * newReleasesCheckedAt) sont ignorés pour éviter les invalidations inutiles.
  */
 #[AsDoctrineListener(event: Events::postPersist)]
 #[AsDoctrineListener(event: Events::postRemove)]
@@ -30,6 +34,13 @@ final readonly class ComicSeriesCacheInvalidator
         Author::class,
         ComicSeries::class,
         Tome::class,
+    ];
+
+    /** Champs ComicSeries qui ne sont pas exposés dans l'API liste. */
+    private const array INTERNAL_FIELDS = [
+        'lookupCompletedAt',
+        'mergeCheckedAt',
+        'newReleasesCheckedAt',
     ];
 
     public function __construct(
@@ -50,7 +61,19 @@ final readonly class ComicSeriesCacheInvalidator
 
     public function postUpdate(PostUpdateEventArgs $event): void
     {
-        $this->invalidateIfRelevant($event->getObject());
+        $entity = $event->getObject();
+
+        if ($entity instanceof ComicSeries) {
+            $changeSet = $event->getObjectManager()->getUnitOfWork()->getEntityChangeSet($entity);
+            $changedFields = \array_keys($changeSet);
+            $publicFields = \array_diff($changedFields, self::INTERNAL_FIELDS);
+
+            if ([] === $publicFields) {
+                return;
+            }
+        }
+
+        $this->invalidateIfRelevant($entity);
     }
 
     private function invalidateIfRelevant(object $entity): void

--- a/backend/src/EventListener/HttpCacheListener.php
+++ b/backend/src/EventListener/HttpCacheListener.php
@@ -44,6 +44,7 @@ final class HttpCacheListener
         $etag = \md5((string) $response->getContent());
         $response->setEtag($etag);
         $response->setPrivate();
+        $response->setMaxAge(300);
         $response->headers->addCacheControlDirective('must-revalidate');
 
         $response->isNotModified($request);

--- a/backend/src/Repository/ComicSeriesRepository.php
+++ b/backend/src/Repository/ComicSeriesRepository.php
@@ -365,7 +365,7 @@ class ComicSeriesRepository extends ServiceEntityRepository
     /**
      * Retourne toutes les séries avec leurs relations pour l'API PWA.
      *
-     * Utilise un cache applicatif (15 min) pour éviter de requêter la base
+     * Utilise un cache applicatif (30 min) pour éviter de requêter la base
      * à chaque chargement. Le cache est invalidé par ComicSeriesCacheInvalidator.
      *
      * @return list<ComicSeriesListItem>
@@ -374,7 +374,7 @@ class ComicSeriesRepository extends ServiceEntityRepository
     {
         /* @var list<ComicSeriesListItem> */
         return $this->cache->get('comic_series_api_all', function (ItemInterface $item): array {
-            $item->expiresAfter(900);
+            $item->expiresAfter(1800);
 
             return $this->doFindAllForApi();
         });

--- a/backend/tests/Unit/EventListener/ComicSeriesCacheInvalidatorTest.php
+++ b/backend/tests/Unit/EventListener/ComicSeriesCacheInvalidatorTest.php
@@ -13,8 +13,8 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PostPersistEventArgs;
 use Doctrine\ORM\Event\PostRemoveEventArgs;
 use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Cache\CacheInterface;
 
@@ -24,13 +24,16 @@ use Symfony\Contracts\Cache\CacheInterface;
 final class ComicSeriesCacheInvalidatorTest extends TestCase
 {
     private CacheInterface&MockObject $cache;
-    private EntityManagerInterface&Stub $entityManager;
+    private EntityManagerInterface&MockObject $entityManager;
+    private UnitOfWork&MockObject $unitOfWork;
     private ComicSeriesCacheInvalidator $listener;
 
     protected function setUp(): void
     {
         $this->cache = $this->createMock(CacheInterface::class);
-        $this->entityManager = $this->createStub(EntityManagerInterface::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->unitOfWork = $this->createMock(UnitOfWork::class);
+        $this->entityManager->method('getUnitOfWork')->willReturn($this->unitOfWork);
 
         $this->listener = new ComicSeriesCacheInvalidator($this->cache);
     }
@@ -90,6 +93,11 @@ final class ComicSeriesCacheInvalidatorTest extends TestCase
     {
         $entity = new ComicSeries();
         $event = new PostUpdateEventArgs($entity, $this->entityManager);
+
+        $this->unitOfWork
+            ->method('getEntityChangeSet')
+            ->with($entity)
+            ->willReturn(['title' => ['Old', 'New']]);
 
         $this->cache
             ->expects(self::once())
@@ -186,5 +194,91 @@ final class ComicSeriesCacheInvalidatorTest extends TestCase
             ->method('delete');
 
         $this->listener->postRemove($event);
+    }
+
+    public function testPostUpdateWithOnlyInternalFieldsDoesNotInvalidateCache(): void
+    {
+        $entity = new ComicSeries();
+        $event = new PostUpdateEventArgs($entity, $this->entityManager);
+
+        $this->unitOfWork
+            ->method('getEntityChangeSet')
+            ->with($entity)
+            ->willReturn([
+                'lookupCompletedAt' => [null, new \DateTimeImmutable()],
+                'mergeCheckedAt' => [null, new \DateTimeImmutable()],
+            ]);
+
+        $this->cache
+            ->expects(self::never())
+            ->method('delete');
+
+        $this->listener->postUpdate($event);
+    }
+
+    public function testPostUpdateWithPublicFieldInvalidatesCache(): void
+    {
+        $entity = new ComicSeries();
+        $event = new PostUpdateEventArgs($entity, $this->entityManager);
+
+        $this->unitOfWork
+            ->method('getEntityChangeSet')
+            ->with($entity)
+            ->willReturn([
+                'lookupCompletedAt' => [null, new \DateTimeImmutable()],
+                'title' => ['Old Title', 'New Title'],
+            ]);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('delete')
+            ->with('comic_series_api_all');
+
+        $this->listener->postUpdate($event);
+    }
+
+    public function testPostUpdateWithNewReleasesCheckedAtOnlyDoesNotInvalidateCache(): void
+    {
+        $entity = new ComicSeries();
+        $event = new PostUpdateEventArgs($entity, $this->entityManager);
+
+        $this->unitOfWork
+            ->method('getEntityChangeSet')
+            ->with($entity)
+            ->willReturn([
+                'newReleasesCheckedAt' => [null, new \DateTimeImmutable()],
+            ]);
+
+        $this->cache
+            ->expects(self::never())
+            ->method('delete');
+
+        $this->listener->postUpdate($event);
+    }
+
+    public function testPostUpdateWithTomeAlwaysInvalidatesCache(): void
+    {
+        $entity = new Tome();
+        $event = new PostUpdateEventArgs($entity, $this->entityManager);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('delete')
+            ->with('comic_series_api_all');
+
+        $this->listener->postUpdate($event);
+    }
+
+    public function testPostUpdateWithAuthorAlwaysInvalidatesCache(): void
+    {
+        $entity = new Author();
+        $event = new PostUpdateEventArgs($entity, $this->entityManager);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('delete')
+            ->with('comic_series_api_all');
+
+        $this->listener->postUpdate($event);
     }
 }

--- a/backend/tests/Unit/EventListener/HttpCacheListenerTest.php
+++ b/backend/tests/Unit/EventListener/HttpCacheListenerTest.php
@@ -118,6 +118,28 @@ final class HttpCacheListenerTest extends TestCase
         self::assertNull($response->getEtag(), 'Ne doit pas ajouter d\'ETag aux réponses d\'erreur');
     }
 
+    public function testSetsMaxAgeOnSuccessfulGetResponse(): void
+    {
+        $request = Request::create('/api/comic_series', Request::METHOD_GET);
+        $response = new Response('{"member":[]}', Response::HTTP_OK, ['Content-Type' => 'application/ld+json']);
+        $event = new ResponseEvent($this->kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $this->listener->onKernelResponse($event);
+
+        self::assertSame('300', $response->headers->getCacheControlDirective('max-age'), 'Doit définir max-age à 300 secondes');
+    }
+
+    public function testDoesNotSetMaxAgeOnNonApiRoutes(): void
+    {
+        $request = Request::create('/api/authors', Request::METHOD_GET);
+        $response = new Response('[]', Response::HTTP_OK);
+        $event = new ResponseEvent($this->kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $this->listener->onKernelResponse($event);
+
+        self::assertNull($response->headers->getCacheControlDirective('max-age'), 'Ne doit pas définir max-age sur les routes non ciblées');
+    }
+
     public function testEtagChangesWithDifferentContent(): void
     {
         $request1 = Request::create('/api/comic_series', Request::METHOD_GET);


### PR DESCRIPTION
## Summary

- **Invalidation granulaire** : vérifie le changeset Doctrine sur `postUpdate` pour `ComicSeries` — les champs internes (`lookupCompletedAt`, `mergeCheckedAt`, `newReleasesCheckedAt`) ne déclenchent plus l'invalidation du cache API
- **TTL cache** : 15min → 30min (l'invalidation explicite garantit la fraîcheur des données)
- **Cache-Control HTTP** : `max-age=300` sur les réponses GET `/api/comic_series` pour que le navigateur serve depuis son cache local pendant 5 minutes

## Test plan

- [x] Tests unitaires : 6 nouveaux cas (champs internes seuls, champs mixtes, Tome/Author bypass)
- [x] Suite complète : 1116/1116 tests passent
- [x] PHPStan level 9 : aucune erreur
- [x] CS Fixer : aucun changement nécessaire

Fixes #403