### PR TITLE
fix: répare la tâche de réinitialisation et rend visibles les échecs de déploiement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 ### Fixed
 
 - **Tâches de déploiement** : `Task001ResetAndImport` échouait en production (`make: No rule to make target 'db-reset'`) car aucun Makefile n'est livré dans l'image. La réinitialisation passe désormais par les commandes console Doctrine directes. Le helper `runMake` (inutilisable en prod) est remplacé par `runProcess()` pour les commandes système arbitraires.
+- **Déploiement NAS** : `nas-update.sh` ne signalait pas l'échec des étapes post-déploiement (cache, migrations, tâches one-shot) — le déploiement restait « vert » malgré une tâche en échec. Ces commandes font désormais échouer le déploiement (sortie non nulle → job GitHub rouge + collecte des logs de crash).
 
 ## [v2.30.0] — 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tâches de déploiement** : `Task001ResetAndImport` échouait en production (`make: No rule to make target 'db-reset'`) car aucun Makefile n'est livré dans l'image. La réinitialisation passe désormais par les commandes console Doctrine directes. Le helper `runMake` (inutilisable en prod) est remplacé par `runProcess()` pour les commandes système arbitraires.
+
 ## [v2.30.0] — 2026-06-07
 
 ### Changed

--- a/backend/deploy-tasks/Task001ResetAndImport.php
+++ b/backend/deploy-tasks/Task001ResetAndImport.php
@@ -25,7 +25,12 @@ final class Task001ResetAndImport extends AbstractDeployTask
             throw new \RuntimeException(\sprintf('Fichier %s introuvable. Copier le fichier avant de déployer.', $importFile));
         }
 
-        $this->runMake('db-reset', $io);
+        // Réinitialise la base : suppression, recréation puis migrations
+        // (équivalent de `make db-reset`, mais sans Makefile en production).
+        $this->runConsole('doctrine:database:drop', ['--force', '--if-exists', '--env=prod'], $io);
+        $this->runConsole('doctrine:database:create', ['--env=prod'], $io);
+        $this->runConsole('doctrine:migrations:migrate', ['-n', '--env=prod'], $io);
+
         $this->runConsole('app:import', [$importFile, '--env=prod'], $io);
 
         $io->success('BDD réinitialisée et import terminé.');

--- a/backend/src/DeployTask/AbstractDeployTask.php
+++ b/backend/src/DeployTask/AbstractDeployTask.php
@@ -12,30 +12,13 @@ use Symfony\Component\Process\Process;
  */
 abstract class AbstractDeployTask implements DeployTaskInterface
 {
-    private const array ALLOWED_MAKE_TARGETS = [
-        'cc', 'db-migrate', 'db-reset', 'db-seed',
-        'install-back', 'install-back-prod', 'install-front', 'install-front-prod',
-    ];
-
     private const array ALLOWED_CONSOLE_PREFIXES = [
         'app:', 'cache:', 'doctrine:', 'lexik:', 'messenger:',
     ];
 
-    private readonly string $rootDir;
-
     public function __construct(
         protected readonly string $projectDir,
     ) {
-        $this->rootDir = \dirname($projectDir);
-    }
-
-    protected function runMake(string $target, SymfonyStyle $io): void
-    {
-        if (!\in_array($target, self::ALLOWED_MAKE_TARGETS, true)) {
-            throw new \InvalidArgumentException(\sprintf('Make target non autorisé : %s', $target));
-        }
-
-        $this->doRun(['make', $target], $this->rootDir, $io);
     }
 
     /**
@@ -56,6 +39,19 @@ abstract class AbstractDeployTask implements DeployTaskInterface
         }
 
         $this->doRun(\array_merge(['php', 'bin/console', $command], $arguments), $this->projectDir, $io);
+    }
+
+    /**
+     * Exécute une commande système arbitraire dans le conteneur (cwd = projectDir).
+     *
+     * Réservé au code first-party des tâches de déploiement : la commande
+     * n'est pas filtrée, contrairement à runConsole().
+     *
+     * @param list<string> $command ex. ['tar', '-xzf', $archive, '-C', $dest]
+     */
+    protected function runProcess(array $command, SymfonyStyle $io): void
+    {
+        $this->doRun($command, $this->projectDir, $io);
     }
 
     /**

--- a/backend/tests/Unit/DeployTask/AbstractDeployTaskTest.php
+++ b/backend/tests/Unit/DeployTask/AbstractDeployTaskTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\DeployTask;
+
+use App\DeployTask\AbstractDeployTask;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Tests unitaires pour AbstractDeployTask.
+ */
+final class AbstractDeployTaskTest extends TestCase
+{
+    public function testRunProcessSucceedsOnZeroExit(): void
+    {
+        $task = $this->createTask();
+
+        $task->callProcess(['true'], $this->createIo());
+
+        $this->addToAssertionCount(1); // aucune exception levée
+    }
+
+    public function testRunProcessThrowsOnNonZeroExit(): void
+    {
+        $task = $this->createTask();
+
+        $this->expectException(\RuntimeException::class);
+
+        $task->callProcess(['false'], $this->createIo());
+    }
+
+    public function testRunConsoleRejectsNonWhitelistedCommand(): void
+    {
+        $task = $this->createTask();
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $task->callConsole('server:run', [], $this->createIo());
+    }
+
+    /**
+     * Sous-classe de test exposant les helpers protégés.
+     */
+    private function createTask(): AbstractDeployTask&TestDeployTaskProxy
+    {
+        return new class(\sys_get_temp_dir()) extends AbstractDeployTask implements TestDeployTaskProxy {
+            public function getDescription(): string
+            {
+                return 'Tâche de test';
+            }
+
+            public function execute(SymfonyStyle $io): void
+            {
+            }
+
+            public function callProcess(array $command, SymfonyStyle $io): void
+            {
+                $this->runProcess($command, $io);
+            }
+
+            public function callConsole(string $command, array $arguments, SymfonyStyle $io): void
+            {
+                $this->runConsole($command, $arguments, $io);
+            }
+        };
+    }
+
+    private function createIo(): SymfonyStyle
+    {
+        return new SymfonyStyle(new ArrayInput([]), new NullOutput());
+    }
+}
+
+/**
+ * Contrat exposant les helpers protégés d'AbstractDeployTask pour les tests.
+ */
+interface TestDeployTaskProxy
+{
+    /**
+     * @param list<string> $command
+     */
+    public function callProcess(array $command, SymfonyStyle $io): void;
+
+    /**
+     * @param array<string> $arguments
+     */
+    public function callConsole(string $command, array $arguments, SymfonyStyle $io): void;
+}

--- a/scripts/nas-update.sh
+++ b/scripts/nas-update.sh
@@ -100,11 +100,17 @@ if try_deploy; then
     sleep 15
 
     # Vider le cache Symfony en tant que www-data (le volume app_var persiste entre les rebuilds)
-    docker compose --env-file "$ENV_FILE" exec -T -u www-data php php bin/console cache:clear --env=prod 2>&1 | tee -a "$LOG_FILE"
+    if ! docker compose --env-file "$ENV_FILE" exec -T -u www-data php php bin/console cache:clear --env=prod 2>&1 | tee -a "$LOG_FILE"; then
+        log "ERREUR: le vidage du cache Symfony a échoué."
+        exit 1
+    fi
     log "Cache Symfony vidé."
 
     # Migrations
-    docker compose --env-file "$ENV_FILE" exec -T php php bin/console doctrine:migrations:migrate -n --env=prod 2>&1 | tee -a "$LOG_FILE"
+    if ! docker compose --env-file "$ENV_FILE" exec -T php php bin/console doctrine:migrations:migrate -n --env=prod 2>&1 | tee -a "$LOG_FILE"; then
+        log "ERREUR: les migrations ont échoué."
+        exit 1
+    fi
     log "Migrations exécutées."
 
     # Copier le fichier d'import s'il existe
@@ -114,7 +120,10 @@ if try_deploy; then
     fi
 
     # Tâches de déploiement one-shot
-    docker compose --env-file "$ENV_FILE" exec -T php php bin/console app:deploy:run-tasks -n --env=prod 2>&1 | tee -a "$LOG_FILE"
+    if ! docker compose --env-file "$ENV_FILE" exec -T php php bin/console app:deploy:run-tasks -n --env=prod 2>&1 | tee -a "$LOG_FILE"; then
+        log "ERREUR: les tâches de déploiement ont échoué."
+        exit 1
+    fi
     log "Tâches de déploiement exécutées."
 
     # Nettoyage du fichier d'import


### PR DESCRIPTION
## Problème

Au déploiement de v2.30.0, la tâche `Task001ResetAndImport` a échoué sur le NAS :

```
make: *** No rule to make target 'db-reset'. Stop.
```

… **mais le déploiement est resté vert sur GitHub** : l'échec n'a pas été remonté. Deux bugs distincts.

### 1. La tâche elle-même

`runMake('db-reset')` exécute `make` dans le parent du dossier projet, or :
- aucun `Makefile` n'est livré dans l'image (le `Makefile` racine est hors du contexte de build `backend/`) ;
- ce `Makefile` racine est conçu pour le monorepo DDEV (`cd backend`, `include backend/.env`) et ne peut pas tourner dans le conteneur prod (layout plat `/var/www/html`).

### 2. L'échec silencieux

`nas-update.sh` lançait `cache:clear`, `doctrine:migrations:migrate` et `app:deploy:run-tasks` en *fire-and-forget* (`cmd | tee`, sans test du code retour). Une étape en échec laissait le script continuer puis sortir en 0 → job GitHub vert. Une **migration** ratée aurait été tout aussi silencieuse.

## Corrections

**Tâche** (`Task001ResetAndImport` / `AbstractDeployTask`)
- Réinitialisation via les commandes console Doctrine directes (`doctrine:database:drop --force --if-exists`, `database:create`, `migrations:migrate -n`).
- Suppression de `runMake`/`ALLOWED_MAKE_TARGETS` (inutilisables en prod) au profit de `runProcess(array $command)` pour les commandes système arbitraires.

**Déploiement** (`nas-update.sh`)
- `cache:clear`, `migrations:migrate` et `run-tasks` font désormais échouer le déploiement (sortie non nulle → job GitHub rouge + collecte des logs de crash via l'étape `if: failure()` existante). `pipefail` était déjà actif. `warm-thumbnails` et le nettoyage d'images restent non bloquants.

## Rejeu automatique

Le runner n'enregistre une tâche comme exécutée qu'**après** son succès : `Task001` est toujours **en attente** et se rejouera au prochain déploiement avec le code corrigé. Aucun nettoyage de `deploy-tasks-executed.json` requis.

## Tests

- ✅ Nouveau `AbstractDeployTaskTest` : `runProcess` (succès / échec → exception) + rejet d'une commande console non whitelistée
- ✅ PHPStan niveau 9 + CS Fixer · 1087 tests backend
- ✅ `bash -n scripts/nas-update.sh`