### PR TITLE
Ajoute des filtres sur la page de revue d'enrichissement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Added
+
+- **Filtres revue d'enrichissement** : recherche par série, filtre par champ, confiance et source sur la page de revue des propositions
+
 ## [v2.21.0] - 2026-03-26
 
 ### Added

--- a/frontend/src/__tests__/integration/pages/EnrichmentReview.test.tsx
+++ b/frontend/src/__tests__/integration/pages/EnrichmentReview.test.tsx
@@ -1,0 +1,204 @@
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import EnrichmentReview from "../../../pages/EnrichmentReview";
+import { renderWithProviders } from "../../helpers/test-utils";
+
+const proposals = [
+  {
+    "@id": "/enrichment_proposals/1",
+    comicSeries: { "@id": "/comic_series/10", id: 10, title: "One Piece" },
+    confidence: "high",
+    createdAt: "2026-01-01T00:00:00+00:00",
+    currentValue: null,
+    field: "description",
+    id: 1,
+    proposedValue: "Un manga d'aventure",
+    reviewedAt: null,
+    source: "AniList",
+    status: "pending",
+  },
+  {
+    "@id": "/enrichment_proposals/2",
+    comicSeries: { "@id": "/comic_series/10", id: 10, title: "One Piece" },
+    confidence: "medium",
+    createdAt: "2026-01-01T00:00:00+00:00",
+    currentValue: null,
+    field: "cover",
+    id: 2,
+    proposedValue: "https://example.com/cover.jpg",
+    reviewedAt: null,
+    source: "GoogleBooks",
+    status: "pending",
+  },
+  {
+    "@id": "/enrichment_proposals/3",
+    comicSeries: { "@id": "/comic_series/20", id: 20, title: "Astérix" },
+    confidence: "low",
+    createdAt: "2026-01-01T00:00:00+00:00",
+    currentValue: "Ancien éditeur",
+    field: "publisher",
+    id: 3,
+    proposedValue: "Hachette",
+    reviewedAt: null,
+    source: "GoogleBooks",
+    status: "pending",
+  },
+  {
+    "@id": "/enrichment_proposals/4",
+    comicSeries: { "@id": "/comic_series/30", id: 30, title: "Batman" },
+    confidence: "high",
+    createdAt: "2026-01-01T00:00:00+00:00",
+    currentValue: null,
+    field: "authors",
+    id: 4,
+    proposedValue: ["Bob Kane"],
+    reviewedAt: null,
+    source: "Wikipedia",
+    status: "pending",
+  },
+];
+
+const server = setupServer(
+  http.get("*/api/enrichment_proposals", () =>
+    HttpResponse.json({
+      "@context": "/api/contexts/EnrichmentProposal",
+      "@id": "/enrichment_proposals",
+      "@type": "Collection",
+      member: proposals,
+      totalItems: proposals.length,
+    }),
+  ),
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("EnrichmentReview", () => {
+  it("renders all series groups when no filters applied", async () => {
+    renderWithProviders(<EnrichmentReview />);
+
+    expect(await screen.findByText("One Piece")).toBeInTheDocument();
+    expect(screen.getByText("Astérix")).toBeInTheDocument();
+    expect(screen.getByText("Batman")).toBeInTheDocument();
+  });
+
+  it("filters proposals by series name search", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EnrichmentReview />);
+
+    await screen.findByText("One Piece");
+
+    await user.type(screen.getByPlaceholderText("Rechercher une série…"), "astérix");
+
+    expect(screen.getByText("Astérix")).toBeInTheDocument();
+    expect(screen.queryByText("One Piece")).not.toBeInTheDocument();
+    expect(screen.queryByText("Batman")).not.toBeInTheDocument();
+  });
+
+  it("filters proposals by field", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EnrichmentReview />);
+
+    await screen.findByText("One Piece");
+
+    await user.click(screen.getByRole("button", { name: "Champ" }));
+    await user.click(screen.getByRole("option", { name: "Couverture" }));
+
+    // Only One Piece has a cover proposal
+    expect(screen.getByText("One Piece")).toBeInTheDocument();
+    expect(screen.queryByText("Astérix")).not.toBeInTheDocument();
+    expect(screen.queryByText("Batman")).not.toBeInTheDocument();
+  });
+
+  it("filters proposals by confidence level", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EnrichmentReview />);
+
+    await screen.findByText("One Piece");
+
+    await user.click(screen.getByRole("button", { name: "Confiance" }));
+    await user.click(screen.getByRole("option", { name: "Basse" }));
+
+    // Only Astérix has low confidence
+    expect(screen.getByText("Astérix")).toBeInTheDocument();
+    expect(screen.queryByText("One Piece")).not.toBeInTheDocument();
+    expect(screen.queryByText("Batman")).not.toBeInTheDocument();
+  });
+
+  it("filters proposals by source", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EnrichmentReview />);
+
+    await screen.findByText("One Piece");
+
+    await user.click(screen.getByRole("button", { name: "Source" }));
+    await user.click(screen.getByRole("option", { name: "Wikipedia" }));
+
+    // Only Batman has Wikipedia source
+    expect(screen.getByText("Batman")).toBeInTheDocument();
+    expect(screen.queryByText("One Piece")).not.toBeInTheDocument();
+    expect(screen.queryByText("Astérix")).not.toBeInTheDocument();
+  });
+
+  it("combines multiple filters", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EnrichmentReview />);
+
+    await screen.findByText("One Piece");
+
+    // Filter by source GoogleBooks
+    await user.click(screen.getByRole("button", { name: "Source" }));
+    await user.click(screen.getByRole("option", { name: "GoogleBooks" }));
+
+    // Both One Piece and Astérix have GoogleBooks proposals
+    expect(screen.getByText("One Piece")).toBeInTheDocument();
+    expect(screen.getByText("Astérix")).toBeInTheDocument();
+    expect(screen.queryByText("Batman")).not.toBeInTheDocument();
+
+    // Add confidence filter: high
+    await user.click(screen.getByRole("button", { name: "Confiance" }));
+    await user.click(screen.getByRole("option", { name: "Haute" }));
+
+    // GoogleBooks + high = impossible — no proposals match both
+    expect(screen.queryByText("One Piece")).not.toBeInTheDocument();
+    expect(screen.queryByText("Astérix")).not.toBeInTheDocument();
+  });
+
+  it("shows result count", async () => {
+    renderWithProviders(<EnrichmentReview />);
+
+    await screen.findByText("One Piece");
+
+    expect(screen.getByText(/4 propositions/)).toBeInTheDocument();
+  });
+
+  it("filters only proposals within a series, keeping other proposals visible", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EnrichmentReview />);
+
+    await screen.findByText("One Piece");
+
+    // Filter by field: description — One Piece has 2 proposals but only 1 is description
+    await user.click(screen.getByRole("button", { name: "Champ" }));
+    await user.click(screen.getByRole("option", { name: "Description" }));
+
+    // One Piece should show but only 1 proposal card
+    const seriesSection = screen.getByText("One Piece").closest("div[class*='rounded-xl']")!;
+    const proposals = within(seriesSection).getAllByTitle("Accepter");
+    expect(proposals).toHaveLength(1);
+  });
+
+  it("shows empty state when filters match nothing", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EnrichmentReview />);
+
+    await screen.findByText("One Piece");
+
+    await user.type(screen.getByPlaceholderText("Rechercher une série…"), "zzzznotfound");
+
+    expect(screen.getByText("Aucune proposition en attente")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/EnrichmentReview.tsx
+++ b/frontend/src/pages/EnrichmentReview.tsx
@@ -1,9 +1,10 @@
-import { Check, Loader2, Sparkles, X } from "lucide-react";
-import { useMemo } from "react";
+import { Check, Loader2, Search, Sparkles, X } from "lucide-react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { toast } from "sonner";
 import Breadcrumb from "../components/Breadcrumb";
 import EmptyState from "../components/EmptyState";
+import SelectListbox from "../components/SelectListbox";
 import { useAcceptProposal, useEnrichmentProposals, useRejectProposal } from "../hooks/useEnrichment";
 import type { EnrichmentProposal } from "../types/api";
 import {
@@ -12,8 +13,16 @@ import {
   EnrichmentConfidenceLabel,
   type EnrichmentConfidence,
   ProposalStatus,
+  type SelectOption,
 } from "../types/enums";
 import { formatEnrichmentValue } from "../utils/enrichmentUtils";
+
+const confidenceOptions: SelectOption[] = [
+  { label: "Toutes", value: "" },
+  { label: EnrichmentConfidenceLabel.high, value: "high" },
+  { label: EnrichmentConfidenceLabel.medium, value: "medium" },
+  { label: EnrichmentConfidenceLabel.low, value: "low" },
+];
 
 function ProposalCard({
   onAccept,
@@ -38,7 +47,7 @@ function ProposalCard({
           </span>
           <span className="text-xs text-text-tertiary">{proposal.source}</span>
         </div>
-        <div className="mt-1 text-sm text-text-secondary">
+        <div className="mt-1 break-all text-sm text-text-secondary">
           <span className="text-text-tertiary">{formatEnrichmentValue(proposal.currentValue)}</span>
           {" → "}
           <span className="font-medium text-text-primary">{formatEnrichmentValue(proposal.proposedValue)}</span>
@@ -71,11 +80,42 @@ export default function EnrichmentReview() {
   const acceptMutation = useAcceptProposal();
   const rejectMutation = useRejectProposal();
 
-  const groupedBySeries = useMemo(() => {
-    if (!proposals) return new Map<number, { proposals: EnrichmentProposal[]; title: string }>();
+  const [search, setSearch] = useState("");
+  const [fieldFilter, setFieldFilter] = useState("");
+  const [confidenceFilter, setConfidenceFilter] = useState("");
+  const [sourceFilter, setSourceFilter] = useState("");
 
+  const fieldOptions: SelectOption[] = useMemo(() => {
+    const fields = new Set(proposals?.map((p) => p.field) ?? []);
+    return [
+      { label: "Tous les champs", value: "" },
+      ...[...fields].sort().map((f) => ({ label: EnrichableFieldLabel[f] ?? f, value: f })),
+    ];
+  }, [proposals]);
+
+  const sourceOptions: SelectOption[] = useMemo(() => {
+    const sources = new Set(proposals?.map((p) => p.source) ?? []);
+    return [
+      { label: "Toutes les sources", value: "" },
+      ...[...sources].sort().map((s) => ({ label: s, value: s })),
+    ];
+  }, [proposals]);
+
+  const filteredProposals = useMemo(() => {
+    if (!proposals) return [];
+    const searchLower = search.toLowerCase();
+    return proposals.filter((p) => {
+      if (searchLower && !p.comicSeries.title.toLowerCase().includes(searchLower)) return false;
+      if (fieldFilter && p.field !== fieldFilter) return false;
+      if (confidenceFilter && p.confidence !== confidenceFilter) return false;
+      if (sourceFilter && p.source !== sourceFilter) return false;
+      return true;
+    });
+  }, [proposals, search, fieldFilter, confidenceFilter, sourceFilter]);
+
+  const groupedBySeries = useMemo(() => {
     const map = new Map<number, { proposals: EnrichmentProposal[]; title: string }>();
-    for (const proposal of proposals) {
+    for (const proposal of filteredProposals) {
       const seriesId = proposal.comicSeries.id;
       const existing = map.get(seriesId);
       if (existing) {
@@ -88,7 +128,7 @@ export default function EnrichmentReview() {
       }
     }
     return map;
-  }, [proposals]);
+  }, [filteredProposals]);
 
   const handleAccept = (id: number) => {
     acceptMutation.mutate(id, {
@@ -108,6 +148,50 @@ export default function EnrichmentReview() {
     <div className="mx-auto max-w-4xl px-4 py-6">
       <Breadcrumb items={[{ href: "/tools", label: "Outils" }, { label: "Revue d'enrichissement" }]} />
       <h1 className="text-xl font-bold text-text-primary">Revue d&apos;enrichissement</h1>
+
+      {!isLoading && proposals && proposals.length > 0 && (
+        <div className="mt-4 space-y-3">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" />
+            <input
+              className="w-full rounded-xl border border-surface-border bg-surface-elevated py-2 pl-9 pr-3 text-sm text-text-primary placeholder:text-text-muted focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-white/10 dark:bg-white/5"
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Rechercher une série…"
+              type="text"
+              value={search}
+            />
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <div className="min-w-[160px]">
+              <SelectListbox
+                onChange={setFieldFilter}
+                options={fieldOptions}
+                placeholder="Champ"
+                value={fieldFilter}
+              />
+            </div>
+            <div className="min-w-[140px]">
+              <SelectListbox
+                onChange={setConfidenceFilter}
+                options={confidenceOptions}
+                placeholder="Confiance"
+                value={confidenceFilter}
+              />
+            </div>
+            <div className="min-w-[160px]">
+              <SelectListbox
+                onChange={setSourceFilter}
+                options={sourceOptions}
+                placeholder="Source"
+                value={sourceFilter}
+              />
+            </div>
+          </div>
+          <p className="text-sm text-text-tertiary">
+            {filteredProposals.length} proposition{filteredProposals.length !== 1 ? "s" : ""}
+          </p>
+        </div>
+      )}
 
       {isLoading && (
         <div className="mt-8 flex items-center justify-center">


### PR DESCRIPTION
## Summary

- Ajout de 4 filtres client-side sur la page de revue d'enrichissement : recherche par nom de série, filtre par champ enrichi, niveau de confiance et source
- Compteur de propositions filtrées
- Fix word-break sur les URLs longues dans les valeurs proposées

Fixes #412

## Test plan

- [x] 9 tests d'intégration couvrant chaque filtre, combinaisons, compteur, état vide
- [x] TypeScript clean (`tsc --noEmit`)
- [ ] Vérifier visuellement les filtres sur la page de revue