### PR TITLE
fix(merge): corrige le scroll horizontal tronqué dans la modal de fusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 - **Migration** : rattrape automatiquement les tomes manquants sur les séries déjà importées (honore `defaultTomeBought` / `defaultTomeOnNas` / `defaultTomeRead`) (#463)
 - **Lookup** : corrige l'erreur HTTP 400 systématique sur MangaDex (mauvaise sérialisation du paramètre `includes[]` par Symfony HttpClient) — les couvertures et auteurs manga sont à nouveau récupérés
 - **Recherche de couverture** : corrige le débordement des images hors de la modal en contraignant correctement la hauteur de la zone défilable (#456)
+- **Fusion** : corrige le scroll horizontal tronqué dans la modal de fusion de séries — le conteneur parent et le tableau des tomes se disputaient le scroll horizontal, ce qui empêchait d'atteindre les dernières colonnes (#457)
 
 ### Removed
 

--- a/frontend/src/components/MergePreviewModal.tsx
+++ b/frontend/src/components/MergePreviewModal.tsx
@@ -52,7 +52,7 @@ export default function MergePreviewModal({
           </div>
 
           {/* Scrollable content */}
-          <div className="min-h-0 flex-1 overflow-auto px-6 pb-2">
+          <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-6 pb-2">
             <MergeMetadataForm
               dispatch={dispatch}
               isSuggesting={isSuggesting}


### PR DESCRIPTION
## Contexte

La modal de fusion de séries n'affichait qu'un scroll horizontal partiel : le contenu du tableau des tomes était tronqué et les dernières colonnes (Lu / NAS / suppression) devenaient inaccessibles sur les petits viewports.

## Cause

Le conteneur parent scrollable utilisait `overflow-auto` (deux axes). Combiné avec le wrapper interne du tableau (`-mx-6 overflow-x-auto px-6`), le navigateur créait **deux scrollbars horizontales concurrentes** : le parent et le tableau. Le scroll du parent prenait la priorité et limitait la plage accessible, rendant impossible l'atteinte des dernières colonnes.

## Fix

Remplacement de `overflow-auto` par `overflow-y-auto overflow-x-hidden` sur la zone scrollable de la `DialogPanel` — le scroll vertical reste géré par le parent, le scroll horizontal est exclusivement géré par le wrapper interne du tableau.

## Tests

- 928/928 tests frontend passent
- `tsc --noEmit` propre

fixes #457