### PR TITLE
fix(import): crée les tomes manquants quand seule la parution est connue

### DIFF
--- a/.claude/memory/patterns.md
+++ b/.claude/memory/patterns.md
@@ -74,7 +74,7 @@ ApiLookupStatus, BatchLookupStatus, ComicStatus (collection status), ComicType (
 | Cover/ | CoverDownloader, CoverSearchService, ThumbnailGenerator, VichCoverRemover |
 | Cover/Upload/ | UploadHandlerInterface, VichUploadHandlerAdapter |
 | Enrichment/ | ConfidenceScorer, EnrichmentService |
-| Import/ | ImportBooksService, ImportExcelService |
+| Import/ | ImportService |
 | Lookup/Contract/ | ApiMessage, LookupProviderInterface, LookupResult… |
 | Lookup/Gemini/ | AbstractGeminiLookupProvider, GeminiClientPool, GeminiJsonParser, GeminiQueryService |
 | Lookup/Provider/ | 12 providers: AniList, Bedetheque, BNF, ComicVine, Gemini, GoogleBooks, Jikan, Kitsu, MangaDex, OpenLibrary, Wikipedia + AbstractLookupProvider |
@@ -108,7 +108,7 @@ ApiLookupStatus, BatchLookupStatus, ComicStatus (collection status), ComicType (
 - Monthly 1st 1h: `app:purge-deleted`
 - Monthly 1st 2h: `app:purge-notifications`
 
-**Other commands**: `app:import-books`, `app:import-excel`, `app:invalidate-tokens`, `app:scan-nas`, `app:warm-thumbnails`.
+**Other commands**: `app:import`, `app:invalidate-tokens`, `app:scan-nas`, `app:warm-thumbnails`.
 
 ## Events
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Import** : crée les tomes manquants quand seule la colonne « Parution » est remplie — avant, `latestPublishedIssue` était persisté sans créer les `Tome` correspondants, ce qui déclenchait ensuite des notifications « tomes manquants » pour toute la plage (#463)
+- **Migration** : rattrape automatiquement les tomes manquants sur les séries déjà importées (honore `defaultTomeBought` / `defaultTomeOnNas` / `defaultTomeRead`) (#463)
+
 ## [v2.26.8] - 2026-04-07
 
 ### Fixed

--- a/backend/migrations/Version20260411143853.php
+++ b/backend/migrations/Version20260411143853.php
@@ -12,9 +12,9 @@ use Doctrine\Migrations\AbstractMigration;
  * est connu mais dont la collection `tome` est incomplète.
  *
  * Contexte : avant le fix d'`ImportService::determineMaxTomeNumber`, un import où
- * seule la colonne « Parution » était remplie setttait `latest_published_issue` sans
- * créer les tomes correspondants, déclenchant ensuite des notifications « tomes
- * manquants » en boucle.
+ * seule la colonne « Parution » était remplie définissait `latest_published_issue`
+ * sans créer les tomes correspondants, déclenchant ensuite des notifications
+ * « tomes manquants » en boucle.
  */
 final class Version20260411143853 extends AbstractMigration
 {

--- a/backend/migrations/Version20260411143853.php
+++ b/backend/migrations/Version20260411143853.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Rattrape les tomes manquants pour les séries dont `latest_published_issue`
+ * est connu mais dont la collection `tome` est incomplète.
+ *
+ * Contexte : avant le fix d'`ImportService::determineMaxTomeNumber`, un import où
+ * seule la colonne « Parution » était remplie setttait `latest_published_issue` sans
+ * créer les tomes correspondants, déclenchant ensuite des notifications « tomes
+ * manquants » en boucle.
+ */
+final class Version20260411143853 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Rattrape les tomes manquants pour les séries dont la parution est connue';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('SET SESSION max_recursive_iterations = 10000');
+        $this->addSql(<<<'SQL'
+            INSERT INTO tome (comic_series_id, number, bought, on_nas, `read`, is_hors_serie, created_at, updated_at)
+            WITH RECURSIVE numbers AS (
+                SELECT 1 AS n
+                UNION ALL
+                SELECT n + 1 FROM numbers WHERE n < 10000
+            )
+            SELECT
+                cs.id,
+                n.n,
+                cs.default_tome_bought,
+                cs.default_tome_on_nas,
+                cs.default_tome_read,
+                0,
+                NOW(),
+                NOW()
+            FROM comic_series cs
+            CROSS JOIN numbers n
+            WHERE cs.deleted_at IS NULL
+              AND cs.latest_published_issue IS NOT NULL
+              AND cs.latest_published_issue > 0
+              AND n.n <= cs.latest_published_issue
+              AND NOT EXISTS (
+                  SELECT 1 FROM tome t
+                  WHERE t.comic_series_id = cs.id
+                    AND t.number = n.n
+                    AND t.is_hors_serie = 0
+              )
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException('Les tomes créés ne peuvent pas être rollback automatiquement.');
+    }
+}

--- a/backend/src/Service/Import/ImportService.php
+++ b/backend/src/Service/Import/ImportService.php
@@ -381,6 +381,9 @@ final class ImportService
 
     /**
      * Détermine le nombre maximum de tomes à créer.
+     *
+     * Inclut toujours `latestPublishedIssue` comme candidat : un tome publié connu
+     * doit exister en base même si l'utilisateur n'en possède encore aucun.
      */
     private function determineMaxTomeNumber(
         ?int $currentIssueValue,
@@ -391,11 +394,7 @@ final class ImportService
     ): ?int {
         $candidates = [];
 
-        if ($currentIssueComplete) {
-            if (null !== $latestPublishedIssue) {
-                $candidates[] = $latestPublishedIssue;
-            }
-        } elseif (null !== $currentIssueValue) {
+        if (!$currentIssueComplete && null !== $currentIssueValue) {
             $candidates[] = $currentIssueValue;
         }
 
@@ -404,6 +403,9 @@ final class ImportService
         }
         if (null !== $lastOnNasValue) {
             $candidates[] = $lastOnNasValue;
+        }
+        if (null !== $latestPublishedIssue) {
+            $candidates[] = $latestPublishedIssue;
         }
 
         if ([] === $candidates) {

--- a/backend/tests/Unit/Service/Import/ImportServiceTest.php
+++ b/backend/tests/Unit/Service/Import/ImportServiceTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Import;
+
+use App\Entity\ComicSeries;
+use App\Entity\Tome;
+use App\Repository\AuthorRepository;
+use App\Repository\ComicSeriesRepository;
+use App\Service\Import\ImportService;
+use Doctrine\ORM\EntityManagerInterface;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires pour ImportService.
+ */
+final class ImportServiceTest extends TestCase
+{
+    /** @var list<ComicSeries> */
+    private array $persistedSeries = [];
+    private ImportService $service;
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    protected function setUp(): void
+    {
+        $authorRepository = $this->createStub(AuthorRepository::class);
+        $comicSeriesRepository = $this->createStub(ComicSeriesRepository::class);
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+
+        $comicSeriesRepository->method('findOneByFuzzyTitle')->willReturn(null);
+
+        $this->persistedSeries = [];
+        $entityManager->method('persist')
+            ->willReturnCallback(function (object $entity): void {
+                if ($entity instanceof ComicSeries) {
+                    $this->persistedSeries[] = $entity;
+                }
+            });
+
+        $this->service = new ImportService(
+            $authorRepository,
+            $comicSeriesRepository,
+            $entityManager,
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            if (\file_exists($file)) {
+                \unlink($file);
+            }
+        }
+    }
+
+    public function testImportCreatesTomesFromPublishedCountAlone(): void
+    {
+        $filePath = $this->createExcelFile([
+            ['Type', 'Titre', 'Achète?', 'Dernier acheté', 'Lu', 'Parution', 'Dernier DL', 'Sur NAS?', 'Parution terminée'],
+            ['BD', 'Série À Acheter', '', '', '', 5, '', '', ''],
+        ]);
+
+        $result = $this->service->import($filePath, dryRun: false);
+
+        self::assertCount(1, $this->persistedSeries);
+        $series = $this->persistedSeries[0];
+        self::assertSame(5, $series->getLatestPublishedIssue());
+        self::assertCount(5, $series->getTomes());
+        self::assertSame(5, $result->totalTomes);
+
+        $numbers = \array_map(static fn (Tome $t): int => $t->getNumber(), $series->getTomes()->toArray());
+        \sort($numbers);
+        self::assertSame([1, 2, 3, 4, 5], $numbers);
+
+        foreach ($series->getTomes() as $tome) {
+            self::assertFalse($tome->isBought());
+            self::assertFalse($tome->isOnNas());
+            self::assertFalse($tome->isHorsSerie());
+        }
+    }
+
+    public function testImportCreatesAllTomesWhenLastBoughtIsLessThanPublishedCount(): void
+    {
+        $filePath = $this->createExcelFile([
+            ['Type', 'Titre', 'Achète?', 'Dernier acheté', 'Lu', 'Parution', 'Dernier DL', 'Sur NAS?', 'Parution terminée'],
+            ['Manga', 'Série Partiellement Achetée', '', 3, '', 10, '', '', ''],
+        ]);
+
+        $this->service->import($filePath, dryRun: false);
+
+        self::assertCount(1, $this->persistedSeries);
+        $series = $this->persistedSeries[0];
+        self::assertSame(10, $series->getLatestPublishedIssue());
+        self::assertCount(10, $series->getTomes());
+
+        $bought = [];
+        $notBought = [];
+        foreach ($series->getTomes() as $tome) {
+            if ($tome->isBought()) {
+                $bought[] = $tome->getNumber();
+            } else {
+                $notBought[] = $tome->getNumber();
+            }
+        }
+        \sort($bought);
+        \sort($notBought);
+        self::assertSame([1, 2, 3], $bought);
+        self::assertSame([4, 5, 6, 7, 8, 9, 10], $notBought);
+    }
+
+    /**
+     * @param list<list<mixed>> $rows
+     */
+    private function createExcelFile(array $rows): string
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->fromArray($rows, null, 'A1');
+
+        $filePath = \tempnam(\sys_get_temp_dir(), 'import_test_').'.xlsx';
+        $writer = IOFactory::createWriter($spreadsheet, 'Xlsx');
+        $writer->save($filePath);
+        $this->tempFiles[] = $filePath;
+
+        return $filePath;
+    }
+}

--- a/backend/tests/Unit/Service/Import/ImportServiceTest.php
+++ b/backend/tests/Unit/Service/Import/ImportServiceTest.php
@@ -112,6 +112,29 @@ final class ImportServiceTest extends TestCase
         self::assertSame([4, 5, 6, 7, 8, 9, 10], $notBought);
     }
 
+    public function testImportCreatesTomesUpToMaxWhenSeriesIsCompleteAndLastBoughtExceedsPublishedCount(): void
+    {
+        $filePath = $this->createExcelFile([
+            ['Type', 'Titre', 'Achète?', 'Dernier acheté', 'Lu', 'Parution', 'Dernier DL', 'Sur NAS?', 'Parution terminée'],
+            ['BD', 'Série Terminée', '', 15, '', 10, '', '', 'oui'],
+        ]);
+
+        $this->service->import($filePath, dryRun: false);
+
+        self::assertCount(1, $this->persistedSeries);
+        $series = $this->persistedSeries[0];
+        self::assertSame(10, $series->getLatestPublishedIssue());
+        self::assertCount(15, $series->getTomes());
+
+        $numbers = \array_map(static fn (Tome $t): int => $t->getNumber(), $series->getTomes()->toArray());
+        \sort($numbers);
+        self::assertSame([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], $numbers);
+
+        foreach ($series->getTomes() as $tome) {
+            self::assertTrue($tome->isBought());
+        }
+    }
+
     /**
      * @param list<list<mixed>> $rows
      */


### PR DESCRIPTION
## Résumé

- `ImportService::determineMaxTomeNumber` n'utilisait `latestPublishedIssue` que si `currentIssueComplete` était vrai — un import avec seule la colonne « Parution » persistait la série sans créer les tomes, ce qui déclenchait ensuite `app:detect-missing-tomes` sur toute la plage 1..N
- `latestPublishedIssue` devient un candidat non conditionnel dans le calcul du max
- Migration Doctrine de rattrapage pour les séries déjà importées (CTE récursif, honore `defaultTomeBought`/`defaultTomeOnNas`/`defaultTomeRead`, `max_recursive_iterations=10000` pour couvrir les longues séries comme 2000 AD)
- 2 tests unitaires : Parution seule → tomes 1..N créés ; Parution > lastBought → 10 tomes dont 3 marqués achetés

## Plan de test

- [x] `bin/phpunit tests/Unit/Service/Import/ImportServiceTest.php` → green
- [x] `make test` complet → 1053/1053
- [x] PHPStan lvl 9 sur fichiers modifiés
- [x] CS Fixer sur fichiers modifiés
- [x] Migration testée en dev : 128 séries zéro-tome → 0 incomplètes (dont 2000 AD à 2463 numéros)

fixes #463