### PR TITLE
fix: la génération des miniatures ne bloque plus le déploiement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Déploiement** : la génération des miniatures de couverture (`app:warm-thumbnails --async`) est désormais déléguée au worker Messenger au lieu de bloquer le déploiement — indispensable à mesure que le catalogue grossit.
+
 ## [v2.30.1] — 2026-06-07
 
 ### Fixed

--- a/backend/config/packages/messenger.yaml
+++ b/backend/config/packages/messenger.yaml
@@ -8,6 +8,7 @@ framework:
         routing:
             App\Message\DownloadCoverMessage: async
             App\Message\EnrichSeriesMessage: async
+            App\Message\WarmThumbnailsMessage: async
         transports:
             async:
                 dsn: '%env(MESSENGER_TRANSPORT_DSN)%'

--- a/backend/src/Command/WarmThumbnailsCommand.php
+++ b/backend/src/Command/WarmThumbnailsCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Command;
 
+use App\Message\WarmThumbnailsMessage;
 use App\Repository\ComicSeriesRepository;
 use App\Service\Cover\ThumbnailGenerator;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -12,6 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * Génère les miniatures LiipImagine pour toutes les couvertures existantes.
@@ -24,6 +26,7 @@ final class WarmThumbnailsCommand extends Command
 {
     public function __construct(
         private readonly ComicSeriesRepository $comicSeriesRepository,
+        private readonly MessageBusInterface $messageBus,
         private readonly ThumbnailGenerator $thumbnailGenerator,
     ) {
         parent::__construct();
@@ -32,6 +35,7 @@ final class WarmThumbnailsCommand extends Command
     protected function configure(): void
     {
         $this
+            ->addOption('async', null, InputOption::VALUE_NONE, 'Déléguer la génération au worker Messenger (non bloquant)')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Simuler sans générer')
         ;
     }
@@ -40,6 +44,8 @@ final class WarmThumbnailsCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
+        /** @var bool $async */
+        $async = $input->getOption('async');
         /** @var bool $dryRun */
         $dryRun = $input->getOption('dry-run');
 
@@ -61,7 +67,7 @@ final class WarmThumbnailsCommand extends Command
             return Command::SUCCESS;
         }
 
-        $generated = 0;
+        $count = 0;
 
         foreach ($series as $comic) {
             $coverImage = $comic->getCoverImage();
@@ -70,11 +76,18 @@ final class WarmThumbnailsCommand extends Command
                 continue;
             }
 
-            $this->thumbnailGenerator->generate($coverImage);
-            ++$generated;
+            if ($async) {
+                $this->messageBus->dispatch(new WarmThumbnailsMessage($coverImage));
+            } else {
+                $this->thumbnailGenerator->generate($coverImage);
+            }
+
+            ++$count;
         }
 
-        $io->success(\sprintf('%d miniature(s) générée(s).', $generated));
+        $io->success($async
+            ? \sprintf('%d génération(s) de miniature déléguée(s) au worker.', $count)
+            : \sprintf('%d miniature(s) générée(s).', $count));
 
         return Command::SUCCESS;
     }

--- a/backend/src/Message/WarmThumbnailsMessage.php
+++ b/backend/src/Message/WarmThumbnailsMessage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+/**
+ * Message pour la génération asynchrone d'une miniature de couverture.
+ */
+final readonly class WarmThumbnailsMessage
+{
+    public function __construct(
+        public string $coverImage,
+    ) {
+    }
+}

--- a/backend/src/MessageHandler/WarmThumbnailsHandler.php
+++ b/backend/src/MessageHandler/WarmThumbnailsHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Message\WarmThumbnailsMessage;
+use App\Service\Cover\ThumbnailGenerator;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Handler pour la génération asynchrone d'une miniature de couverture.
+ */
+#[AsMessageHandler]
+final readonly class WarmThumbnailsHandler
+{
+    public function __construct(
+        private ThumbnailGenerator $thumbnailGenerator,
+    ) {
+    }
+
+    public function __invoke(WarmThumbnailsMessage $message): void
+    {
+        $this->thumbnailGenerator->generate($message->coverImage);
+    }
+}

--- a/backend/tests/Integration/Command/WarmThumbnailsCommandTest.php
+++ b/backend/tests/Integration/Command/WarmThumbnailsCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Command;
 
+use App\Message\WarmThumbnailsMessage;
 use App\Service\Cover\ThumbnailGenerator;
 use App\Tests\Factory\EntityFactory;
 use Doctrine\ORM\EntityManagerInterface;
@@ -11,6 +12,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 
 /**
  * Tests d'intégration pour la commande app:warm-thumbnails.
@@ -53,6 +56,51 @@ final class WarmThumbnailsCommandTest extends KernelTestCase
 
         self::assertSame(0, $commandTester->getStatusCode());
         self::assertStringContainsString('2', $commandTester->getDisplay());
+    }
+
+    public function testAsyncDispatchesMessagesInsteadOfGenerating(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+
+        /** @var ThumbnailGenerator&MockObject $thumbnailGenerator */
+        $thumbnailGenerator = $this->createMock(ThumbnailGenerator::class);
+        $container->set(ThumbnailGenerator::class, $thumbnailGenerator);
+
+        // En mode async, rien n'est généré synchroniquement.
+        $thumbnailGenerator->expects(self::never())
+            ->method('generate');
+
+        /** @var EntityManagerInterface $em */
+        $em = $container->get(EntityManagerInterface::class);
+
+        $series1 = EntityFactory::createComicSeries('Async 1');
+        $series1->setCoverImage('async1.webp');
+        $em->persist($series1);
+
+        $series2 = EntityFactory::createComicSeries('Async 2');
+        $series2->setCoverImage('async2.webp');
+        $em->persist($series2);
+
+        $em->flush();
+
+        $application = new Application(self::$kernel); // @phpstan-ignore argument.type
+        $command = $application->find('app:warm-thumbnails');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['--async' => true]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+
+        // Un message WarmThumbnailsMessage par couverture est mis en file
+        // (le transport peut aussi contenir des messages déclenchés par la
+        // création des séries — on ne compte que les nôtres).
+        /** @var InMemoryTransport $transport */
+        $transport = $container->get('messenger.transport.async');
+        $warmMessages = \array_filter(
+            $transport->getSent(),
+            static fn (Envelope $envelope): bool => $envelope->getMessage() instanceof WarmThumbnailsMessage,
+        );
+        self::assertCount(2, $warmMessages);
     }
 
     public function testDryRunDoesNotGenerateThumbnails(): void

--- a/backend/tests/Unit/MessageHandler/WarmThumbnailsHandlerTest.php
+++ b/backend/tests/Unit/MessageHandler/WarmThumbnailsHandlerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MessageHandler;
+
+use App\Message\WarmThumbnailsMessage;
+use App\MessageHandler\WarmThumbnailsHandler;
+use App\Service\Cover\ThumbnailGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires pour WarmThumbnailsHandler.
+ */
+final class WarmThumbnailsHandlerTest extends TestCase
+{
+    public function testInvokeGeneratesThumbnailForCover(): void
+    {
+        /** @var ThumbnailGenerator&MockObject $thumbnailGenerator */
+        $thumbnailGenerator = $this->createMock(ThumbnailGenerator::class);
+        $thumbnailGenerator->expects(self::once())
+            ->method('generate')
+            ->with('cover1.webp');
+
+        $handler = new WarmThumbnailsHandler($thumbnailGenerator);
+        $handler(new WarmThumbnailsMessage('cover1.webp'));
+    }
+}

--- a/scripts/nas-update.sh
+++ b/scripts/nas-update.sh
@@ -129,9 +129,10 @@ if try_deploy; then
     # Nettoyage du fichier d'import
     docker compose --env-file "$ENV_FILE" exec -T php rm -f var/import.xlsx 2>&1 | tee -a "$LOG_FILE"
 
-    # Miniatures de couverture (LiipImagine)
-    docker compose --env-file "$ENV_FILE" exec -T -u www-data php php bin/console app:warm-thumbnails --env=prod 2>&1 | tee -a "$LOG_FILE"
-    log "Miniatures de couverture générées."
+    # Miniatures de couverture (LiipImagine) : délègue au worker Messenger
+    # pour ne pas bloquer le déploiement sur tout le catalogue.
+    docker compose --env-file "$ENV_FILE" exec -T -u www-data php php bin/console app:warm-thumbnails --async --env=prod 2>&1 | tee -a "$LOG_FILE"
+    log "Génération des miniatures déléguée au worker."
 
     # Supprimer les anciennes images bibliotheque (garde uniquement la version courante)
     docker images --format '{{.Repository}}:{{.Tag}}' \


### PR DESCRIPTION
## Contexte

Au déploiement v2.30.1, l'étape `app:warm-thumbnails` tournait de façon **synchrone** dans `nas-update.sh`. Anodin tant que le catalogue est vide (« Aucune série avec couverture locale »), mais voué à faire dépasser le délai SSH à mesure que les 1188 séries récupèrent leurs couvertures.

## Changement

`app:warm-thumbnails` gagne une option **`--async`** :
- énumère les couvertures et délègue chaque génération au worker via un `WarmThumbnailsMessage` (un par couverture), routé sur le transport `async` déjà consommé par le worker (retries + transport d'échec) ;
- le mode synchrone reste disponible pour le dev/manuel.

`nas-update.sh` utilise `--async` : le déploiement ne fait plus que mettre les miniatures en file, le worker s'en charge ensuite.

Suit le motif existant `DownloadCoverMessage` / `EnrichSeriesMessage`.

## Pourquoi pas un timeout SSH plus long ?

Envisagé puis écarté : maintenant que l'étape non bornée est asynchrone, un déploiement long signalerait un vrai problème — augmenter le timeout ne ferait que masquer un blocage. Le défaut (10 min) est conservé.

## Tests

- ✅ `WarmThumbnailsHandlerTest` (génère la miniature pour la couverture du message)
- ✅ `WarmThumbnailsCommandTest::testAsyncDispatchesMessagesInsteadOfGenerating` (un message par couverture, aucune génération synchrone)
- ✅ PHPStan niveau 9 + CS Fixer · 1089 tests backend · `bash -n scripts/nas-update.sh`