### PR TITLE
Corrige l'absence du titre de série dans la revue d'enrichissement

### DIFF
--- a/backend/src/Entity/ComicSeries.php
+++ b/backend/src/Entity/ComicSeries.php
@@ -85,13 +85,13 @@ class ComicSeries implements SoftDeletableInterface
 {
     use SoftDeletableTrait;
 
-    #[Groups(['comic:list', 'comic:read'])]
+    #[Groups(['comic:list', 'comic:read', 'enrichment:read'])]
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
-    #[Groups(['comic:list', 'comic:read', 'comic:write'])]
+    #[Groups(['comic:list', 'comic:read', 'comic:write', 'enrichment:read'])]
     #[ORM\Column(length: 255)]
     #[Assert\NotBlank]
     private string $title = '';

--- a/frontend/src/pages/EnrichmentReview.tsx
+++ b/frontend/src/pages/EnrichmentReview.tsx
@@ -105,7 +105,7 @@ export default function EnrichmentReview() {
     if (!proposals) return [];
     const searchLower = search.toLowerCase();
     return proposals.filter((p) => {
-      if (searchLower && !p.comicSeries.title.toLowerCase().includes(searchLower)) return false;
+      if (searchLower && !p.comicSeries.title?.toLowerCase().includes(searchLower)) return false;
       if (fieldFilter && p.field !== fieldFilter) return false;
       if (confidenceFilter && p.confidence !== confidenceFilter) return false;
       if (sourceFilter && p.source !== sourceFilter) return false;


### PR DESCRIPTION
## Summary

- Ajoute le groupe `enrichment:read` sur `id` et `title` de `ComicSeries` pour que l'API retourne ces champs dans les propositions d'enrichissement
- Ajoute un optional chaining en frontend par sécurité sur le filtre de recherche

Fixes #412

## Test plan

- [ ] Vérifier que les titres de séries apparaissent sur la page de revue
- [ ] Vérifier que la recherche textuelle fonctionne