### PR TITLE
fix: stop ISBN search from overwriting series with tome data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Recherche par ISBN (fiche série)** : un ISBN identifie un album précis. Pour une série multi-tomes, la recherche remplissait la fiche série avec les infos du **tome** (ex. ISBN du tome 1 d'« Akademy » → titre « La cour des grands » au lieu d'« Akademy »). Désormais : un ISBN one-shot remplit la série normalement ; un ISBN de tome ne modifie jamais le titre de la série et n'applique que les champs de série ; si le statut (one-shot ou non) ne peut être déterminé, la recherche est bloquée avec un message invitant à utiliser la recherche par titre.
+
 ## [v2.31.0] — 2026-06-07
 
 ### Changed

--- a/frontend/src/__tests__/integration/hooks/useLookupFeature.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useLookupFeature.test.tsx
@@ -1,0 +1,243 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useLookupFeature } from "../../../hooks/useLookupFeature";
+import type { FormData } from "../../../hooks/useComicForm";
+import { createMockLookupResult } from "../../helpers/factories";
+import { server } from "../../helpers/server";
+import { createTestQueryClient } from "../../helpers/test-utils";
+
+const { toastSuccess, toastWarning, toastError } = vi.hoisted(() => ({
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastWarning: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: toastError, success: toastSuccess, warning: toastWarning },
+}));
+
+const API_BASE = "/api";
+const ISBN = "9782756006383";
+
+type UpdateFn = <K extends keyof FormData>(key: K, value: FormData[K]) => void;
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function createForm(overrides: Partial<FormData> = {}): FormData {
+  return {
+    amazonUrl: "",
+    authors: [],
+    coverUrl: "",
+    defaultTomeBought: false,
+    defaultTomeOnNas: false,
+    defaultTomeRead: false,
+    description: "",
+    isOneShot: false,
+    latestPublishedIssue: "",
+    latestPublishedIssueComplete: false,
+    lookupCompletedAt: null,
+    publishedDate: "",
+    publisher: "",
+    status: "buying",
+    title: "Akademy",
+    tomes: [],
+    type: "BD",
+    ...overrides,
+  };
+}
+
+/** Rend le hook en mode ISBN et attend que le résultat ISBN soit chargé. */
+async function renderIsbnMode(update: ReturnType<typeof vi.fn>) {
+  const form = createForm();
+  const view = renderHook(
+    () => useLookupFeature(form, update as unknown as UpdateFn),
+    { wrapper: createWrapper() },
+  );
+
+  act(() => {
+    view.result.current.setLookupMode("isbn");
+    view.result.current.setLookupIsbn(ISBN);
+  });
+
+  await waitFor(() =>
+    expect(view.result.current.lookupResult.data).toBeDefined(),
+  );
+
+  return view;
+}
+
+describe("useLookupFeature.applyLookup (ISBN)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    toastSuccess.mockClear();
+    toastWarning.mockClear();
+    toastError.mockClear();
+  });
+
+  it("one-shot : applique tous les champs (titre inclus)", async () => {
+    server.use(
+      http.get(`${API_BASE}/lookup/isbn`, () =>
+        HttpResponse.json(
+          createMockLookupResult({
+            description: "Synopsis du one-shot",
+            isOneShot: true,
+            title: "Le Photographe",
+          }),
+        ),
+      ),
+    );
+
+    const update = vi.fn();
+    const view = await renderIsbnMode(update);
+
+    await act(async () => {
+      await view.result.current.applyLookup();
+    });
+
+    expect(update).toHaveBeenCalledWith("title", "Le Photographe");
+    expect(update).toHaveBeenCalledWith("description", "Synopsis du one-shot");
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+
+  it("multi-tomes (isOneShot=false depuis l'ISBN) : ne touche jamais au titre", async () => {
+    server.use(
+      http.get(`${API_BASE}/lookup/isbn`, () =>
+        HttpResponse.json(
+          createMockLookupResult({
+            description: "Résumé du tome 1",
+            isOneShot: false,
+            latestPublishedIssue: 5,
+            thumbnail: "https://example.test/tome1.jpg",
+            title: "La cour des grands",
+          }),
+        ),
+      ),
+    );
+
+    const update = vi.fn();
+    const view = await renderIsbnMode(update);
+
+    await act(async () => {
+      await view.result.current.applyLookup();
+    });
+
+    const updatedKeys = update.mock.calls.map((call) => call[0]);
+    expect(updatedKeys).not.toContain("title");
+    expect(updatedKeys).not.toContain("description");
+    expect(updatedKeys).not.toContain("coverUrl");
+    expect(updatedKeys).not.toContain("publishedDate");
+    expect(update).toHaveBeenCalledWith("isOneShot", false);
+    expect(update).toHaveBeenCalledWith("latestPublishedIssue", "5");
+    expect(toastWarning).toHaveBeenCalled();
+  });
+
+  it("isOneShot null : lookup titre résout multi-tomes → titre conservé", async () => {
+    server.use(
+      http.get(`${API_BASE}/lookup/isbn`, () =>
+        HttpResponse.json(
+          createMockLookupResult({
+            isOneShot: null,
+            title: "La cour des grands",
+          }),
+        ),
+      ),
+      http.get(`${API_BASE}/lookup/title`, () =>
+        HttpResponse.json(
+          createMockLookupResult({
+            isOneShot: false,
+            latestPublishedIssue: 5,
+            title: "La cour des grands",
+          }),
+        ),
+      ),
+    );
+
+    const update = vi.fn();
+    const view = await renderIsbnMode(update);
+
+    await act(async () => {
+      await view.result.current.applyLookup();
+    });
+
+    const updatedKeys = update.mock.calls.map((call) => call[0]);
+    expect(updatedKeys).not.toContain("title");
+    expect(update).toHaveBeenCalledWith("isOneShot", false);
+    expect(update).toHaveBeenCalledWith("latestPublishedIssue", "5");
+    expect(toastWarning).toHaveBeenCalled();
+  });
+
+  it("isOneShot null : lookup titre résout one-shot → applique le titre", async () => {
+    server.use(
+      http.get(`${API_BASE}/lookup/isbn`, () =>
+        HttpResponse.json(
+          createMockLookupResult({ isOneShot: null, title: "Le Photographe" }),
+        ),
+      ),
+      http.get(`${API_BASE}/lookup/title`, () =>
+        HttpResponse.json(
+          createMockLookupResult({
+            isOneShot: true,
+            title: "Le Photographe",
+          }),
+        ),
+      ),
+    );
+
+    const update = vi.fn();
+    const view = await renderIsbnMode(update);
+
+    await act(async () => {
+      await view.result.current.applyLookup();
+    });
+
+    expect(update).toHaveBeenCalledWith("title", "Le Photographe");
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+
+  it("isOneShot indéterminé même après lookup titre : n'applique rien", async () => {
+    server.use(
+      http.get(`${API_BASE}/lookup/isbn`, () =>
+        HttpResponse.json(
+          createMockLookupResult({
+            isOneShot: null,
+            title: "La cour des grands",
+          }),
+        ),
+      ),
+      http.get(`${API_BASE}/lookup/title`, () =>
+        HttpResponse.json(
+          createMockLookupResult({
+            isOneShot: null,
+            title: "La cour des grands",
+          }),
+        ),
+      ),
+    );
+
+    const update = vi.fn();
+    const view = await renderIsbnMode(update);
+
+    await act(async () => {
+      await view.result.current.applyLookup();
+    });
+
+    expect(update).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
@@ -410,17 +410,20 @@ describe("ComicForm", () => {
       ).toBeInTheDocument();
     });
 
-    it("chains ISBN lookup to title lookup when clicking Appliquer", async () => {
+    it("one-shot résolu via lookup titre : remplit le formulaire", async () => {
       const user = userEvent.setup();
 
+      // ISBN sans statut one-shot (cas BNF) → résolu par le lookup titre.
       const isbnResult = createMockLookupResult({
         isbn: "9781234567890",
+        isOneShot: null,
         title: "ISBN Series Title",
       });
 
       const titleResult = createMockLookupResult({
         authors: "Chained Author",
         description: "Chained description",
+        isOneShot: true,
         publisher: "ChainedPub",
         thumbnail: "https://example.com/chained.jpg",
         title: "ISBN Series Title",
@@ -464,14 +467,15 @@ describe("ComicForm", () => {
       );
     });
 
-    it("ISBN lookup with empty title applies result directly without title lookup", async () => {
+    it("one-shot connu depuis l'ISBN : applique directement sans lookup titre", async () => {
       const user = userEvent.setup();
 
       const isbnResult = createMockLookupResult({
         isbn: "9781234567890",
+        isOneShot: true,
         publisher: "DirectPub",
         thumbnail: "https://example.com/cover.jpg",
-        title: "",
+        title: "Direct One Shot",
       });
 
       let titleLookupCalled = false;
@@ -510,25 +514,24 @@ describe("ComicForm", () => {
 
       await user.click(screen.getByText("Appliquer"));
 
-      // Publisher should be applied directly from ISBN result
+      // One-shot : titre et éditeur appliqués directement depuis l'ISBN.
       await waitFor(() => {
-        expect(screen.getByLabelText("Éditeur")).toHaveValue("DirectPub");
+        expect(screen.getByLabelText("Titre *")).toHaveValue("Direct One Shot");
       });
-      // Title lookup must NOT have been called
+      expect(screen.getByLabelText("Éditeur")).toHaveValue("DirectPub");
+      // Pas de lookup titre puisque le statut one-shot est déjà connu.
       expect(titleLookupCalled).toBe(false);
-      // Toast for direct apply
-      await waitFor(() => {
-        expect(screen.getByText("Informations récupérées")).toBeInTheDocument();
-      });
     });
 
-    it("falls back to ISBN result when title lookup fails after ISBN lookup", async () => {
+    it("statut one-shot indéterminable : bloque et ne touche pas au titre", async () => {
       const user = userEvent.setup();
 
+      // ISBN sans statut one-shot, et le lookup titre échoue → indéterminé.
       const isbnResult = createMockLookupResult({
         isbn: "9781234567890",
+        isOneShot: null,
         publisher: "ISBN-Only Pub",
-        title: "Fallback Title",
+        title: "Tome Title",
       });
 
       server.use(
@@ -564,11 +567,14 @@ describe("ComicForm", () => {
 
       await user.click(screen.getByText("Appliquer"));
 
-      // Should fall back to ISBN result fields
+      // Message d'erreur affiché, et aucun champ série corrompu.
       await waitFor(() => {
-        expect(screen.getByLabelText("Titre *")).toHaveValue("Fallback Title");
+        expect(
+          screen.getByText(/Impossible de déterminer la série/),
+        ).toBeInTheDocument();
       });
-      expect(screen.getByLabelText("Éditeur")).toHaveValue("ISBN-Only Pub");
+      expect(screen.getByLabelText("Titre *")).toHaveValue("");
+      expect(screen.getByLabelText("Éditeur")).toHaveValue("");
     });
 
     it("applies isOneShot=true from lookup result and checks the oneshot checkbox", async () => {

--- a/frontend/src/hooks/useLookupFeature.ts
+++ b/frontend/src/hooks/useLookupFeature.ts
@@ -84,6 +84,26 @@ export function useLookupFeature(
     }
   };
 
+  /**
+   * Applique uniquement les champs de niveau série pour une série multi-tomes.
+   * Un ISBN identifie un tome précis : son titre, sa couverture, sa description
+   * et sa date sont propres au tome et ne doivent jamais écraser la fiche série.
+   */
+  const applySeriesLevelFields = (
+    isbnResult: LookupResult,
+    seriesResult: LookupResult,
+  ) => {
+    update("isOneShot", false);
+
+    const latestPublishedIssue =
+      seriesResult.latestPublishedIssue ?? isbnResult.latestPublishedIssue;
+    if (latestPublishedIssue !== null) {
+      update("latestPublishedIssue", latestPublishedIssue.toString());
+    }
+
+    update("lookupCompletedAt", new Date().toISOString());
+  };
+
   const submitTitleSearch = () => {
     const trimmed = lookupTitle.trim();
     if (trimmed.length >= 2) {
@@ -103,22 +123,48 @@ export function useLookupFeature(
     const result = lookupResult.data;
     if (!result) return;
 
-    if (lookupMode === "isbn" && result.title) {
-      setIsApplying(true);
-      try {
-        const titleResult = await fetchLookupTitle(result.title, form.type);
-        applySeriesFields(titleResult);
-        toast.success("Informations récupérées (ISBN → titre)");
-      } catch {
-        applySeriesFields(result);
-        toast.success("Informations récupérées (ISBN uniquement)");
-      } finally {
-        setIsApplying(false);
-      }
-    } else {
+    if (lookupMode !== "isbn") {
       applySeriesFields(result);
       setSelectedCandidateTitle(null);
       toast.success("Informations récupérées");
+      return;
+    }
+
+    // Un ISBN identifie un album précis :
+    //  - one-shot   → l'album EST la série → on applique tout (titre inclus)
+    //  - multi-tomes → l'album est un tome → on n'écrase jamais la fiche série
+    //  - indéterminé → on n'applique rien (le titre du tome corromprait la série)
+    setIsApplying(true);
+    try {
+      let isOneShot = result.isOneShot;
+      let seriesResult = result;
+
+      // BNF/Google Books ne renseignent pas isOneShot : on lève le doute via un
+      // lookup par titre (qui résout généralement le statut one-shot).
+      if (isOneShot === null && result.title) {
+        try {
+          seriesResult = await fetchLookupTitle(result.title, form.type);
+          isOneShot = seriesResult.isOneShot;
+        } catch {
+          // Statut toujours indéterminé : traité ci-dessous.
+        }
+      }
+
+      if (isOneShot === true) {
+        applySeriesFields(seriesResult);
+        toast.success("Informations récupérées (one-shot)");
+      } else if (isOneShot === false) {
+        applySeriesLevelFields(result, seriesResult);
+        toast.warning(
+          "Série multi-tomes : titre conservé. Utilisez la recherche par titre pour compléter la fiche.",
+        );
+      } else {
+        toast.error(
+          "Impossible de déterminer la série depuis cet ISBN. Utilisez la recherche par titre.",
+        );
+      }
+    } finally {
+      setIsApplying(false);
     }
   };
 


### PR DESCRIPTION
## Problème

Depuis la fiche d'une série, une recherche par ISBN remplissait la fiche avec les informations du **tome** au lieu de la série. Exemple : ISBN `9782756006383` (tome 1 d'« Akademy ») → titre « La cour des grands » au lieu d'« Akademy ».

## Cause racine (confirmée par un lookup réel)

Un ISBN identifie un **album**, pas une série.
- Pour une série multi-tomes, les fournisseurs catalogue (**BNF**, Google Books) ne connaissent que le titre du tome. `BnfLookup` liste d'ailleurs `isOneShot` comme champ non supporté → `null` = info manquante, pas « false ».
- Seul **Bedetheque/Gemini** peut renvoyer le nom de série, mais les clés Gemini étaient en quota (429), avec aussi des 500/503 côté API Gemini → la fusion retombait sur BNF → **le titre du tome devenait le titre de la série**.
- Le frontend re-cherchait ensuite par `result.title` (le sous-titre du tome) et l'écrivait dans la série — impossible de retrouver la série ainsi.

## Correctif (frontend uniquement — `useLookupFeature.applyLookup`)

Branche sur le statut one-shot (règle métier : one-shot ⇒ ISBN = série ; sinon ⇒ ISBN = tome) :

| Statut | Comportement |
|---|---|
| **one-shot** | l'album EST la série → application complète, titre inclus |
| **multi-tomes** | le titre de la série n'est **jamais** écrasé ; seuls les champs de série (`isOneShot`, `latestPublishedIssue`) sont appliqués ; avertissement |
| **indéterminé** | aucune application ; message invitant à utiliser la recherche par titre |

`isOneShot` étant souvent absent côté BNF, un lookup titre de secours tente de lever le doute avant de décider.

Aucun changement backend nécessaire : `LookupApplier` (auto-enrich / share) n'écrit jamais le `title`, donc ces chemins n'étaient pas affectés.

## Tests

- Nouveau `useLookupFeature.test.tsx` — 5 cas couvrant chaque branche.
- 3 tests ISBN de `ComicForm.test.tsx` revus pour le nouveau comportement.
- Suite frontend complète : **955 tests OK**, `tsc --noEmit` propre.