### PR TITLE
Liste de courses — mode magasin avec badges et one-tap achat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Added
 
+- **Liste de courses — mode magasin** : page « À acheter » refaite avec regroupement par type (Manga, BD, Comics, Livre), badges individuels cliquables par tome manquant (one-tap achat), actions rapides (détail, Amazon), feedback optimiste
 - **Continuer la lecture** : section horizontale en haut de la page d'accueil affichant les séries avec des tomes non lus, indiquant le prochain tome à lire
 - **Thématisation dynamique** : bouton « Modifier » teinté par la couleur dominante de la couverture, focus rings dynamiques sur les boutons d'action, variable CSS `--series-color` étendue à toute la page détail
 - **Collection Map** : grille visuelle compacte des tomes sur la page détail avec code couleur (acheté/téléchargé/lu/manquant), toggle carte/tableau persisté en localStorage

--- a/backend/src/Entity/ComicSeries.php
+++ b/backend/src/Entity/ComicSeries.php
@@ -868,18 +868,34 @@ class ComicSeries implements SoftDeletableInterface
     }
 
     /**
-     * Numéros des tomes non achetés.
+     * Tomes non achetés avec ID, numéro et indicateur hors-série.
      *
-     * @return int[]
+     * Triés par isHorsSerie ASC puis number ASC (réguliers d'abord, puis hors-série).
+     *
+     * @return list<array{id: int, isHorsSerie: bool, number: int}>
      */
     #[ApiProperty]
     #[Groups(['comic:list'])]
-    public function getUnboughtTomeNumbers(): array
+    public function getUnboughtTomes(): array
     {
-        return $this->tomes
+        $unbought = $this->tomes
             ->filter(static fn (Tome $t): bool => !$t->isBought())
-            ->map(static fn (Tome $t): int => $t->getNumber())
+            ->map(static fn (Tome $t): array => [
+                'id' => (int) $t->getId(),
+                'isHorsSerie' => $t->isHorsSerie(),
+                'number' => $t->getNumber(),
+            ])
             ->toArray();
+
+        \usort($unbought, static function (array $a, array $b): int {
+            if ($a['isHorsSerie'] !== $b['isHorsSerie']) {
+                return $a['isHorsSerie'] <=> $b['isHorsSerie'];
+            }
+
+            return $a['number'] <=> $b['number'];
+        });
+
+        return $unbought;
     }
 
     /**

--- a/backend/tests/Unit/Entity/ComicSeriesTest.php
+++ b/backend/tests/Unit/Entity/ComicSeriesTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Entity;
 
 use App\Entity\ComicSeries;
+use App\Entity\Tome;
 use App\Enum\ComicStatus;
 use App\Enum\ComicType;
 use App\Tests\Factory\EntityFactory;
@@ -846,5 +847,65 @@ final class ComicSeriesTest extends TestCase
 
         self::assertInstanceOf(\DateTimeImmutable::class, $comic->getUpdatedAt());
         self::assertGreaterThan($originalUpdatedAt, $comic->getUpdatedAt());
+    }
+
+    // ---------------------------------------------------------------
+    // getUnboughtTomes()
+    // ---------------------------------------------------------------
+
+    public function testGetUnboughtTomesReturnsIdNumberAndHorsSerie(): void
+    {
+        $comic = EntityFactory::createComicSeries();
+
+        $tome1 = EntityFactory::createTome(number: 1, bought: false);
+        $tome2 = EntityFactory::createTome(number: 2, bought: true);
+        $tome3 = EntityFactory::createTome(number: 3, bought: false);
+
+        $ref = new \ReflectionProperty(Tome::class, 'id');
+        $ref->setValue($tome1, 10);
+        $ref->setValue($tome2, 20);
+        $ref->setValue($tome3, 30);
+
+        $comic->addTome($tome1);
+        $comic->addTome($tome2);
+        $comic->addTome($tome3);
+
+        $result = $comic->getUnboughtTomes();
+
+        self::assertCount(2, $result);
+        self::assertSame(['id' => 10, 'isHorsSerie' => false, 'number' => 1], $result[0]);
+        self::assertSame(['id' => 30, 'isHorsSerie' => false, 'number' => 3], $result[1]);
+    }
+
+    public function testGetUnboughtTomesIncludesHorsSerieAfterRegular(): void
+    {
+        $comic = EntityFactory::createComicSeries();
+
+        $tomeReg = EntityFactory::createTome(number: 1, bought: false);
+        $tomeHs = EntityFactory::createTome(number: 1, bought: false);
+        $tomeHs->setIsHorsSerie(true);
+
+        $ref = new \ReflectionProperty(Tome::class, 'id');
+        $ref->setValue($tomeReg, 100);
+        $ref->setValue($tomeHs, 200);
+
+        $comic->addTome($tomeHs);
+        $comic->addTome($tomeReg);
+
+        $result = $comic->getUnboughtTomes();
+
+        self::assertCount(2, $result);
+        // Regular first, then hors-série
+        self::assertSame(['id' => 100, 'isHorsSerie' => false, 'number' => 1], $result[0]);
+        self::assertSame(['id' => 200, 'isHorsSerie' => true, 'number' => 1], $result[1]);
+    }
+
+    public function testGetUnboughtTomesReturnsEmptyWhenAllBought(): void
+    {
+        $comic = EntityFactory::createComicSeries();
+        $tome = EntityFactory::createTome(number: 1, bought: true);
+        $comic->addTome($tome);
+
+        self::assertSame([], $comic->getUnboughtTomes());
     }
 }

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -342,6 +342,7 @@ Three-tier: **Unit** (no kernel) → **Integration** (kernel + DB) → **Functio
 | Hook | Purpose |
 |------|---------|
 | `useAuth` | Google login mutation, logout |
+| `useBuyTome` | PATCH tome as bought with optimistic update on comics list (ToBuy page) |
 | `useAuthors` | GET `/api/authors?name=...` (autocomplete) |
 | `useBatchLookup` | Preview query + SSE streaming (start/cancel/progress/summary) |
 | `useComic` / `useComics` | GET single / GET collection with filters |

--- a/frontend/src/__tests__/helpers/factories.ts
+++ b/frontend/src/__tests__/helpers/factories.ts
@@ -67,7 +67,7 @@ export function createMockComicSeries(
     title: `Series ${id}`,
     tomesCount: 0,
     type: ComicType.BD,
-    unboughtTomeNumbers: [],
+    unboughtTomes: [],
     updatedAt: "2025-01-01T00:00:00+00:00",
     ...overrides,
   };

--- a/frontend/src/__tests__/integration/pages/ToBuy.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ToBuy.test.tsx
@@ -1,51 +1,21 @@
-import { screen } from "@testing-library/react";
-import { queryKeys } from "../../../queryKeys";
-import type { ComicSeries } from "../../../types/api";
-import { createTestQueryClient, renderWithProviders } from "../../helpers/test-utils";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import ToBuy from "../../../pages/ToBuy";
+import { queryKeys } from "../../../queryKeys";
+import { createMockComicSeries, createMockHydraCollection } from "../../helpers/factories";
+import { createTestQueryClient, renderWithProviders } from "../../helpers/test-utils";
 
-function makeSeries(id: number, title: string, overrides: Partial<ComicSeries> = {}): ComicSeries {
-  return {
-    "@id": `/api/comics/${id}`,
-    authors: [],
-    boughtCount: 0,
-    coveredCount: 0,
-    coverImage: null,
-    coverUrl: null,
-    createdAt: "2024-01-01T00:00:00+00:00",
-    defaultTomeBought: true,
-    defaultTomeDownloaded: false,
-    defaultTomeRead: false,
-    description: null,
-    downloadedCount: 0,
-    id,
-    isOneShot: false,
-    latestPublishedIssue: null,
-    latestPublishedIssueComplete: false,
-    latestPublishedIssueUpdatedAt: null,
-    maxTomeNumber: null,
-    publishedDate: null,
-    publisher: null,
-    readCount: 0,
-    status: "buying",
-    title,
-    tomesCount: 0,
-    type: "manga",
-    unboughtTomeNumbers: [],
-    updatedAt: "2024-01-01T00:00:00+00:00",
-    ...overrides,
-  };
-}
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
 
 function renderWithComics(comics: ComicSeries[]) {
   const queryClient = createTestQueryClient();
-  queryClient.setQueryData(queryKeys.comics.all, {
-    "@context": "/api/contexts/ComicSeries",
-    "@id": "/api/comics",
-    "@type": "Collection",
-    member: comics,
-    totalItems: comics.length,
-  });
+  queryClient.setQueryData(queryKeys.comics.all, createMockHydraCollection(comics));
   return renderWithProviders(<ToBuy />, { initialEntries: ["/to-buy"], queryClient });
 }
 
@@ -55,59 +25,168 @@ describe("ToBuy", () => {
     expect(screen.getByText("Rien à acheter")).toBeInTheDocument();
   });
 
-  it("shows buying series with unbought tomes as ranges", () => {
-    const series = makeSeries(1, "One Piece", {
-      unboughtTomeNumbers: [2, 3, 4, 7, 8, 10],
+  it("groups series by type with section headers", () => {
+    const manga = createMockComicSeries({
+      id: 1,
+      title: "One Piece",
+      type: "manga",
+      unboughtTomes: [{ id: 10, isHorsSerie: false, number: 1 }],
+    });
+    const bd = createMockComicSeries({
+      id: 2,
+      title: "Astérix",
+      type: "bd",
+      unboughtTomes: [{ id: 20, isHorsSerie: false, number: 2 }],
+    });
+    renderWithComics([manga, bd]);
+
+    expect(screen.getByText("Manga")).toBeInTheDocument();
+    expect(screen.getByText("BD")).toBeInTheDocument();
+  });
+
+  it("shows individual tome badges with numbers", () => {
+    const series = createMockComicSeries({
+      id: 1,
+      title: "Naruto",
+      type: "manga",
+      unboughtTomes: [
+        { id: 10, isHorsSerie: false, number: 3 },
+        { id: 20, isHorsSerie: false, number: 5 },
+      ],
     });
     renderWithComics([series]);
-    expect(screen.getAllByText("One Piece")[0]).toBeInTheDocument();
-    expect(screen.getAllByText("Prochain : T.2-4, T.7-8, T.10")[0]).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: "Marquer le tome 3 comme acheté" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Marquer le tome 5 comme acheté" })).toBeInTheDocument();
+  });
+
+  it("displays hors-série badges with HS prefix", () => {
+    const series = createMockComicSeries({
+      id: 1,
+      title: "Dragon Ball",
+      type: "manga",
+      unboughtTomes: [
+        { id: 10, isHorsSerie: true, number: 1 },
+      ],
+    });
+    renderWithComics([series]);
+
+    expect(screen.getByRole("button", { name: "Marquer le tome HS 1 comme acheté" })).toBeInTheDocument();
+  });
+
+  it("sorts series alphabetically within each group", () => {
+    const comics = [
+      createMockComicSeries({
+        id: 1,
+        title: "Zetman",
+        type: "manga",
+        unboughtTomes: [{ id: 10, isHorsSerie: false, number: 1 }],
+      }),
+      createMockComicSeries({
+        id: 2,
+        title: "Akira",
+        type: "manga",
+        unboughtTomes: [{ id: 20, isHorsSerie: false, number: 1 }],
+      }),
+    ];
+    renderWithComics(comics);
+
+    const mangaSection = screen.getByTestId("type-section-manga");
+    const titles = within(mangaSection).getAllByTestId("series-title");
+    expect(titles[0]).toHaveTextContent("Akira");
+    expect(titles[1]).toHaveTextContent("Zetman");
+  });
+
+  it("shows eye icon link to detail page", () => {
+    const series = createMockComicSeries({
+      id: 42,
+      title: "Bleach",
+      type: "manga",
+      unboughtTomes: [{ id: 10, isHorsSerie: false, number: 1 }],
+    });
+    renderWithComics([series]);
+
+    const detailLink = screen.getByRole("link", { name: /détail/i });
+    expect(detailLink).toHaveAttribute("href", "/comic/42");
+  });
+
+  it("shows Amazon link when amazonUrl exists", () => {
+    const series = createMockComicSeries({
+      amazonUrl: "https://amazon.fr/bleach",
+      id: 1,
+      title: "Bleach",
+      type: "manga",
+      unboughtTomes: [{ id: 10, isHorsSerie: false, number: 1 }],
+    });
+    renderWithComics([series]);
+
+    const amazonLink = screen.getByRole("link", { name: /amazon/i });
+    expect(amazonLink).toHaveAttribute("href", "https://amazon.fr/bleach");
+  });
+
+  it("hides Amazon link when no amazonUrl", () => {
+    const series = createMockComicSeries({
+      amazonUrl: null,
+      id: 1,
+      title: "Bleach",
+      type: "manga",
+      unboughtTomes: [{ id: 10, isHorsSerie: false, number: 1 }],
+    });
+    renderWithComics([series]);
+
+    expect(screen.queryByRole("link", { name: /amazon/i })).not.toBeInTheDocument();
+  });
+
+  it("calls PATCH endpoint on badge click", async () => {
+    const user = userEvent.setup();
+    let patchCalled = false;
+    const series = createMockComicSeries({
+      id: 1,
+      title: "Solo",
+      type: "manga",
+      unboughtTomes: [
+        { id: 10, isHorsSerie: false, number: 2 },
+        { id: 20, isHorsSerie: false, number: 3 },
+      ],
+    });
+
+    server.use(
+      http.patch("*/api/tomes/10", () => {
+        patchCalled = true;
+        return HttpResponse.json({ id: 10, bought: true });
+      }),
+      http.get("*/api/comic_series", () =>
+        HttpResponse.json(createMockHydraCollection([{
+          ...series,
+          unboughtTomes: [{ id: 20, isHorsSerie: false, number: 3 }],
+        }]))),
+    );
+
+    renderWithComics([series]);
+
+    const badge = screen.getByRole("button", { name: "Marquer le tome 2 comme acheté" });
+    await user.click(badge);
+
+    await waitFor(() => {
+      expect(patchCalled).toBe(true);
+    });
   });
 
   it("excludes finished series", () => {
-    const series = makeSeries(1, "Naruto", {
+    const series = createMockComicSeries({
       status: "finished",
-      unboughtTomeNumbers: [1],
+      unboughtTomes: [{ id: 10, isHorsSerie: false, number: 1 }],
     });
     renderWithComics([series]);
-    expect(screen.queryByText("Naruto")).not.toBeInTheDocument();
     expect(screen.getByText("Rien à acheter")).toBeInTheDocument();
   });
 
   it("excludes one-shots", () => {
-    const series = makeSeries(1, "Akira", {
+    const series = createMockComicSeries({
       isOneShot: true,
-      unboughtTomeNumbers: [1],
+      unboughtTomes: [{ id: 10, isHorsSerie: false, number: 1 }],
     });
     renderWithComics([series]);
-    expect(screen.queryByText("Akira")).not.toBeInTheDocument();
-  });
-
-  it("excludes series with all tomes bought", () => {
-    const series = makeSeries(1, "Bleach", {
-      unboughtTomeNumbers: [],
-    });
-    renderWithComics([series]);
-    expect(screen.queryByText("Bleach")).not.toBeInTheDocument();
-  });
-
-  it("sorts series by title", () => {
-    const series = [
-      makeSeries(1, "Zetman", { unboughtTomeNumbers: [1] }),
-      makeSeries(2, "Akira Toriyama", { unboughtTomeNumbers: [1] }),
-    ];
-    renderWithComics(series);
-    // Les liens de la grille (après la section hero) sont triés par titre
-    const gridLinks = screen.getByTestId("virtual-grid").querySelectorAll("a");
-    expect(gridLinks[0]).toHaveTextContent("Akira Toriyama");
-    expect(gridLinks[1]).toHaveTextContent("Zetman");
-  });
-
-  it("shows single tome as 'Prochain : T.X'", () => {
-    const series = makeSeries(1, "Solo", {
-      unboughtTomeNumbers: [2],
-    });
-    renderWithComics([series]);
-    expect(screen.getAllByText("Prochain : T.2")[0]).toBeInTheDocument();
+    expect(screen.getByText("Rien à acheter")).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/unit/components/ShelfRow.test.tsx
+++ b/frontend/src/__tests__/unit/components/ShelfRow.test.tsx
@@ -33,7 +33,7 @@ const mockComic = (id: number, title: string): ComicSeries => ({
   title,
   tomesCount: 3,
   type: "manga",
-  unboughtTomeNumbers: [],
+  unboughtTomes: [],
   updatedAt: "2026-01-01T00:00:00+00:00",
 });
 

--- a/frontend/src/__tests__/unit/components/ShelfView.test.tsx
+++ b/frontend/src/__tests__/unit/components/ShelfView.test.tsx
@@ -33,7 +33,7 @@ const mockComic = (id: number, title: string, status: string): ComicSeries => ({
   title,
   tomesCount: 3,
   type: "manga",
-  unboughtTomeNumbers: [],
+  unboughtTomes: [],
   updatedAt: "2026-01-01T00:00:00+00:00",
 });
 

--- a/frontend/src/__tests__/unit/utils/releaseUtils.test.ts
+++ b/frontend/src/__tests__/unit/utils/releaseUtils.test.ts
@@ -31,7 +31,7 @@ function makeComic(overrides: Partial<ComicSeries> = {}): ComicSeries {
     title: "Test",
     tomesCount: 0,
     type: ComicType.MANGA,
-    unboughtTomeNumbers: [],
+    unboughtTomes: [],
     updatedAt: "2024-01-01T00:00:00+00:00",
     ...overrides,
   };

--- a/frontend/src/__tests__/unit/utils/toBuyUtils.test.tsx
+++ b/frontend/src/__tests__/unit/utils/toBuyUtils.test.tsx
@@ -1,53 +1,37 @@
-import type { ComicSeries } from "../../../types/api";
+import { describe, expect, it } from "vitest";
+import { createMockComicSeries } from "../../helpers/factories";
 import { filterSeriesToBuy, formatTomeRanges, getNextTomesToBuy } from "../../../utils/toBuyUtils";
 
-function makeSeries(overrides: Partial<ComicSeries> = {}): ComicSeries {
-  return {
-    "@id": "/api/comics/1",
-    authors: [],
-    boughtCount: 0,
-    coveredCount: 0,
-    coverImage: null,
-    coverUrl: null,
-    createdAt: "2024-01-01T00:00:00+00:00",
-    defaultTomeBought: true,
-    defaultTomeDownloaded: false,
-    defaultTomeRead: false,
-    description: null,
-    downloadedCount: 0,
-    id: 1,
-    isOneShot: false,
-    latestPublishedIssue: null,
-    latestPublishedIssueComplete: false,
-    latestPublishedIssueUpdatedAt: null,
-    maxTomeNumber: null,
-    publishedDate: null,
-    publisher: null,
-    readCount: 0,
-    status: "buying",
-    title: "Test Series",
-    tomesCount: 0,
-    type: "manga",
-    unboughtTomeNumbers: [],
-    updatedAt: "2024-01-01T00:00:00+00:00",
-    ...overrides,
-  };
-}
-
 describe("getNextTomesToBuy", () => {
-  it("returns empty array when all tomes are bought", () => {
-    const series = makeSeries({ unboughtTomeNumbers: [] });
+  it("returns empty array when no unbought tomes", () => {
+    const series = createMockComicSeries({ unboughtTomes: [] });
     expect(getNextTomesToBuy(series)).toEqual([]);
   });
 
-  it("returns unbought tome numbers sorted", () => {
-    const series = makeSeries({ unboughtTomeNumbers: [3, 2] });
-    expect(getNextTomesToBuy(series)).toEqual([2, 3]);
+  it("returns unbought tomes sorted by number", () => {
+    const series = createMockComicSeries({
+      unboughtTomes: [
+        { id: 30, isHorsSerie: false, number: 3 },
+        { id: 20, isHorsSerie: false, number: 2 },
+      ],
+    });
+    const result = getNextTomesToBuy(series);
+    expect(result).toEqual([
+      { id: 20, isHorsSerie: false, number: 2 },
+      { id: 30, isHorsSerie: false, number: 3 },
+    ]);
   });
 
-  it("returns empty array when series has no tomes", () => {
-    const series = makeSeries({ unboughtTomeNumbers: [] });
-    expect(getNextTomesToBuy(series)).toEqual([]);
+  it("places hors-série after regular tomes", () => {
+    const series = createMockComicSeries({
+      unboughtTomes: [
+        { id: 200, isHorsSerie: true, number: 1 },
+        { id: 100, isHorsSerie: false, number: 1 },
+      ],
+    });
+    const result = getNextTomesToBuy(series);
+    expect(result[0].isHorsSerie).toBe(false);
+    expect(result[1].isHorsSerie).toBe(true);
   });
 });
 
@@ -79,36 +63,31 @@ describe("formatTomeRanges", () => {
 
 describe("filterSeriesToBuy", () => {
   it("includes buying series with unbought tomes", () => {
-    const series = makeSeries({
+    const series = createMockComicSeries({
       status: "buying",
-      unboughtTomeNumbers: [1],
+      unboughtTomes: [{ id: 1, isHorsSerie: false, number: 1 }],
     });
     expect(filterSeriesToBuy([series])).toEqual([series]);
   });
 
   it("excludes non-buying series", () => {
-    const series = makeSeries({
+    const series = createMockComicSeries({
       status: "finished",
-      unboughtTomeNumbers: [1],
+      unboughtTomes: [{ id: 1, isHorsSerie: false, number: 1 }],
     });
     expect(filterSeriesToBuy([series])).toEqual([]);
   });
 
   it("excludes one-shots", () => {
-    const series = makeSeries({
+    const series = createMockComicSeries({
       isOneShot: true,
-      unboughtTomeNumbers: [1],
+      unboughtTomes: [{ id: 1, isHorsSerie: false, number: 1 }],
     });
     expect(filterSeriesToBuy([series])).toEqual([]);
   });
 
   it("excludes series with all tomes bought", () => {
-    const series = makeSeries({ unboughtTomeNumbers: [] });
-    expect(filterSeriesToBuy([series])).toEqual([]);
-  });
-
-  it("excludes series with no tomes", () => {
-    const series = makeSeries({ unboughtTomeNumbers: [] });
+    const series = createMockComicSeries({ unboughtTomes: [] });
     expect(filterSeriesToBuy([series])).toEqual([]);
   });
 });

--- a/frontend/src/hooks/useBuyTome.ts
+++ b/frontend/src/hooks/useBuyTome.ts
@@ -1,0 +1,56 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { endpoints } from "../endpoints";
+import { queryKeys } from "../queryKeys";
+import { apiFetch } from "../services/api";
+import type { ComicSeries, HydraCollection, Tome } from "../types/api";
+
+/**
+ * Marque un tome comme acheté via PATCH et met à jour la liste optimistiquement.
+ */
+export function useBuyTome() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    Tome,
+    Error,
+    { seriesId: number; tomeId: number },
+    { previousData: HydraCollection<ComicSeries> | undefined }
+  >({
+    mutationFn: ({ tomeId }) =>
+      apiFetch<Tome>(endpoints.tomes.detail(tomeId), {
+        body: JSON.stringify({ bought: true }),
+        headers: { "Content-Type": "application/merge-patch+json" },
+        method: "PATCH",
+      }),
+    onError: (_err, _variables, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(queryKeys.comics.all, context.previousData);
+      }
+    },
+    onMutate: (variables) => {
+      queryClient.cancelQueries({ queryKey: queryKeys.comics.all });
+
+      const previousData = queryClient.getQueryData<HydraCollection<ComicSeries>>(queryKeys.comics.all);
+
+      queryClient.setQueryData<HydraCollection<ComicSeries>>(queryKeys.comics.all, (old) => {
+        if (!old) return old;
+        const idx = old.member.findIndex((s) => s.id === variables.seriesId);
+        if (idx === -1) return old;
+        const updated = [...old.member];
+        updated[idx] = {
+          ...updated[idx],
+          unboughtTomes: updated[idx].unboughtTomes.filter((t) => t.id !== variables.tomeId),
+        };
+        return { ...old, member: updated };
+      });
+
+      return { previousData };
+    },
+    onSettled: () => {
+      // Marquer comme stale sans refetch immédiat — l'optimistic update suffit.
+      // Le refetch se fera au prochain focus ou navigation.
+      queryClient.invalidateQueries({ queryKey: queryKeys.comics.all, refetchType: "none" });
+      queryClient.invalidateQueries({ queryKey: queryKeys.comics.detailPrefix, refetchType: "none" });
+    },
+  });
+}

--- a/frontend/src/hooks/useCreateComic.ts
+++ b/frontend/src/hooks/useCreateComic.ts
@@ -48,7 +48,7 @@ export function useCreateComic() {
           title: variables.title ?? "",
           tomesCount: 0,
           type: variables.type ?? ComicType.BD,
-          unboughtTomeNumbers: [],
+          unboughtTomes: [],
           updatedAt: new Date().toISOString(),
         };
         return {

--- a/frontend/src/pages/ToBuy.tsx
+++ b/frontend/src/pages/ToBuy.tsx
@@ -1,89 +1,55 @@
-import { Filter, Loader2, Search, ShoppingCart } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
-import { Link, useSearchParams } from "react-router-dom";
-import ComicCard from "../components/ComicCard";
-import ComicCardSkeleton from "../components/ComicCardSkeleton";
+import { ExternalLink, Eye, Loader2, Search, ShoppingCart } from "lucide-react";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { Link } from "react-router-dom";
 import CoverImage from "../components/CoverImage";
 import EmptyState from "../components/EmptyState";
-import FilterChips from "../components/FilterChips";
-import Filters from "../components/Filters";
 import SearchInput from "../components/SearchInput";
-import VirtualGrid from "../components/VirtualGrid";
+import { useBuyTome } from "../hooks/useBuyTome";
 import { useComics } from "../hooks/useComics";
 import { useDebounce } from "../hooks/useDebounce";
-import { useMediaQuery } from "../hooks/useMediaQuery";
-import { ComicTypePlaceholder } from "../types/enums";
+import type { ComicSeries } from "../types/api";
+import { ComicTypeLabel, ComicTypePlaceholder } from "../types/enums";
+import type { ComicType } from "../types/enums";
 import { getCoverSrc, getCoverThumbnailSrc } from "../utils/coverUtils";
 import { searchComics } from "../utils/searchComics";
-import { sortComics } from "../utils/sortComics";
-import type { SortOption } from "../utils/sortComics";
 import { filterSeriesToBuy, formatTomeRanges, getNextTomesToBuy } from "../utils/toBuyUtils";
 
 const HERO_COUNT = 10;
 
-const VALID_SORTS: Set<string> = new Set([
-  "createdAt-asc",
-  "createdAt-desc",
-  "title-asc",
-  "title-desc",
-  "tomes-asc",
-  "tomes-desc",
-]);
+/** Ordre d'affichage des types. */
+const TYPE_ORDER: ComicType[] = ["manga", "bd", "comics", "livre"];
 
 export default function ToBuy() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const type = searchParams.get("type") ?? "";
-  const status = searchParams.get("status") ?? "";
-  const sortParam = searchParams.get("sort") ?? "";
-  const sort: SortOption = VALID_SORTS.has(sortParam) ? (sortParam as SortOption) : "title-asc";
-
   const { data, isFetching, isLoading } = useComics();
   const allComics = data?.member ?? [];
 
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebounce(search, 300);
-  const isMobile = useMediaQuery("(max-width: 639px)");
 
-  const updateParam = useCallback(
-    (key: string, value: string) => {
-      setSearchParams(
-        (prev) => {
-          const next = new URLSearchParams(prev);
-          if (value) {
-            next.set(key, value);
-          } else {
-            next.delete(key);
-          }
-          return next;
-        },
-        { replace: true },
-      );
-    },
-    [setSearchParams],
-  );
-
-  const handleSearchChange = useCallback((v: string) => setSearch(v), []);
-  const handleStatusChange = useCallback((v: string) => updateParam("status", v), [updateParam]);
-  const handleTypeChange = useCallback((v: string) => updateParam("type", v), [updateParam]);
-  const handleSortChange = useCallback(
-    (v: SortOption) => updateParam("sort", v === "title-asc" ? "" : v),
-    [updateParam],
-  );
+  const buyTome = useBuyTome();
+  const buyTomeRef = useRef(buyTome);
+  buyTomeRef.current = buyTome;
 
   const toBuyComics = useMemo(() => filterSeriesToBuy(allComics), [allComics]);
 
   const filtered = useMemo(() => {
-    const preFiltered = toBuyComics.filter((c) => {
-      if (type && c.type !== type) return false;
-      if (status && c.status !== status) return false;
-      return true;
-    });
-    const searched = searchComics(preFiltered, debouncedSearch);
-    return sortComics(searched, sort).map((comic) => ({
-      comic,
-      nextTomes: formatTomeRanges(getNextTomesToBuy(comic)),
-    }));
-  }, [toBuyComics, debouncedSearch, sort, type, status]);
+    return searchComics(toBuyComics, debouncedSearch);
+  }, [toBuyComics, debouncedSearch]);
+
+  /** Séries groupées par type, triées A-Z dans chaque groupe. */
+  const groupedByType = useMemo(() => {
+    const groups = new Map<ComicType, ComicSeries[]>();
+    for (const comic of filtered) {
+      const type = comic.type as ComicType;
+      if (!groups.has(type)) groups.set(type, []);
+      groups.get(type)!.push(comic);
+    }
+    // Tri A-Z dans chaque groupe
+    for (const list of groups.values()) {
+      list.sort((a, b) => a.title.localeCompare(b.title, "fr"));
+    }
+    return groups;
+  }, [filtered]);
 
   const recentlyAdded = useMemo(() => {
     if (toBuyComics.length === 0) return [];
@@ -92,21 +58,15 @@ export default function ToBuy() {
       .slice(0, HERO_COUNT);
   }, [toBuyComics]);
 
-  const handleResetFilters = useCallback(() => {
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        next.delete("type");
-        next.delete("status");
-        next.delete("sort");
-        return next;
-      },
-      { replace: true },
-    );
-  }, [setSearchParams]);
+  const handleSearchChange = useCallback((v: string) => setSearch(v), []);
+  const handleBuyTome = useCallback(
+    (seriesId: number, tomeId: number) => {
+      buyTomeRef.current.mutate({ seriesId, tomeId });
+    },
+    [],
+  );
 
-  const hasActiveFilters = !!type || !!status;
-  const showHero = !isLoading && !debouncedSearch && !hasActiveFilters && recentlyAdded.length > 0;
+  const showHero = !isLoading && !debouncedSearch && recentlyAdded.length > 0;
 
   return (
     <div className="space-y-4">
@@ -119,6 +79,8 @@ export default function ToBuy() {
           <div className="-mx-4 flex snap-x snap-mandatory gap-4 overflow-x-auto px-4 pb-2 scrollbar-none">
             {recentlyAdded.map((comic) => {
               const src = getCoverThumbnailSrc(comic) ?? getCoverSrc(comic);
+              const tomes = getNextTomesToBuy(comic);
+              const regularNumbers = tomes.filter((t) => !t.isHorsSerie).map((t) => t.number);
               return (
                 <Link
                   className="group flex w-[140px] shrink-0 snap-center flex-col gap-1.5 sm:w-[160px]"
@@ -126,7 +88,8 @@ export default function ToBuy() {
                   to={`/comic/${comic.id}`}
                   viewTransition
                 >
-                  <div className="card-glow overflow-hidden rounded-xl transition-transform duration-200 group-hover:-translate-y-1 group-hover:scale-[1.02]"
+                  <div
+                    className="card-glow overflow-hidden rounded-xl transition-transform duration-200 group-hover:-translate-y-1 group-hover:scale-[1.02]"
                     style={{ ["--glow-rgb" as string]: "99, 102, 241" }}
                   >
                     <CoverImage
@@ -142,7 +105,7 @@ export default function ToBuy() {
                     {comic.title}
                   </h3>
                   <p className="font-mono-stats text-xs text-accent-sage">
-                    Prochain : {formatTomeRanges(getNextTomesToBuy(comic))}
+                    Prochain : {formatTomeRanges(regularNumbers)}
                   </p>
                 </Link>
               );
@@ -162,19 +125,9 @@ export default function ToBuy() {
         </div>
       )}
 
-      {/* Search + filters */}
+      {/* Search */}
       <div className="flex items-center gap-2">
         <SearchInput onChange={handleSearchChange} value={search} />
-        {isMobile && (
-          <Filters
-            onSortChange={handleSortChange}
-            onStatusChange={handleStatusChange}
-            onTypeChange={handleTypeChange}
-            sort={sort}
-            status={status}
-            type={type}
-          />
-        )}
         <span className="flex shrink-0 items-center gap-1.5 font-mono-stats text-sm text-text-muted">
           {isFetching && !isLoading && (
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -183,32 +136,15 @@ export default function ToBuy() {
         </span>
       </div>
 
-      {/* Quick filter chips */}
-      <FilterChips
-        onStatusChange={handleStatusChange}
-        onTypeChange={handleTypeChange}
-        status={status}
-        type={type}
-      />
-
-      {/* Desktop filters */}
-      {!isMobile && (
-        <div className="flex min-w-0 items-center gap-3">
-          <Filters
-            onSortChange={handleSortChange}
-            onStatusChange={handleStatusChange}
-            onTypeChange={handleTypeChange}
-            sort={sort}
-            status={status}
-            type={type}
-          />
-        </div>
-      )}
-
+      {/* Contenu */}
       {isLoading ? (
-        <div className="grid grid-cols-2 gap-5 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-          {Array.from({ length: 8 }, (_, i) => (
-            <ComicCardSkeleton key={i} />
+        <div className="space-y-6">
+          {Array.from({ length: 3 }, (_, i) => (
+            <div className="animate-pulse space-y-3" key={i}>
+              <div className="h-5 w-20 rounded bg-surface-elevated" />
+              <div className="h-12 rounded bg-surface-elevated" />
+              <div className="h-12 rounded bg-surface-elevated" />
+            </div>
           ))}
         </div>
       ) : filtered.length === 0 ? (
@@ -216,13 +152,6 @@ export default function ToBuy() {
           <EmptyState
             icon={Search}
             title={`Aucun résultat pour « ${debouncedSearch} »`}
-          />
-        ) : hasActiveFilters ? (
-          <EmptyState
-            actionLabel="Réinitialiser les filtres"
-            icon={Filter}
-            onAction={handleResetFilters}
-            title="Aucune série avec ces filtres"
           />
         ) : (
           <EmptyState
@@ -232,18 +161,121 @@ export default function ToBuy() {
           />
         )
       ) : (
-        <VirtualGrid
-          items={filtered}
-          renderItem={({ comic, nextTomes }) => (
-            <>
-              <ComicCard comic={comic} />
-              <p className="mt-1 truncate px-1 text-xs text-accent-sage">
-                Prochain : {nextTomes}
-              </p>
-            </>
-          )}
-        />
+        <div className="space-y-6">
+          {TYPE_ORDER.filter((type) => groupedByType.has(type)).map((type) => (
+            <section data-testid={`type-section-${type}`} key={type}>
+              <h2 className="mb-3 font-display text-base font-semibold text-text-primary">
+                {ComicTypeLabel[type]}{" "}
+                <span className="text-sm font-normal text-text-muted">
+                  ({groupedByType.get(type)!.length})
+                </span>
+              </h2>
+              <div className="space-y-2">
+                {groupedByType.get(type)!.map((comic) => (
+                  <SeriesRow
+                    comic={comic}
+                    key={comic.id}
+                    onBuyTome={handleBuyTome}
+                  />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
       )}
     </div>
   );
 }
+
+interface SeriesRowProps {
+  comic: ComicSeries;
+  onBuyTome: (seriesId: number, tomeId: number) => void;
+}
+
+const SeriesRow = memo(function SeriesRow({ comic, onBuyTome }: SeriesRowProps) {
+  const src = getCoverThumbnailSrc(comic) ?? getCoverSrc(comic);
+  const tomes = getNextTomesToBuy(comic);
+
+  return (
+    <div className="flex items-start gap-3 rounded-xl bg-surface-elevated/50 p-3 dark:bg-white/[0.03]">
+      {/* Couverture miniature */}
+      <Link className="shrink-0" to={`/comic/${comic.id}`} viewTransition>
+        <CoverImage
+          alt={comic.title}
+          className="aspect-[3/4] w-10 rounded-md"
+          fallbackSrc={ComicTypePlaceholder[comic.type]}
+          height={60}
+          src={src ?? ComicTypePlaceholder[comic.type]}
+          width={40}
+        />
+      </Link>
+
+      {/* Contenu */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <h3
+            className="truncate font-display text-sm font-medium text-text-primary"
+            data-testid="series-title"
+          >
+            {comic.title}
+          </h3>
+
+          {/* Actions rapides */}
+          <div className="ml-auto flex shrink-0 items-center gap-1.5">
+            <Link
+              aria-label="Voir le détail"
+              className="rounded-md p-1 text-text-muted transition hover:bg-surface-border hover:text-text-primary dark:hover:bg-white/10"
+              to={`/comic/${comic.id}`}
+              viewTransition
+            >
+              <Eye className="h-4 w-4" />
+            </Link>
+            {comic.amazonUrl && (
+              <a
+                aria-label="Voir sur Amazon"
+                className="rounded-md p-1 text-text-muted transition hover:bg-surface-border hover:text-text-primary dark:hover:bg-white/10"
+                href={comic.amazonUrl}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <ExternalLink className="h-4 w-4" />
+              </a>
+            )}
+          </div>
+        </div>
+
+        {/* Badges des tomes */}
+        <div className="mt-1.5 flex flex-wrap gap-1.5">
+          {tomes.map((tome) => (
+            <TomeBadge
+              isHorsSerie={tome.isHorsSerie}
+              key={tome.id}
+              number={tome.number}
+              onBuy={() => onBuyTome(comic.id, tome.id)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+interface TomeBadgeProps {
+  isHorsSerie: boolean;
+  number: number;
+  onBuy: () => void;
+}
+
+const TomeBadge = memo(function TomeBadge({ isHorsSerie, number, onBuy }: TomeBadgeProps) {
+  const label = isHorsSerie ? `HS ${number}` : `${number}`;
+  return (
+    <button
+      aria-label={`Marquer le tome ${label} comme acheté`}
+      className="cursor-pointer rounded-full bg-primary-100 px-2.5 py-0.5 font-mono-stats text-xs font-semibold text-primary-700 transition active:scale-90 dark:bg-primary-950/30 dark:text-primary-300"
+      onClick={onBuy}
+      type="button"
+    >
+      {label}
+    </button>
+  );
+});

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -77,7 +77,7 @@ export interface ComicSeries {
   tomes?: Tome[];
   tomesCount: number;
   type: ComicType;
-  unboughtTomeNumbers: number[];
+  unboughtTomes: Array<{ id: number; isHorsSerie: boolean; number: number }>;
   updatedAt: string;
 }
 

--- a/frontend/src/utils/toBuyUtils.ts
+++ b/frontend/src/utils/toBuyUtils.ts
@@ -1,7 +1,12 @@
 import type { ComicSeries } from "../types/api";
 
-export function getNextTomesToBuy(series: ComicSeries): number[] {
-  return [...series.unboughtTomeNumbers].sort((a, b) => a - b);
+type UnboughtTome = ComicSeries["unboughtTomes"][number];
+
+export function getNextTomesToBuy(series: ComicSeries): UnboughtTome[] {
+  return [...series.unboughtTomes].sort((a, b) => {
+    if (a.isHorsSerie !== b.isHorsSerie) return a.isHorsSerie ? 1 : -1;
+    return a.number - b.number;
+  });
 }
 
 /**
@@ -31,6 +36,6 @@ export function formatTomeRanges(numbers: number[]): string {
 
 export function filterSeriesToBuy(series: ComicSeries[]): ComicSeries[] {
   return series.filter(
-    (s) => s.status === "buying" && !s.isOneShot && s.unboughtTomeNumbers.length > 0,
+    (s) => s.status === "buying" && !s.isOneShot && s.unboughtTomes.length > 0,
   );
 }


### PR DESCRIPTION
## Summary

- Refonte de la page « À acheter » : regroupement par type, badges individuels par tome, one-tap achat via PATCH avec feedback optimiste
- Backend : `getUnboughtTomes()` retourne `[{id, number, isHorsSerie}]` au lieu de `unboughtTomeNumbers: int[]`
- Nouveau hook `useBuyTome` avec optimistic update ciblé (seule la série modifiée re-render)
- Layout compact optimisé pour usage à une main en librairie

## Test plan

- [x] Backend : 3 tests unitaires `getUnboughtTomes()` (regular, hors-série, all bought)
- [x] Frontend : 11 tests intégration ToBuy (grouping, badges, HS prefix, sorting, actions, PATCH, empty states)
- [x] PHPStan level 9 clean, CS Fixer clean, tsc --noEmit clean
- [x] 1123 backend + 930 frontend tests pass

Fixes #427