### PR TITLE
fix(merge): corrige les dropdowns tronqués dans la modal de fusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 - **Lookup** : corrige l'erreur HTTP 400 systématique sur MangaDex (mauvaise sérialisation du paramètre `includes[]` par Symfony HttpClient) — les couvertures et auteurs manga sont à nouveau récupérés
 - **Recherche de couverture** : corrige le débordement des images hors de la modal en contraignant correctement la hauteur de la zone défilable (#456)
 - **Fusion** : corrige le scroll horizontal tronqué dans la modal de fusion de séries — le conteneur parent et le tableau des tomes se disputaient le scroll horizontal, ce qui empêchait d'atteindre les dernières colonnes (#457)
+- **Fusion** : corrige l'affichage des dropdowns Type et Statut dans la modal de fusion — les options étaient tronquées par le conteneur scrollable ; elles sont désormais portailisées et se repositionnent automatiquement hors du viewport (#458)
 
 ### Removed
 

--- a/frontend/src/components/SelectListbox.tsx
+++ b/frontend/src/components/SelectListbox.tsx
@@ -47,7 +47,10 @@ export default function SelectListbox({
             </span>
             <ChevronDown className="h-4 w-4 text-text-muted" />
           </ListboxButton>
-          <ListboxOptions className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-xl border border-surface-border bg-surface-primary py-1 shadow-layered-lg transition focus:outline-none dark:border-white/10 dark:bg-surface-elevated">
+          <ListboxOptions
+            anchor="bottom start"
+            className="z-50 mt-1 max-h-60 w-[var(--button-width)] overflow-auto rounded-xl border border-surface-border bg-surface-primary py-1 shadow-layered-lg transition focus:outline-none dark:border-white/10 dark:bg-surface-elevated"
+          >
             {options.map((option) => (
               <ListboxOption
                 className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm text-text-primary data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-950/30"


### PR DESCRIPTION
## Résumé

Les dropdowns **Type** et **Statut** de la modal de fusion étaient tronqués par le conteneur scrollable de la modal — seules 1-2 options étaient visibles, le reste débordait hors du viewport.

## Correctif

- `SelectListbox` : ajout de la prop `anchor="bottom start"` sur `ListboxOptions` (Headless UI v2) → les options sont portailisées, s'affranchissent des `overflow` parents et se repositionnent automatiquement si nécessaire.
- Largeur alignée sur le bouton via `w-[var(--button-width)]`.

S'applique à tous les usages de `SelectListbox` (MergeMetadataForm, ComicForm, EnrichmentReview, Filters, MergeSeries).

## Test plan

- [x] \`SelectListbox.test.tsx\` — 7/7 passent
- [x] \`tsc --noEmit\` propre
- [ ] Vérification manuelle : ouvrir la modal de fusion, dérouler Type/Statut — les options s'affichent au-dessus du bouton si manque de place en bas.

fixes #458