### PR TITLE
feat(enrichment-review): affiche les miniatures et déploie les descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Revue d'enrichissement** : les propositions de couverture affichent une miniature (192 px) au lieu de l'URL brute, avec placeholder selon le type (BD/Manga/Comics/Livre). Les propositions de description tronquées se déploient au clic pour lire le texte complet (côté revue `/tools/enrichment-review` et section « Propositions à traiter » de la fiche série).
+
 ## [v2.29.0] — 2026-04-12
 
 ### Added

--- a/backend/src/Entity/ComicSeries.php
+++ b/backend/src/Entity/ComicSeries.php
@@ -100,7 +100,7 @@ class ComicSeries implements SoftDeletableInterface
     #[ORM\Column(type: Types::STRING, length: 20, enumType: ComicStatus::class)]
     private ComicStatus $status = ComicStatus::BUYING;
 
-    #[Groups(['comic:list', 'comic:read', 'comic:write'])]
+    #[Groups(['comic:list', 'comic:read', 'comic:write', 'enrichment:read'])]
     #[ORM\Column(type: Types::STRING, length: 20, enumType: ComicType::class)]
     private ComicType $type = ComicType::BD;
 

--- a/frontend/src/__mocks__/react-virtuoso.tsx
+++ b/frontend/src/__mocks__/react-virtuoso.tsx
@@ -1,0 +1,27 @@
+import { forwardRef, useImperativeHandle, type ReactNode } from "react";
+
+interface VirtuosoProps {
+  itemContent: (index: number) => ReactNode;
+  totalCount?: number;
+  data?: unknown[];
+}
+
+export const Virtuoso = forwardRef<unknown, VirtuosoProps>(function Virtuoso(
+  { itemContent, totalCount, data },
+  ref,
+) {
+  useImperativeHandle(ref, () => ({
+    getState: (cb: (s: unknown) => void) => cb(undefined),
+    scrollToIndex: () => {},
+  }));
+
+  const count = totalCount ?? data?.length ?? 0;
+  const rows = [] as ReactNode[];
+  for (let i = 0; i < count; i++) {
+    rows.push(<div key={i}>{itemContent(i)}</div>);
+  }
+  return <div data-testid="mock-virtuoso">{rows}</div>;
+});
+
+export type VirtuosoHandle = unknown;
+export type StateSnapshot = unknown;

--- a/frontend/src/__tests__/integration/components/ContinueReading.test.tsx
+++ b/frontend/src/__tests__/integration/components/ContinueReading.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import ContinueReading from "../../../components/ContinueReading";
@@ -11,6 +11,10 @@ function renderComponent(comics: ComicSeries[]) {
       <ContinueReading comics={comics} />
     </MemoryRouter>,
   );
+}
+
+function expandSection() {
+  fireEvent.click(screen.getByRole("button", { name: /Continuer la lecture/ }));
 }
 
 describe("ContinueReading", () => {
@@ -38,6 +42,7 @@ describe("ContinueReading", () => {
       }),
     ];
     renderComponent(comics);
+    expandSection();
     expect(screen.getByText("One Piece")).toBeInTheDocument();
   });
 
@@ -52,6 +57,7 @@ describe("ContinueReading", () => {
       }),
     ];
     renderComponent(comics);
+    expandSection();
     expect(screen.getByText("Naruto")).toBeInTheDocument();
   });
 
@@ -73,6 +79,7 @@ describe("ContinueReading", () => {
       }),
     ];
     renderComponent(comics);
+    expandSection();
     expect(screen.queryByText("All Read")).not.toBeInTheDocument();
     expect(screen.getByText("Unread")).toBeInTheDocument();
   });
@@ -88,6 +95,7 @@ describe("ContinueReading", () => {
       }),
     ];
     renderComponent(comics);
+    expandSection();
     expect(screen.getByText("Tome 8")).toBeInTheDocument();
   });
 
@@ -121,6 +129,7 @@ describe("ContinueReading", () => {
       }),
     ];
     renderComponent(comics);
+    expandSection();
     const link = screen.getByRole("link", { name: /Bleach/i });
     expect(link).toHaveAttribute("href", "/comic/42");
   });
@@ -144,6 +153,7 @@ describe("ContinueReading", () => {
       }),
     ];
     renderComponent(comics);
+    expandSection();
     expect(screen.queryByText("One Shot")).not.toBeInTheDocument();
     expect(screen.getByText("Series")).toBeInTheDocument();
   });

--- a/frontend/src/__tests__/integration/pages/EnrichmentReview.test.tsx
+++ b/frontend/src/__tests__/integration/pages/EnrichmentReview.test.tsx
@@ -8,7 +8,12 @@ import { renderWithProviders } from "../../helpers/test-utils";
 const proposals = [
   {
     "@id": "/enrichment_proposals/1",
-    comicSeries: { "@id": "/comic_series/10", id: 10, title: "One Piece" },
+    comicSeries: {
+      "@id": "/comic_series/10",
+      id: 10,
+      title: "One Piece",
+      type: "manga",
+    },
     confidence: "high",
     createdAt: "2026-01-01T00:00:00+00:00",
     currentValue: null,
@@ -21,7 +26,12 @@ const proposals = [
   },
   {
     "@id": "/enrichment_proposals/2",
-    comicSeries: { "@id": "/comic_series/10", id: 10, title: "One Piece" },
+    comicSeries: {
+      "@id": "/comic_series/10",
+      id: 10,
+      title: "One Piece",
+      type: "manga",
+    },
     confidence: "medium",
     createdAt: "2026-01-01T00:00:00+00:00",
     currentValue: null,
@@ -34,7 +44,12 @@ const proposals = [
   },
   {
     "@id": "/enrichment_proposals/3",
-    comicSeries: { "@id": "/comic_series/20", id: 20, title: "Astérix" },
+    comicSeries: {
+      "@id": "/comic_series/20",
+      id: 20,
+      title: "Astérix",
+      type: "bd",
+    },
     confidence: "low",
     createdAt: "2026-01-01T00:00:00+00:00",
     currentValue: "Ancien éditeur",
@@ -47,7 +62,12 @@ const proposals = [
   },
   {
     "@id": "/enrichment_proposals/4",
-    comicSeries: { "@id": "/comic_series/30", id: 30, title: "Batman" },
+    comicSeries: {
+      "@id": "/comic_series/30",
+      id: 30,
+      title: "Batman",
+      type: "comics",
+    },
     confidence: "high",
     createdAt: "2026-01-01T00:00:00+00:00",
     currentValue: null,

--- a/frontend/src/__tests__/integration/pages/Home.test.tsx
+++ b/frontend/src/__tests__/integration/pages/Home.test.tsx
@@ -251,7 +251,7 @@ describe("Home", () => {
     renderWithProviders(<Home />);
 
     await waitFor(() => {
-      expect(screen.getByText("2/2")).toBeInTheDocument();
+      expect(screen.getAllByText("2/2").length).toBeGreaterThan(0);
     });
   });
 

--- a/frontend/src/components/ProposalCard.tsx
+++ b/frontend/src/components/ProposalCard.tsx
@@ -1,6 +1,8 @@
 import { Check, X } from "lucide-react";
+import { useState } from "react";
 import type { EnrichmentProposal } from "../types/api";
 import {
+  ComicTypePlaceholder,
   EnrichableFieldLabel,
   EnrichmentConfidenceColor,
   EnrichmentConfidenceLabel,
@@ -10,6 +12,7 @@ import {
   type ProposalStatus,
 } from "../types/enums";
 import { formatEnrichmentValue } from "../utils/enrichmentUtils";
+import CoverImage from "./CoverImage";
 
 const TriggeredByLabel: Record<string, string> = {
   "command:auto-enrich": "auto-enrich",
@@ -38,6 +41,93 @@ export default function ProposalCard({
   proposal: EnrichmentProposal;
   readonly?: boolean;
 }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const renderValues = () => {
+    if (proposal.field === "cover") {
+      const placeholder = ComicTypePlaceholder[proposal.comicSeries.type];
+      const currentSrc =
+        typeof proposal.currentValue === "string" && proposal.currentValue
+          ? proposal.currentValue
+          : placeholder;
+      const proposedSrc =
+        typeof proposal.proposedValue === "string" && proposal.proposedValue
+          ? proposal.proposedValue
+          : placeholder;
+      return (
+        <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
+          <CoverImage
+            alt="Couverture actuelle"
+            className="w-48 rounded-lg shadow-sm"
+            fallbackSrc={placeholder}
+            loading="lazy"
+            objectFit="contain"
+            src={currentSrc}
+          />
+          <span className="text-text-tertiary">→</span>
+          <CoverImage
+            alt="Couverture proposée"
+            className="w-48 rounded-lg shadow-sm"
+            fallbackSrc={placeholder}
+            loading="lazy"
+            objectFit="contain"
+            src={proposedSrc}
+          />
+        </div>
+      );
+    }
+
+    if (proposal.field === "description") {
+      const currentText = expanded
+        ? String(proposal.currentValue ?? "—")
+        : formatEnrichmentValue(proposal.currentValue);
+      const proposedText = expanded
+        ? String(proposal.proposedValue ?? "—")
+        : formatEnrichmentValue(proposal.proposedValue);
+      return (
+        <div
+          className={`mt-1 text-sm text-text-secondary ${expanded ? "whitespace-pre-wrap" : "break-all"}`}
+        >
+          <span
+            className="cursor-pointer text-text-tertiary hover:text-text-primary"
+            onClick={() => setExpanded((v) => !v)}
+            title={
+              expanded
+                ? "Cliquer pour réduire"
+                : "Cliquer pour afficher la description complète"
+            }
+          >
+            {currentText}
+          </span>
+          {" → "}
+          <span
+            className="cursor-pointer font-medium text-text-primary hover:text-text-primary"
+            onClick={() => setExpanded((v) => !v)}
+            title={
+              expanded
+                ? "Cliquer pour réduire"
+                : "Cliquer pour afficher la description complète"
+            }
+          >
+            {proposedText}
+          </span>
+        </div>
+      );
+    }
+
+    return (
+      <div className="mt-1 break-all text-sm text-text-secondary">
+        <span className="text-text-tertiary">
+          {formatEnrichmentValue(proposal.currentValue)}
+        </span>
+        {" → "}
+        <span className="font-medium text-text-primary">
+          {formatEnrichmentValue(proposal.proposedValue)}
+        </span>
+      </div>
+    );
+  };
+
   return (
     <div className="flex items-start justify-between gap-3 rounded-lg border border-surface-border bg-surface-secondary p-3">
       <div className="min-w-0 flex-1">
@@ -79,21 +169,7 @@ export default function ProposalCard({
             </>
           )}
         </div>
-        <div className="mt-1 break-all text-sm text-text-secondary">
-          <span className="text-text-tertiary">
-            {formatEnrichmentValue(
-              proposal.currentValue,
-              proposal.field === "cover" ? Infinity : undefined,
-            )}
-          </span>
-          {" → "}
-          <span className="font-medium text-text-primary">
-            {formatEnrichmentValue(
-              proposal.proposedValue,
-              proposal.field === "cover" ? Infinity : undefined,
-            )}
-          </span>
-        </div>
+        {renderValues()}
       </div>
       {!readonly && onAccept && onReject && (
         <div className="flex shrink-0 gap-1">

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -18,6 +18,19 @@ globalThis.ResizeObserver = class {
   disconnect() {}
 };
 
+// jsdom does not implement IntersectionObserver — required by useScrollReveal
+globalThis.IntersectionObserver = class {
+  readonly root = null;
+  readonly rootMargin = "";
+  readonly thresholds: ReadonlyArray<number> = [];
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+} as unknown as typeof IntersectionObserver;
+
 // jsdom does not implement matchMedia — provide a minimal stub
 Object.defineProperty(window, "matchMedia", {
   value: (query: string) => ({

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -263,7 +263,7 @@ export interface LookupCandidate {
 
 export interface EnrichmentProposal {
   "@id": string;
-  comicSeries: { "@id": string; id: number; title: string };
+  comicSeries: { "@id": string; id: number; title: string; type: ComicType };
   confidence: EnrichmentConfidence;
   createdAt: string;
   currentValue: unknown;

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
   plugins: [react()],
   test: {
     alias: {
+      "react-virtuoso": new URL(
+        "./src/__mocks__/react-virtuoso.tsx",
+        import.meta.url,
+      ).pathname,
       "virtual:pwa-register": new URL(
         "./src/__mocks__/virtual-pwa-register.ts",
         import.meta.url,


### PR DESCRIPTION
## Résumé

- Les propositions de couverture dans la revue d'enrichissement (`/tools/enrichment-review`) et dans la section « Propositions à traiter » de la fiche série affichent désormais deux miniatures côte à côte (192 px, `object-contain`) au lieu de l'URL brute. Placeholder par type (BD/Manga/Comics/Livre) quand la couverture actuelle est absente.
- Les propositions de `description` se troncent par défaut (100 caractères) et se déploient au clic pour lire le texte complet. Second clic retronque.
- Autres champs (`publisher`, `authors`, `isbn`…) inchangés.

## Changements techniques

- `ComicSeries::$type` exposé au groupe `enrichment:read` pour choisir le bon placeholder côté frontend.
- `ProposalCard` branche un rendu dédié selon `proposal.field` (cover / description / autre).
- Type `EnrichmentProposal.comicSeries` enrichi avec `type: ComicType`.

## Test plan

- [ ] Sur `/tools/enrichment-review`, vérifier que les propositions `Couverture` affichent deux miniatures côte à côte
- [ ] Vérifier le placeholder par type quand la couverture actuelle est absente
- [ ] Cliquer sur une description tronquée, vérifier l'expansion puis la rétroversion
- [ ] Sur une fiche série avec propositions en attente, même comportement dans « Propositions à traiter »
- [ ] Autres champs (publisher, authors, isbn…) inchangés