### PR TITLE
fix(covers): corrige le débordement des images dans la modal de recherche

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 - **Import** : crée les tomes manquants quand seule la colonne « Parution » est remplie — avant, `latestPublishedIssue` était persisté sans créer les `Tome` correspondants, ce qui déclenchait ensuite des notifications « tomes manquants » pour toute la plage (#463)
 - **Migration** : rattrape automatiquement les tomes manquants sur les séries déjà importées (honore `defaultTomeBought` / `defaultTomeOnNas` / `defaultTomeRead`) (#463)
 - **Lookup** : corrige l'erreur HTTP 400 systématique sur MangaDex (mauvaise sérialisation du paramètre `includes[]` par Symfony HttpClient) — les couvertures et auteurs manga sont à nouveau récupérés
+- **Recherche de couverture** : corrige le débordement des images hors de la modal en contraignant correctement la hauteur de la zone défilable (#456)
 
 ### Removed
 

--- a/frontend/src/components/CoverSearchModal.tsx
+++ b/frontend/src/components/CoverSearchModal.tsx
@@ -102,9 +102,9 @@ export default function CoverSearchModal({
             </div>
           </div>
 
-          <div className="relative">
+          <div className="relative min-h-0 flex-1">
             <div
-              className="overflow-y-auto p-4"
+              className="h-full overflow-y-auto p-4"
               onScroll={handleScroll}
               ref={scrollRef}
             >


### PR DESCRIPTION
## Résumé

Les images débordaient de la modal de sélection de couvertures : la zone défilable n'était pas correctement contrainte.

Le `DialogPanel` est en `flex flex-col max-h-[80vh]`, mais le wrapper de la zone défilable n'avait pas `flex-1 min-h-0`. Résultat : le conteneur `overflow-y-auto` prenait la hauteur naturelle de son contenu au lieu de l'espace restant dans le panneau, et la grille d'images débordait.

## Changements

- `CoverSearchModal.tsx` : ajout de `min-h-0 flex-1` sur le wrapper relatif et de `h-full` sur le conteneur défilable
- `CHANGELOG.md` : entrée sous `Fixed`

fixes #456