### PR TITLE
Enrichissement — traçabilité du déclencheur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Added
+
+- **Enrichissement — traçabilité** : affichage de l'horodatage et du déclencheur (`via création`, `via mise à jour`, `via auto-enrich`) sur les propositions d'enrichissement
+
 ## [v2.24.0] - 2026-03-29
 
 ### Added

--- a/backend/migrations/Version20260329121945.php
+++ b/backend/migrations/Version20260329121945.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260329121945 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajoute le champ triggered_by sur enrichment_proposal';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE enrichment_proposal ADD triggered_by VARCHAR(100) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE enrichment_proposal DROP triggered_by');
+    }
+}

--- a/backend/src/Command/AutoEnrichCommand.php
+++ b/backend/src/Command/AutoEnrichCommand.php
@@ -124,6 +124,7 @@ final class AutoEnrichCommand extends Command
                             $result,
                             LookupMode::TITLE,
                             $sources,
+                            'command:auto-enrich',
                         );
 
                         $series->setLookupCompletedAt(new \DateTimeImmutable());

--- a/backend/src/Entity/EnrichmentProposal.php
+++ b/backend/src/Entity/EnrichmentProposal.php
@@ -96,6 +96,10 @@ class EnrichmentProposal
     #[Groups(['enrichment:read'])]
     private ProposalStatus $status;
 
+    #[ORM\Column(length: 100, nullable: true)]
+    #[Groups(['enrichment:read'])]
+    private ?string $triggeredBy = null;
+
     public function __construct(
         ComicSeries $comicSeries,
         EnrichmentConfidence $confidence,
@@ -103,6 +107,7 @@ class EnrichmentProposal
         EnrichableField $field,
         mixed $proposedValue,
         string $source,
+        ?string $triggeredBy = null,
     ) {
         $this->comicSeries = $comicSeries;
         $this->confidence = $confidence;
@@ -112,6 +117,7 @@ class EnrichmentProposal
         $this->proposedValue = $proposedValue;
         $this->source = $source;
         $this->status = ProposalStatus::PENDING;
+        $this->triggeredBy = $triggeredBy;
     }
 
     public function getComicSeries(): ComicSeries
@@ -162,6 +168,11 @@ class EnrichmentProposal
     public function getStatus(): ProposalStatus
     {
         return $this->status;
+    }
+
+    public function getTriggeredBy(): ?string
+    {
+        return $this->triggeredBy;
     }
 
     public function accept(): void

--- a/backend/src/EventListener/EnrichOnCreateListener.php
+++ b/backend/src/EventListener/EnrichOnCreateListener.php
@@ -38,7 +38,7 @@ final class EnrichOnCreateListener
             return;
         }
 
-        $this->messageBus->dispatch(new EnrichSeriesMessage($id));
+        $this->messageBus->dispatch(new EnrichSeriesMessage($id, 'event:create'));
     }
 
     public static function disable(): void

--- a/backend/src/EventListener/ReEnrichOnUpdateListener.php
+++ b/backend/src/EventListener/ReEnrichOnUpdateListener.php
@@ -45,6 +45,6 @@ final readonly class ReEnrichOnUpdateListener
             return;
         }
 
-        $this->messageBus->dispatch(new EnrichSeriesMessage($id));
+        $this->messageBus->dispatch(new EnrichSeriesMessage($id, 'event:update'));
     }
 }

--- a/backend/src/Message/EnrichSeriesMessage.php
+++ b/backend/src/Message/EnrichSeriesMessage.php
@@ -11,6 +11,7 @@ final readonly class EnrichSeriesMessage
 {
     public function __construct(
         public int $seriesId,
+        public ?string $triggeredBy = null,
     ) {
     }
 }

--- a/backend/src/MessageHandler/EnrichSeriesHandler.php
+++ b/backend/src/MessageHandler/EnrichSeriesHandler.php
@@ -67,6 +67,7 @@ final readonly class EnrichSeriesHandler
                 $result,
                 LookupMode::TITLE,
                 $sources,
+                $message->triggeredBy,
             );
 
             $this->logger->info('Enrichissement de "{title}" : confiance {confidence}', [

--- a/backend/src/Service/Enrichment/EnrichmentService.php
+++ b/backend/src/Service/Enrichment/EnrichmentService.php
@@ -75,6 +75,7 @@ class EnrichmentService
         LookupResult $result,
         LookupMode $mode,
         array $sources,
+        ?string $triggeredBy = null,
     ): EnrichmentConfidence {
         $confidence = $this->confidenceScorer->score(
             $series->getTitle(),
@@ -85,9 +86,9 @@ class EnrichmentService
         );
 
         match ($confidence) {
-            EnrichmentConfidence::HIGH => $this->autoApply($series, $result, $confidence, $sources),
-            EnrichmentConfidence::MEDIUM => $this->createProposals($series, $result, $confidence, $sources),
-            EnrichmentConfidence::LOW => $this->logSkip($series, $result, $confidence, $sources),
+            EnrichmentConfidence::HIGH => $this->autoApply($series, $result, $confidence, $sources, $triggeredBy),
+            EnrichmentConfidence::MEDIUM => $this->createProposals($series, $result, $confidence, $sources, $triggeredBy),
+            EnrichmentConfidence::LOW => $this->logSkip($series, $result, $confidence, $sources, $triggeredBy),
         };
 
         return $confidence;
@@ -156,6 +157,7 @@ class EnrichmentService
         LookupResult $result,
         EnrichmentConfidence $confidence,
         array $sources,
+        ?string $triggeredBy,
     ): void {
         $source = \implode(', ', $sources);
 
@@ -184,6 +186,7 @@ class EnrichmentService
                 field: $enrichableField,
                 proposedValue: $newValue,
                 source: $source,
+                triggeredBy: $triggeredBy,
             );
             $proposal->preAccept();
             $this->entityManager->persist($proposal);
@@ -203,6 +206,7 @@ class EnrichmentService
         LookupResult $result,
         EnrichmentConfidence $confidence,
         array $sources,
+        ?string $triggeredBy,
     ): void {
         $source = \implode(', ', $sources);
 
@@ -232,6 +236,7 @@ class EnrichmentService
                 field: $enrichableField,
                 proposedValue: $proposedValue,
                 source: $source,
+                triggeredBy: $triggeredBy,
             );
             $this->entityManager->persist($proposal);
         }
@@ -245,6 +250,7 @@ class EnrichmentService
         LookupResult $result,
         EnrichmentConfidence $confidence,
         array $sources,
+        ?string $triggeredBy,
     ): void {
         $source = \implode(', ', $sources);
 
@@ -264,6 +270,7 @@ class EnrichmentService
                 field: $enrichableField,
                 proposedValue: $proposedValue,
                 source: $source,
+                triggeredBy: $triggeredBy,
             );
             $proposal->skip();
             $this->entityManager->persist($proposal);

--- a/backend/tests/Unit/Service/Enrichment/EnrichmentServiceTest.php
+++ b/backend/tests/Unit/Service/Enrichment/EnrichmentServiceTest.php
@@ -83,6 +83,47 @@ final class EnrichmentServiceTest extends TestCase
     }
 
     /**
+     * Teste que triggeredBy est propagé aux propositions créées.
+     */
+    public function testTriggeredByIsPropagatedToProposals(): void
+    {
+        $series = $this->createSeries();
+        $result = new LookupResult(description: 'Nouvelle description', publisher: 'Glénat', source: 'bnf');
+
+        $this->confidenceScorer->method('score')->willReturn(EnrichmentConfidence::MEDIUM);
+        $this->proposalRepository->method('findPendingBySeriesAndField')->willReturn(null);
+
+        $this->enrichmentService->enrich($series, $result, LookupMode::TITLE, ['bnf'], 'command:auto-enrich');
+
+        $proposals = \array_filter($this->persisted, static fn ($e) => $e instanceof EnrichmentProposal);
+        self::assertGreaterThanOrEqual(1, \count($proposals));
+
+        /** @var EnrichmentProposal $proposal */
+        $proposal = \array_values($proposals)[0];
+        self::assertSame('command:auto-enrich', $proposal->getTriggeredBy());
+    }
+
+    /**
+     * Teste que triggeredBy est null par défaut.
+     */
+    public function testTriggeredByIsNullByDefault(): void
+    {
+        $series = $this->createSeries();
+        $result = new LookupResult(description: 'Nouvelle description', source: 'bnf');
+
+        $this->confidenceScorer->method('score')->willReturn(EnrichmentConfidence::MEDIUM);
+        $this->proposalRepository->method('findPendingBySeriesAndField')->willReturn(null);
+
+        $this->enrichmentService->enrich($series, $result, LookupMode::TITLE, ['bnf']);
+
+        $proposals = \array_filter($this->persisted, static fn ($e) => $e instanceof EnrichmentProposal);
+
+        /** @var EnrichmentProposal $proposal */
+        $proposal = \array_values($proposals)[0];
+        self::assertNull($proposal->getTriggeredBy());
+    }
+
+    /**
      * Teste que MEDIUM crée des propositions PENDING pour les champs modifiables.
      */
     public function testMediumConfidenceCreatesProposals(): void

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -11,7 +11,7 @@ Reference for implementing features without exploring the codebase.
 | `Author` | name:string(unique), followedForNewSeries:bool(default false) | `comicSeries:M2M(mappedBy)` | GetCollection(search by name), Get, Patch, Post |
 | `SeriesSuggestion` | title, type:`ComicType`, authors:JSON, reason:string, status:`SuggestionStatus`(default PENDING) | `sourceSeries:M2O→ComicSeries(SET NULL)` | GetCollection(filter status), Patch(status) |
 | `User` | email:string(unique), googleId?, roles, tokenVersion:int(default=1) | — | — |
-| `EnrichmentProposal` | field:`EnrichableField`, confidence:`EnrichmentConfidence`, currentValue:JSON?, proposedValue:JSON, source:string, status:`ProposalStatus`(default PENDING), reviewedAt? | `comicSeries:M2O→ComicSeries(CASCADE)` | GetCollection(filter status/comicSeries), Get, Patch(/accept), Patch(/reject) |
+| `EnrichmentProposal` | field:`EnrichableField`, confidence:`EnrichmentConfidence`, currentValue:JSON?, proposedValue:JSON, source:string, triggeredBy?:string(100), status:`ProposalStatus`(default PENDING), reviewedAt? | `comicSeries:M2O→ComicSeries(CASCADE)` | GetCollection(filter status/comicSeries), Get, Patch(/accept), Patch(/reject) |
 | `Notification` | title, message, type:`NotificationType`, read:bool, relatedEntityType?:`NotificationEntityType`, relatedEntityId?:int, metadata?:JSON | `user:M2O→User(CASCADE)` | GetCollection(filter read/type, paginated), Get, Patch(read), Delete |
 | `NotificationPreference` | type:`NotificationType`, channel:`NotificationChannel`(default IN_APP) | `user:M2O→User(CASCADE)` | GetCollection(provider: initializer), Patch |
 | `PushSubscription` | endpoint:string(unique), publicKey, authToken, expirationTime? | `user:M2O→User(CASCADE)` | GetCollection, Post, Delete |

--- a/frontend/src/components/ProposalCard.tsx
+++ b/frontend/src/components/ProposalCard.tsx
@@ -11,6 +11,12 @@ import {
 } from "../types/enums";
 import { formatEnrichmentValue } from "../utils/enrichmentUtils";
 
+const TriggeredByLabel: Record<string, string> = {
+  "command:auto-enrich": "auto-enrich",
+  "event:create": "création",
+  "event:update": "mise à jour",
+};
+
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString("fr-FR", {
     day: "numeric",
@@ -45,6 +51,11 @@ export default function ProposalCard({
             {EnrichmentConfidenceLabel[proposal.confidence as EnrichmentConfidence]}
           </span>
           <span className="text-xs text-text-tertiary">{proposal.source}</span>
+          {proposal.triggeredBy && (
+            <span className="text-xs text-text-tertiary">
+              via {TriggeredByLabel[proposal.triggeredBy] ?? proposal.triggeredBy}
+            </span>
+          )}
           <span className="text-xs text-text-tertiary">{formatDate(proposal.createdAt)}</span>
           {readonly && (
             <>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -273,6 +273,7 @@ export interface EnrichmentProposal {
   reviewedAt: string | null;
   source: string;
   status: ProposalStatus;
+  triggeredBy: string | null;
 }
 
 export interface SeriesSuggestion {


### PR DESCRIPTION
## Summary

- Ajoute le champ `triggeredBy` sur `EnrichmentProposal` pour tracer l'origine de chaque proposition (`event:create`, `event:update`, `command:auto-enrich`)
- Affiche l'horodatage de création et le déclencheur sur toutes les propositions dans le frontend
- Migration, tests unitaires et docs mis à jour

## Test plan

- [ ] Créer une série → vérifier que la proposition affiche "via création"
- [ ] Modifier une série avec champs manquants → vérifier "via mise à jour"
- [ ] Lancer `app:auto-enrich` → vérifier "via auto-enrich"
- [ ] Vérifier que les anciennes propositions (sans `triggeredBy`) s'affichent sans erreur