### PR TITLE
Supprime le polling inutile et optimise les requêtes IndexedDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 ### Fixed
 
 - **Freezes de l'interface** : persistance IndexedDB du cache déplacée hors du thread principal via `requestIdleCallback`, detail queries retirées de la déhydratation (doublon avec la collection), seeding par lot au lieu de N appels individuels
+- **Polling inutile** : `useSyncFailures` ne poll plus quand il n'y a aucun échec de synchronisation ; `getPendingCount` utilise les index IndexedDB au lieu de charger tous les enregistrements
 
 ## [v2.23.0] - 2026-03-26
 

--- a/frontend/src/__tests__/integration/hooks/useSyncFailures.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useSyncFailures.test.tsx
@@ -63,6 +63,29 @@ describe("useSyncFailures", () => {
     });
   });
 
+  it("stops polling when no failures exist", async () => {
+    const queryClient = createTestQueryClient();
+
+    const { result } = renderHook(() => useSyncFailures(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    // Wait for the query to have fetched at least once
+    await waitFor(() => {
+      const queries = queryClient.getQueryCache().findAll({ queryKey: ["syncFailures"] });
+      expect(queries[0]?.state.dataUpdateCount).toBeGreaterThanOrEqual(1);
+    });
+
+    const query = queryClient.getQueryCache().findAll({ queryKey: ["syncFailures"] })[0];
+    const fetchCount = query.state.dataUpdateCount;
+
+    // Wait longer than the 3s polling interval — no additional fetches should happen
+    await new Promise((r) => setTimeout(r, 4000));
+
+    expect(query.state.dataUpdateCount).toBe(fetchCount);
+    expect(result.current.failures).toEqual([]);
+  }, 10000);
+
   it("removes a failure", async () => {
     const id = await addSyncFailure({
       error: "Error",

--- a/frontend/src/hooks/useSyncFailures.ts
+++ b/frontend/src/hooks/useSyncFailures.ts
@@ -14,7 +14,10 @@ export function useSyncFailures() {
   const { data: failures = [] } = useQuery<SyncFailure[]>({
     queryFn: getSyncFailures,
     queryKey: queryKeys.offline.syncFailures,
-    refetchInterval: 3000,
+    refetchInterval: (query) => {
+      const count = query.state.data?.length ?? 0;
+      return count > 0 ? 3000 : false;
+    },
   });
 
   // Écouter les messages du SW pour rafraîchir immédiatement

--- a/frontend/src/services/offlineQueue.ts
+++ b/frontend/src/services/offlineQueue.ts
@@ -143,8 +143,9 @@ export async function clearQueue(): Promise<void> {
 
 export async function getPendingCount(): Promise<number> {
   const db = await getDb();
-  const all = await db.getAll("offlineQueue");
-  return all.filter((item) => item.status === "pending" || item.status === "failed").length;
+  const pending = await db.countFromIndex("offlineQueue", "by-status", "pending");
+  const failed = await db.countFromIndex("offlineQueue", "by-status", "failed");
+  return pending + failed;
 }
 
 export async function addSyncFailure(


### PR DESCRIPTION
## Summary

- `useSyncFailures` : arrête le polling 3s quand aucun échec de sync n'existe (même pattern que `usePendingQueueCount`)
- `getPendingCount` : utilise `countFromIndex` sur l'index `by-status` au lieu de `getAll` + filter JS

Fixes #435

## Test plan

- [x] 934 tests Vitest passent
- [x] `tsc --noEmit` clean
- [ ] Vérifier que les échecs de sync sont toujours détectés (SW message listener les signale)