### PR TITLE
Diffère queryClient.clear() pour éviter le freeze au logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 - **Freezes de l'interface** : persistance IndexedDB du cache déplacée hors du thread principal via `requestIdleCallback`, detail queries retirées de la déhydratation (doublon avec la collection), seeding par lot au lieu de N appels individuels
 - **Polling inutile** : `useSyncFailures` ne poll plus quand il n'y a aucun échec de synchronisation ; `getPendingCount` utilise les index IndexedDB au lieu de charger tous les enregistrements
+- **Freeze au logout** : `queryClient.clear()` différé via `setTimeout(0)` pour ne pas bloquer la navigation ou l'affichage du spinner
 
 ## [v2.23.0] - 2026-03-26
 

--- a/frontend/src/__tests__/integration/hooks/useAuth.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useAuth.test.tsx
@@ -167,7 +167,8 @@ describe("useAuth", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/login", { viewTransition: true });
   });
 
-  it("logout clears SW api-cache", () => {
+  it("logout clears SW api-cache after navigation", async () => {
+    vi.useFakeTimers();
     localStorage.setItem("jwt_token", "some-token");
 
     const { result } = renderHook(() => useAuth(), {
@@ -178,6 +179,12 @@ describe("useAuth", () => {
       result.current.logout();
     });
 
+    // Cache clearing is deferred via setTimeout(0) to avoid blocking navigation
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
     expect(caches.delete).toHaveBeenCalledWith("api-cache");
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -20,11 +20,14 @@ export function useAuth() {
   });
 
   const logout = useCallback(() => {
-    queryClient.clear();
-    del("bibliotheque-query-cache");
-    void caches.delete("api-cache");
     removeToken();
     navigate("/login", { viewTransition: true });
+    // Defer cache clearing — the user already sees the login page
+    setTimeout(() => {
+      queryClient.clear();
+      void del("bibliotheque-query-cache");
+      void caches.delete("api-cache");
+    }, 0);
   }, [navigate, queryClient]);
 
   return {

--- a/frontend/src/pages/Tools.tsx
+++ b/frontend/src/pages/Tools.tsx
@@ -65,6 +65,8 @@ export default function Tools() {
   const handleClearCache = async () => {
     setClearing(true);
     try {
+      // Yield to browser to paint spinner before synchronous clear
+      await new Promise((r) => setTimeout(r, 0));
       queryClient.clear();
       await del("bibliotheque-query-cache");
       await queryClient.refetchQueries();


### PR DESCRIPTION
## Summary

- `useAuth` : navigue vers `/login` d'abord, puis diffère `queryClient.clear()` + nettoyage IndexedDB/SW cache via `setTimeout(0)`
- `Tools` : yield au navigateur (`await setTimeout(0)`) avant `queryClient.clear()` pour afficher le spinner

Fixes #436

## Test plan

- [x] 934 tests Vitest passent
- [x] `tsc --noEmit` clean
- [ ] Vérifier que le logout ne freeze plus visuellement
- [ ] Vérifier que le bouton "Vider le cache" affiche le spinner immédiatement