### PR TITLE
Corrige les freezes causés par la persistance du cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 - **HeroCarousel sur la page d'accueil** : la section « Récemment ajoutés » est remplacée par « Continuer la lecture »
 
+### Fixed
+
+- **Freezes de l'interface** : persistance IndexedDB du cache déplacée hors du thread principal via `requestIdleCallback`, detail queries retirées de la déhydratation (doublon avec la collection), seeding par lot au lieu de N appels individuels
+
 ## [v2.23.0] - 2026-03-26
 
 ### Added

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -136,8 +136,7 @@ export default function App() {
           persistOptions={{
             dehydrateOptions: {
               shouldDehydrateQuery: (query) => {
-                const key = query.queryKey[0];
-                return key === queryKeys.comics.all[0] || key === queryKeys.comics.detailPrefix[0];
+                return query.queryKey[0] === queryKeys.comics.all[0];
               },
             },
             maxAge: 60 * 60 * 1000,

--- a/frontend/src/__tests__/integration/hooks/useComics.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useComics.test.tsx
@@ -113,4 +113,33 @@ describe("useComics", () => {
     const cachedComic = queryClient.getQueryData(queryKeys.comics.detail(42));
     expect(cachedComic).toEqual(series);
   });
+
+  it("seeds detail cache for multiple series without using queryClient.setQueryData", async () => {
+    const series1 = createMockComicSeries({ id: 1, title: "Naruto" });
+    const series2 = createMockComicSeries({ id: 2, title: "One Piece" });
+    const series3 = createMockComicSeries({ id: 3, title: "Bleach" });
+
+    server.use(
+      http.get("/api/comic_series", () =>
+        HttpResponse.json(createMockHydraCollection([series1, series2, series3])),
+      ),
+    );
+
+    const queryClient = createTestQueryClient();
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useComics(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // All 3 series should be seeded in detail cache
+    expect(queryClient.getQueryData(queryKeys.comics.detail(1))).toEqual(series1);
+    expect(queryClient.getQueryData(queryKeys.comics.detail(2))).toEqual(series2);
+    expect(queryClient.getQueryData(queryKeys.comics.detail(3))).toEqual(series3);
+  });
 });

--- a/frontend/src/__tests__/unit/queryClient.test.ts
+++ b/frontend/src/__tests__/unit/queryClient.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from "vitest";
-import { queryClient } from "../../queryClient";
+import { describe, expect, it, vi } from "vitest";
+import type { PersistedClient } from "@tanstack/react-query-persist-client";
+
+let storedValue: PersistedClient | undefined;
+vi.mock("idb-keyval", () => ({
+  del: vi.fn(async () => { storedValue = undefined; }),
+  get: vi.fn(async () => storedValue),
+  set: vi.fn(async (_key: unknown, value: PersistedClient) => { storedValue = value; }),
+}));
+
+// Import after mock
+const { persister, queryClient } = await import("../../queryClient");
 
 describe("queryClient default options", () => {
   it("has correct query defaults", () => {
@@ -16,5 +26,66 @@ describe("queryClient default options", () => {
     const defaults = queryClient.getDefaultOptions().mutations;
 
     expect(defaults?.networkMode).toBe("offlineFirst");
+  });
+});
+
+describe("persister", () => {
+  beforeEach(() => {
+    storedValue = undefined;
+  });
+
+  it("defers persistClient off main thread (does not block synchronously)", async () => {
+    vi.useFakeTimers();
+
+    const mockClient: PersistedClient = {
+      buster: "",
+      clientState: { mutations: [], queries: [] },
+      timestamp: Date.now(),
+    };
+
+    // persistClient should return a promise that resolves after idle scheduling
+    const promise = persister.persistClient(mockClient);
+
+    // Advance timers to trigger the setTimeout fallback (jsdom has no requestIdleCallback)
+    await vi.advanceTimersByTimeAsync(10);
+
+    await promise;
+
+    vi.useRealTimers();
+  });
+
+  it("strips non-cloneable values via JSON round-trip before writing to IndexedDB", async () => {
+    vi.useFakeTimers();
+    const { set } = await import("idb-keyval");
+
+    const mockClient: PersistedClient = {
+      buster: "",
+      clientState: {
+        mutations: [],
+        queries: [{
+          queryHash: "[\"test\"]",
+          queryKey: ["test"],
+          state: { data: "hello" } as never,
+        }],
+      },
+      timestamp: Date.now(),
+    };
+
+    const promise = persister.persistClient(mockClient);
+    await vi.advanceTimersByTimeAsync(10);
+    await promise;
+
+    // Verify set was called with a clean object (JSON round-tripped)
+    expect(set).toHaveBeenCalledWith(
+      "bibliotheque-query-cache",
+      expect.objectContaining({ buster: "" }),
+    );
+
+    // Verify the stored value is retrievable
+    const restored = await persister.restoreClient();
+    expect(restored).toBeDefined();
+    expect(restored?.clientState.queries[0].state.data).toBe("hello");
+
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/hooks/useComics.ts
+++ b/frontend/src/hooks/useComics.ts
@@ -4,6 +4,20 @@ import { queryKeys } from "../queryKeys";
 import { apiFetch } from "../services/api";
 import type { ComicSeries, HydraCollection } from "../types/api";
 
+/**
+ * Seed le cache détail de chaque série sans déclencher N notifications individuelles.
+ * Écrit directement dans le QueryCache pour éviter les cascades de persist.
+ */
+function seedDetailCache(queryClient: ReturnType<typeof useQueryClient>, members: ComicSeries[]): void {
+  const cache = queryClient.getQueryCache();
+  for (const series of members) {
+    const query = cache.build(queryClient, {
+      queryKey: queryKeys.comics.detail(series.id),
+    });
+    query.setData(series);
+  }
+}
+
 export function useComics() {
   const queryClient = useQueryClient();
 
@@ -11,10 +25,7 @@ export function useComics() {
     queryFn: async () => {
       const data =
         await apiFetch<HydraCollection<ComicSeries>>(endpoints.comicSeries.collection);
-      // Seeder le cache individuel pour la navigation hors ligne
-      data.member.forEach((series) => {
-        queryClient.setQueryData(queryKeys.comics.detail(series.id), series);
-      });
+      seedDetailCache(queryClient, data.member);
       return data;
     },
     queryKey: queryKeys.comics.all,

--- a/frontend/src/queryClient.ts
+++ b/frontend/src/queryClient.ts
@@ -2,6 +2,12 @@ import { QueryClient } from "@tanstack/react-query";
 import type { PersistedClient, Persister } from "@tanstack/react-query-persist-client";
 import { del, get, set } from "idb-keyval";
 
+// Safari < 16.4 fallback
+const scheduleIdle: typeof requestIdleCallback =
+  typeof requestIdleCallback === "function"
+    ? requestIdleCallback
+    : (cb) => setTimeout(cb, 1) as unknown as number;
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -19,10 +25,16 @@ export const queryClient = new QueryClient({
 
 function createIDBPersister(idbValidKey: IDBValidKey = "reactQuery"): Persister {
   return {
-    persistClient: async (client: PersistedClient) => {
+    persistClient: (client: PersistedClient) => {
+      // Schedule off main thread to avoid blocking renders.
       // JSON round-trip strips non-cloneable values (Promises from TanStack Query v5 suspense)
-      // that would cause DataCloneError with IndexedDB's structured clone algorithm
-      await set(idbValidKey, JSON.parse(JSON.stringify(client)) as PersistedClient);
+      // that would cause DataCloneError with IndexedDB's structured clone algorithm.
+      return new Promise<void>((resolve, reject) => {
+        scheduleIdle(() => {
+          const cleaned = JSON.parse(JSON.stringify(client)) as PersistedClient;
+          set(idbValidKey, cleaned).then(resolve, reject);
+        });
+      });
     },
     removeClient: async () => {
       await del(idbValidKey);


### PR DESCRIPTION
## Summary

- Déplace la sérialisation JSON + écriture IndexedDB dans `requestIdleCallback` (fallback `setTimeout` pour Safari < 16.4)
- Retire les detail queries de `shouldDehydrateQuery` — la collection est déjà persistée et seed les détails au restore
- Remplace le seeding `forEach`/`setQueryData` par `QueryCache.build()` + `query.setData()` pour éviter les cascades de persist

Fixes #434

## Test plan

- [x] 933 tests Vitest passent
- [x] `tsc --noEmit` clean
- [ ] Vérifier sur mobile (PWA) que la navigation ne freeze plus au retour d'onglet
- [ ] Vérifier que le cache offline fonctionne toujours (couper réseau, naviguer)