### PR TITLE
fix(search): corrige l'ergonomie du champ de recherche

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Fixed
 
+- **Recherche** : ajout du bouton croix pour vider le champ de recherche (#452)
+- **Recherche** : ajout du focus automatique sur le champ de recherche (#453)
 - **Couvertures** : corrige l'affichage inchangé après validation, changement manuel ou invalidation d'une couverture (cache-busting frontend + invalidation LiipImagine + nettoyage fichier au revert)
 - **Cron** : corrige les tâches planifiées qui échouaient en cascade après une erreur Doctrine (EntityManager fermé) — ajout du middleware `doctrine_close_connection` et réinitialisation de l'EM dans les commandes longues
 

--- a/backend/src/Controller/DevLoginController.php
+++ b/backend/src/Controller/DevLoginController.php
@@ -8,11 +8,11 @@ use App\Repository\UserRepository;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\Attribute\When;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
-use Symfony\Component\DependencyInjection\Attribute\When;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**

--- a/backend/tests/Unit/Command/AutoEnrichCommandTest.php
+++ b/backend/tests/Unit/Command/AutoEnrichCommandTest.php
@@ -72,7 +72,7 @@ final class AutoEnrichCommandTest extends TestCase
 
         // La première série déclenche une erreur qui ferme l'EM
         $this->lookupOrchestrator->method('lookupByTitle')
-            ->willReturnCallback(function (string $title) {
+            ->willReturnCallback(static function (string $title) {
                 if ('Série qui ferme EM' === $title) {
                     throw EntityManagerClosed::create();
                 }

--- a/backend/tests/Unit/Command/DownloadCoversCommandTest.php
+++ b/backend/tests/Unit/Command/DownloadCoversCommandTest.php
@@ -61,7 +61,7 @@ final class DownloadCoversCommandTest extends TestCase
 
         $callCount = 0;
         $this->coverDownloader->method('downloadAndStore')
-            ->willReturnCallback(function () use (&$callCount): bool {
+            ->willReturnCallback(static function () use (&$callCount): bool {
                 ++$callCount;
                 if (1 === $callCount) {
                     throw EntityManagerClosed::create();

--- a/frontend/src/__tests__/unit/components/SearchInput.test.tsx
+++ b/frontend/src/__tests__/unit/components/SearchInput.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import SearchInput from "../../../components/SearchInput";
+
+describe("SearchInput", () => {
+  it("does not show clear button when value is empty", () => {
+    render(<SearchInput onChange={vi.fn()} value="" />);
+    expect(screen.queryByLabelText("Vider la recherche")).not.toBeInTheDocument();
+  });
+
+  it("shows clear button when value is non-empty", () => {
+    render(<SearchInput onChange={vi.fn()} value="naruto" />);
+    expect(screen.getByLabelText("Vider la recherche")).toBeInTheDocument();
+  });
+
+  it("calls onChange with empty string when clear button is clicked", async () => {
+    const onChange = vi.fn();
+    render(<SearchInput onChange={onChange} value="naruto" />);
+
+    await userEvent.click(screen.getByLabelText("Vider la recherche"));
+
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("auto-focuses input when autoFocus is true", () => {
+    render(<SearchInput autoFocus onChange={vi.fn()} value="" />);
+    expect(screen.getByRole("searchbox")).toHaveFocus();
+  });
+
+  it("does not auto-focus input by default", () => {
+    render(<SearchInput onChange={vi.fn()} value="" />);
+    expect(screen.getByRole("searchbox")).not.toHaveFocus();
+  });
+});

--- a/frontend/src/components/SearchInput.tsx
+++ b/frontend/src/components/SearchInput.tsx
@@ -1,7 +1,8 @@
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 
 interface SearchInputProps {
   ariaLabel?: string;
+  autoFocus?: boolean;
   onChange: (value: string) => void;
   placeholder?: string;
   value: string;
@@ -9,6 +10,7 @@ interface SearchInputProps {
 
 export default function SearchInput({
   ariaLabel,
+  autoFocus,
   onChange,
   placeholder = "Rechercher…",
   value,
@@ -18,12 +20,23 @@ export default function SearchInput({
       <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" strokeWidth={1.5} />
       <input
         aria-label={ariaLabel}
-        className="w-full rounded-xl border border-surface-border bg-surface-elevated px-4 py-2.5 pl-10 text-sm text-text-primary placeholder:text-text-muted focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-white/10 dark:bg-white/5 dark:backdrop-blur-sm"
+        autoFocus={autoFocus}
+        className="w-full rounded-xl border border-surface-border bg-surface-elevated px-4 py-2.5 pl-10 pr-9 text-sm text-text-primary placeholder:text-text-muted focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-white/10 dark:bg-white/5 dark:backdrop-blur-sm"
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         type="search"
         value={value}
       />
+      {value && (
+        <button
+          aria-label="Vider la recherche"
+          className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1 text-text-muted hover:text-text-primary"
+          onClick={() => onChange("")}
+          type="button"
+        >
+          <X className="h-4 w-4" strokeWidth={1.5} />
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -187,6 +187,7 @@ export default function Home() {
       <div className="flex items-center gap-2">
         <SearchInput
           ariaLabel="Rechercher par titre, auteur, éditeur"
+          autoFocus
           onChange={handleSearchChange}
           placeholder="Rechercher par titre, auteur, éditeur…"
           value={search}

--- a/frontend/src/pages/ToBuy.tsx
+++ b/frontend/src/pages/ToBuy.tsx
@@ -127,7 +127,7 @@ export default function ToBuy() {
 
       {/* Search */}
       <div className="flex items-center gap-2">
-        <SearchInput onChange={handleSearchChange} value={search} />
+        <SearchInput autoFocus onChange={handleSearchChange} value={search} />
         <span className="flex shrink-0 items-center gap-1.5 font-mono-stats text-sm text-text-muted">
           {isFetching && !isLoading && (
             <Loader2 className="h-3.5 w-3.5 animate-spin" />


### PR DESCRIPTION
## Summary
- Ajout d'un bouton croix (X) pour vider le champ de recherche, visible uniquement quand le champ contient du texte
- Ajout du focus automatique sur le champ de recherche (pages Home et À acheter)
- 5 tests unitaires SearchInput

## Test plan
- [x] Bouton croix visible quand texte présent, caché sinon
- [x] Clic sur la croix vide le champ
- [x] Focus automatique au chargement de la page
- [x] 927 tests passent, TypeScript clean

Fixes #452, fixes #453