### PR TITLE
test: réduit le bruit des notices PHPUnit dans la suite

### DIFF
--- a/backend/tests/Integration/Command/CheckNewReleasesCommandTest.php
+++ b/backend/tests/Integration/Command/CheckNewReleasesCommandTest.php
@@ -30,7 +30,7 @@ final class CheckNewReleasesCommandTest extends KernelTestCase
         $this->em = self::getContainer()->get(EntityManagerInterface::class);
 
         // Mock le LookupOrchestrator pour éviter les vrais appels API
-        $orchestrator = $this->createMock(LookupOrchestrator::class);
+        $orchestrator = $this->createStub(LookupOrchestrator::class);
         $orchestrator->method('lookupByTitle')->willReturn(
             new LookupResult(latestPublishedIssue: 15),
         );

--- a/backend/tests/Unit/Command/AutoEnrichCommandTest.php
+++ b/backend/tests/Unit/Command/AutoEnrichCommandTest.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\EntityManagerClosed;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -25,18 +26,18 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 final class AutoEnrichCommandTest extends TestCase
 {
-    private MockObject&ComicSeriesRepository $comicSeriesRepository;
+    private Stub&ComicSeriesRepository $comicSeriesRepository;
     private MockObject&EntityManagerInterface $entityManager;
     private MockObject&EnrichmentService $enrichmentService;
-    private MockObject&LookupOrchestrator $lookupOrchestrator;
+    private Stub&LookupOrchestrator $lookupOrchestrator;
     private MockObject&ManagerRegistry $managerRegistry;
 
     protected function setUp(): void
     {
-        $this->comicSeriesRepository = $this->createMock(ComicSeriesRepository::class);
+        $this->comicSeriesRepository = $this->createStub(ComicSeriesRepository::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
         $this->enrichmentService = $this->createMock(EnrichmentService::class);
-        $this->lookupOrchestrator = $this->createMock(LookupOrchestrator::class);
+        $this->lookupOrchestrator = $this->createStub(LookupOrchestrator::class);
         $this->managerRegistry = $this->createMock(ManagerRegistry::class);
     }
 

--- a/backend/tests/Unit/Command/DownloadCoversCommandTest.php
+++ b/backend/tests/Unit/Command/DownloadCoversCommandTest.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\EntityManagerClosed;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -21,16 +22,16 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 final class DownloadCoversCommandTest extends TestCase
 {
-    private MockObject&ComicSeriesRepository $comicSeriesRepository;
-    private MockObject&CoverDownloader $coverDownloader;
-    private MockObject&EntityManagerInterface $entityManager;
+    private Stub&ComicSeriesRepository $comicSeriesRepository;
+    private Stub&CoverDownloader $coverDownloader;
+    private Stub&EntityManagerInterface $entityManager;
     private MockObject&ManagerRegistry $managerRegistry;
 
     protected function setUp(): void
     {
-        $this->comicSeriesRepository = $this->createMock(ComicSeriesRepository::class);
-        $this->coverDownloader = $this->createMock(CoverDownloader::class);
-        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->comicSeriesRepository = $this->createStub(ComicSeriesRepository::class);
+        $this->coverDownloader = $this->createStub(CoverDownloader::class);
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
         $this->managerRegistry = $this->createMock(ManagerRegistry::class);
     }
 

--- a/backend/tests/Unit/EventListener/ComicSeriesCacheInvalidatorTest.php
+++ b/backend/tests/Unit/EventListener/ComicSeriesCacheInvalidatorTest.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Event\PostRemoveEventArgs;
 use Doctrine\ORM\Event\PostUpdateEventArgs;
 use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Cache\CacheInterface;
 
@@ -24,14 +25,14 @@ use Symfony\Contracts\Cache\CacheInterface;
 final class ComicSeriesCacheInvalidatorTest extends TestCase
 {
     private CacheInterface&MockObject $cache;
-    private EntityManagerInterface&MockObject $entityManager;
+    private EntityManagerInterface&Stub $entityManager;
     private UnitOfWork&MockObject $unitOfWork;
     private ComicSeriesCacheInvalidator $listener;
 
     protected function setUp(): void
     {
         $this->cache = $this->createMock(CacheInterface::class);
-        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
         $this->unitOfWork = $this->createMock(UnitOfWork::class);
         $this->entityManager->method('getUnitOfWork')->willReturn($this->unitOfWork);
 

--- a/backend/tests/Unit/EventListener/CoverUrlChangeListenerTest.php
+++ b/backend/tests/Unit/EventListener/CoverUrlChangeListenerTest.php
@@ -11,6 +11,7 @@ use App\Tests\Factory\EntityFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -20,13 +21,13 @@ use Symfony\Component\Messenger\MessageBusInterface;
  */
 final class CoverUrlChangeListenerTest extends TestCase
 {
-    private EntityManagerInterface&MockObject $entityManager;
+    private EntityManagerInterface&Stub $entityManager;
     private CoverUrlChangeListener $listener;
     private MessageBusInterface&MockObject $messageBus;
 
     protected function setUp(): void
     {
-        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
         $this->messageBus = $this->createMock(MessageBusInterface::class);
         $this->listener = new CoverUrlChangeListener($this->messageBus);
     }
@@ -129,9 +130,9 @@ final class CoverUrlChangeListenerTest extends TestCase
         $this->listener->preUpdate($args);
     }
 
-    private function createSeriesWithId(int $id): ComicSeries&MockObject
+    private function createSeriesWithId(int $id): ComicSeries&Stub
     {
-        $series = $this->createMock(ComicSeries::class);
+        $series = $this->createStub(ComicSeries::class);
         $series->method('getId')->willReturn($id);
 
         return $series;

--- a/backend/tests/Unit/EventListener/EnrichOnCreateListenerTest.php
+++ b/backend/tests/Unit/EventListener/EnrichOnCreateListenerTest.php
@@ -32,7 +32,7 @@ final class EnrichOnCreateListenerTest extends TestCase
      */
     public function testDispatchesMessageForPersistedSeries(): void
     {
-        $series = $this->createMock(ComicSeries::class);
+        $series = $this->createStub(ComicSeries::class);
         $series->method('getId')->willReturn(42);
 
         $this->messageBus->expects(self::once())
@@ -48,7 +48,7 @@ final class EnrichOnCreateListenerTest extends TestCase
      */
     public function testDoesNotDispatchIfNoId(): void
     {
-        $series = $this->createMock(ComicSeries::class);
+        $series = $this->createStub(ComicSeries::class);
         $series->method('getId')->willReturn(null);
 
         $this->messageBus->expects(self::never())->method('dispatch');
@@ -64,7 +64,7 @@ final class EnrichOnCreateListenerTest extends TestCase
         EnrichOnCreateListener::disable();
 
         try {
-            $series = $this->createMock(ComicSeries::class);
+            $series = $this->createStub(ComicSeries::class);
             $series->method('getId')->willReturn(42);
 
             $this->messageBus->expects(self::never())->method('dispatch');

--- a/backend/tests/Unit/EventListener/ReEnrichOnUpdateListenerTest.php
+++ b/backend/tests/Unit/EventListener/ReEnrichOnUpdateListenerTest.php
@@ -32,7 +32,7 @@ final class ReEnrichOnUpdateListenerTest extends TestCase
      */
     public function testDispatchesWhenDescriptionMissing(): void
     {
-        $series = $this->createMock(ComicSeries::class);
+        $series = $this->createStub(ComicSeries::class);
         $series->method('getId')->willReturn(42);
         $series->method('getDescription')->willReturn(null);
         $series->method('getPublisher')->willReturn('Glénat');
@@ -53,7 +53,7 @@ final class ReEnrichOnUpdateListenerTest extends TestCase
      */
     public function testDoesNotDispatchWhenAllFieldsFilled(): void
     {
-        $series = $this->createMock(ComicSeries::class);
+        $series = $this->createStub(ComicSeries::class);
         $series->method('getId')->willReturn(42);
         $series->method('getDescription')->willReturn('Description');
         $series->method('getPublisher')->willReturn('Glénat');
@@ -71,7 +71,7 @@ final class ReEnrichOnUpdateListenerTest extends TestCase
      */
     public function testDoesNotDispatchIfRecentLookup(): void
     {
-        $series = $this->createMock(ComicSeries::class);
+        $series = $this->createStub(ComicSeries::class);
         $series->method('getId')->willReturn(42);
         $series->method('getDescription')->willReturn(null);
         $series->method('getPublisher')->willReturn(null);

--- a/backend/tests/Unit/EventListener/TomeLatestIssueListenerTest.php
+++ b/backend/tests/Unit/EventListener/TomeLatestIssueListenerTest.php
@@ -10,7 +10,7 @@ use App\EventListener\TomeLatestIssueListener;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PrePersistEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -19,11 +19,11 @@ use PHPUnit\Framework\TestCase;
 final class TomeLatestIssueListenerTest extends TestCase
 {
     private TomeLatestIssueListener $listener;
-    private EntityManagerInterface&MockObject $entityManager;
+    private EntityManagerInterface&Stub $entityManager;
 
     protected function setUp(): void
     {
-        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
         $this->listener = new TomeLatestIssueListener();
     }
 

--- a/backend/tests/Unit/Service/ComicSeries/PurgeServiceTest.php
+++ b/backend/tests/Unit/Service/ComicSeries/PurgeServiceTest.php
@@ -12,6 +12,7 @@ use App\Service\ComicSeries\PurgeService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\FilterCollection;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,7 +22,7 @@ final class PurgeServiceTest extends TestCase
 {
     private ComicSeriesRepository&MockObject $comicSeriesRepository;
     private ComicSeriesService&MockObject $comicSeriesService;
-    private EntityManagerInterface&MockObject $entityManager;
+    private EntityManagerInterface&Stub $entityManager;
     private FilterCollection&MockObject $filterCollection;
     private PurgeService $purgeService;
 
@@ -29,7 +30,7 @@ final class PurgeServiceTest extends TestCase
     {
         $this->comicSeriesRepository = $this->createMock(ComicSeriesRepository::class);
         $this->comicSeriesService = $this->createMock(ComicSeriesService::class);
-        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
         $this->filterCollection = $this->createMock(FilterCollection::class);
 
         $this->entityManager->method('getFilters')->willReturn($this->filterCollection);
@@ -133,9 +134,9 @@ final class PurgeServiceTest extends TestCase
         self::assertSame('2025-06-15T10:30:00+00:00', $data['deletedAt']);
     }
 
-    private function createComicSeriesMock(int $id, string $title, \DateTimeImmutable $deletedAt): ComicSeries&MockObject
+    private function createComicSeriesMock(int $id, string $title, \DateTimeImmutable $deletedAt): ComicSeries&Stub
     {
-        $series = $this->createMock(ComicSeries::class);
+        $series = $this->createStub(ComicSeries::class);
         $series->method('getDeletedAt')->willReturn($deletedAt);
         $series->method('getId')->willReturn($id);
         $series->method('getTitle')->willReturn($title);

--- a/backend/tests/Unit/Service/Cover/CoverDownloaderTest.php
+++ b/backend/tests/Unit/Service/Cover/CoverDownloaderTest.php
@@ -11,6 +11,7 @@ use App\Tests\Factory\EntityFactory;
 use Intervention\Image\Drivers\Gd\Driver as GdDriver;
 use Intervention\Image\ImageManager;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -22,12 +23,12 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 final class CoverDownloaderTest extends TestCase
 {
     private ThumbnailGenerator&MockObject $thumbnailGenerator;
-    private UploadHandlerInterface&MockObject $uploadHandler;
+    private UploadHandlerInterface&Stub $uploadHandler;
 
     protected function setUp(): void
     {
         $this->thumbnailGenerator = $this->createMock(ThumbnailGenerator::class);
-        $this->uploadHandler = $this->createMock(UploadHandlerInterface::class);
+        $this->uploadHandler = $this->createStub(UploadHandlerInterface::class);
     }
 
     public function testDownloadAndStoreSetsCoverFile(): void

--- a/backend/tests/Unit/Service/Lookup/BatchLookupServiceTest.php
+++ b/backend/tests/Unit/Service/Lookup/BatchLookupServiceTest.php
@@ -16,22 +16,23 @@ use App\Tests\Factory\EntityFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 final class BatchLookupServiceTest extends TestCase
 {
     private ComicSeriesRepository&MockObject $comicSeriesRepository;
     private EntityManagerInterface&MockObject $entityManager;
-    private LookupApplier&MockObject $lookupApplier;
-    private LookupOrchestrator&MockObject $lookupOrchestrator;
+    private LookupApplier&Stub $lookupApplier;
+    private LookupOrchestrator&Stub $lookupOrchestrator;
     private BatchLookupService $service;
 
     protected function setUp(): void
     {
         $this->comicSeriesRepository = $this->createMock(ComicSeriesRepository::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
-        $this->lookupApplier = $this->createMock(LookupApplier::class);
-        $this->lookupOrchestrator = $this->createMock(LookupOrchestrator::class);
+        $this->lookupApplier = $this->createStub(LookupApplier::class);
+        $this->lookupOrchestrator = $this->createStub(LookupOrchestrator::class);
 
         $this->service = new BatchLookupService(
             $this->comicSeriesRepository,

--- a/backend/tests/Unit/Service/Lookup/LookupApplierTest.php
+++ b/backend/tests/Unit/Service/Lookup/LookupApplierTest.php
@@ -282,7 +282,7 @@ final class LookupApplierTest extends TestCase
             source: 'test',
         );
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
         $response->method('getStatusCode')->willReturn(200);
         $this->httpClient->method('request')
             ->with('HEAD', 'https://www.amazon.fr/dp/B08N5WRWNW')
@@ -302,7 +302,7 @@ final class LookupApplierTest extends TestCase
             source: 'test',
         );
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
         $response->method('getStatusCode')->willReturn(404);
         $this->httpClient->method('request')
             ->with('HEAD', 'https://www.amazon.fr/dp/FAKE123')

--- a/backend/tests/Unit/Service/Lookup/Provider/AniListLookupTest.php
+++ b/backend/tests/Unit/Service/Lookup/Provider/AniListLookupTest.php
@@ -964,7 +964,8 @@ final class AniListLookupTest extends TestCase
         $exception = new class('Timeout') extends \RuntimeException implements TransportExceptionInterface {};
         $response->method('toArray')->willThrowException($exception);
 
-        $this->createLoggerMock();
+        $this->logger = $this->createStub(LoggerInterface::class);
+        $this->provider = new AniListLookup($this->httpClient, $this->logger);
 
         $results = $this->provider->resolveMultipleLookup($response);
 

--- a/backend/tests/Unit/Service/Lookup/Provider/BedethequeLookupTest.php
+++ b/backend/tests/Unit/Service/Lookup/Provider/BedethequeLookupTest.php
@@ -376,7 +376,7 @@ final class BedethequeLookupTest extends TestCase
             'status' => 'RESOURCE_EXHAUSTED',
         ]);
 
-        $pool = $this->createMock(GeminiClientPool::class);
+        $pool = $this->createStub(GeminiClientPool::class);
         $pool->method('executeWithRetry')->willThrowException($exception);
 
         $realCache = new ArrayAdapter();
@@ -406,7 +406,7 @@ final class BedethequeLookupTest extends TestCase
             'status' => 'INTERNAL',
         ]);
 
-        $pool = $this->createMock(GeminiClientPool::class);
+        $pool = $this->createStub(GeminiClientPool::class);
         $pool->method('executeWithRetry')->willThrowException($exception);
 
         $realCache = new ArrayAdapter();
@@ -430,7 +430,7 @@ final class BedethequeLookupTest extends TestCase
      */
     public function testResolveLookupGenericThrowable(): void
     {
-        $pool = $this->createMock(GeminiClientPool::class);
+        $pool = $this->createStub(GeminiClientPool::class);
         $pool->method('executeWithRetry')->willThrowException(new \RuntimeException('Connection lost'));
 
         $realCache = new ArrayAdapter();
@@ -564,11 +564,11 @@ final class BedethequeLookupTest extends TestCase
     }
 
     /**
-     * Crée un GeminiClientPool mock qui délègue au client fourni.
+     * Crée un GeminiClientPool stub qui délègue au client fourni.
      */
     private function createPoolFromClient(GeminiClient $client): GeminiClientPool
     {
-        $pool = $this->createMock(GeminiClientPool::class);
+        $pool = $this->createStub(GeminiClientPool::class);
         $pool->method('executeWithRetry')->willReturnCallback(
             static fn (callable $callback) => $callback($client, 'gemini-2.5-flash'),
         );

--- a/backend/tests/Unit/Service/Lookup/Provider/GeminiLookupTest.php
+++ b/backend/tests/Unit/Service/Lookup/Provider/GeminiLookupTest.php
@@ -334,7 +334,7 @@ final class GeminiLookupTest extends TestCase
             'status' => 'RESOURCE_EXHAUSTED',
         ]);
 
-        $pool = $this->createMock(GeminiClientPool::class);
+        $pool = $this->createStub(GeminiClientPool::class);
         $pool->method('executeWithRetry')->willThrowException($exception);
 
         $realCache = new ArrayAdapter();
@@ -366,7 +366,7 @@ final class GeminiLookupTest extends TestCase
             'status' => 'INTERNAL',
         ]);
 
-        $pool = $this->createMock(GeminiClientPool::class);
+        $pool = $this->createStub(GeminiClientPool::class);
         $pool->method('executeWithRetry')->willThrowException($exception);
 
         $realCache = new ArrayAdapter();
@@ -392,7 +392,7 @@ final class GeminiLookupTest extends TestCase
      */
     public function testResolveLookupGenericThrowable(): void
     {
-        $pool = $this->createMock(GeminiClientPool::class);
+        $pool = $this->createStub(GeminiClientPool::class);
         $pool->method('executeWithRetry')->willThrowException(new \RuntimeException('Connection lost'));
 
         $realCache = new ArrayAdapter();
@@ -794,11 +794,11 @@ final class GeminiLookupTest extends TestCase
     }
 
     /**
-     * Crée un GeminiClientPool mock qui délègue au client fourni.
+     * Crée un GeminiClientPool stub qui délègue au client fourni.
      */
     private function createPoolFromClient(GeminiClient $client): GeminiClientPool
     {
-        $pool = $this->createMock(GeminiClientPool::class);
+        $pool = $this->createStub(GeminiClientPool::class);
         $pool->method('executeWithRetry')->willReturnCallback(
             static fn (callable $callback) => $callback($client, 'gemini-2.5-flash'),
         );

--- a/backend/tests/Unit/Service/Lookup/Provider/GoogleBooksLookupTest.php
+++ b/backend/tests/Unit/Service/Lookup/Provider/GoogleBooksLookupTest.php
@@ -727,7 +727,8 @@ final class GoogleBooksLookupTest extends TestCase
         $exception = new class('Timeout') extends \RuntimeException implements TransportExceptionInterface {};
         $response->method('toArray')->willThrowException($exception);
 
-        $this->createLoggerMock();
+        $this->logger = $this->createStub(LoggerInterface::class);
+        $this->provider = new GoogleBooksLookup('test-api-key', $this->httpClient, $this->logger);
 
         $results = $this->provider->resolveMultipleLookup(['query' => null, 'response' => $response]);
 

--- a/backend/tests/Unit/Service/Merge/MergePreviewBuilderTest.php
+++ b/backend/tests/Unit/Service/Merge/MergePreviewBuilderTest.php
@@ -285,7 +285,7 @@ class MergePreviewBuilderTest extends TestCase
 
     private function createPoolFromClient(GeminiClient $client): GeminiClientPool
     {
-        $pool = $this->createMock(GeminiClientPool::class);
+        $pool = $this->createStub(GeminiClientPool::class);
         $pool->method('executeWithRetry')->willReturnCallback(
             static fn (callable $callback) => $callback($client, 'gemini-2.5-flash'),
         );

--- a/backend/tests/Unit/Service/Merge/SeriesGroupDetectorTest.php
+++ b/backend/tests/Unit/Service/Merge/SeriesGroupDetectorTest.php
@@ -314,7 +314,7 @@ final class SeriesGroupDetectorTest extends TestCase
      */
     private function createPoolFromClient(GeminiClient $client): GeminiClientPool
     {
-        $pool = $this->createMock(GeminiClientPool::class);
+        $pool = $this->createStub(GeminiClientPool::class);
         $pool->method('executeWithRetry')->willReturnCallback(
             static fn (callable $callback) => $callback($client, 'gemini-2.5-flash'),
         );

--- a/backend/tests/Unit/Service/Merge/SeriesMergerTest.php
+++ b/backend/tests/Unit/Service/Merge/SeriesMergerTest.php
@@ -15,6 +15,7 @@ use App\Repository\ComicSeriesRepository;
 use App\Service\Merge\SeriesMerger;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,14 +24,14 @@ use PHPUnit\Framework\TestCase;
 final class SeriesMergerTest extends TestCase
 {
     private AuthorRepository&MockObject $authorRepository;
-    private ComicSeriesRepository&MockObject $comicSeriesRepository;
+    private ComicSeriesRepository&Stub $comicSeriesRepository;
     private EntityManagerInterface&MockObject $entityManager;
     private SeriesMerger $merger;
 
     protected function setUp(): void
     {
         $this->authorRepository = $this->createMock(AuthorRepository::class);
-        $this->comicSeriesRepository = $this->createMock(ComicSeriesRepository::class);
+        $this->comicSeriesRepository = $this->createStub(ComicSeriesRepository::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
 
         $this->merger = new SeriesMerger(

--- a/backend/tests/Unit/Service/Recommendation/NewReleaseCheckerServiceTest.php
+++ b/backend/tests/Unit/Service/Recommendation/NewReleaseCheckerServiceTest.php
@@ -13,6 +13,7 @@ use App\Service\Recommendation\NewReleaseCheckerService;
 use App\Tests\Factory\EntityFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,14 +22,14 @@ use PHPUnit\Framework\TestCase;
 final class NewReleaseCheckerServiceTest extends TestCase
 {
     private EntityManagerInterface&MockObject $entityManager;
-    private LookupOrchestrator&MockObject $lookupOrchestrator;
+    private LookupOrchestrator&Stub $lookupOrchestrator;
     private NewReleaseCheckerService $service;
     private ComicSeriesRepository&MockObject $repository;
 
     protected function setUp(): void
     {
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
-        $this->lookupOrchestrator = $this->createMock(LookupOrchestrator::class);
+        $this->lookupOrchestrator = $this->createStub(LookupOrchestrator::class);
         $this->repository = $this->createMock(ComicSeriesRepository::class);
 
         $this->service = new NewReleaseCheckerService(


### PR DESCRIPTION
## Contexte

Le passage à PHPUnit 12.5 (#471) a introduit **139 notices** « No expectations were configured for the mock object — consider a test stub instead » : PHPUnit signale les `createMock()` utilisés sans `->expects()`, qui devraient être des stubs.

## Changements

Conversion en `createStub()` des objets utilisés **uniquement comme stubs** (ni `->expects()` ni `->with()`), ce qui correspond au style déjà majoritaire du projet (338 `createStub` existants). 20 fichiers de tests.

Restent volontairement des `createMock()` :
- les **mocks véritables** vérifiés via `->expects()` ;
- ceux qui **filtrent les arguments via `->with()`** (déprécié sur un stub, et le retirer supprimerait une assertion).

Leur notice résiduelle est attendue et acceptable.

## Garde-fous

- **Aucune dépréciation introduite** (un premier jet en avait créé 4 via `->with()` sur stub + supprimé 5 `->with()` ; corrigé).
- **Aucune assertion perdue** : 2942 avant comme après.
- Notices : **139 → 77**.

## Tests

- ✅ PHPStan niveau 9 + CS Fixer
- ✅ 1084 tests, 2942 assertions, 0 dépréciation