### PR TITLE
fix: pause background enrichment when Gemini quota is exhausted

### DIFF
--- a/.claude/memory/patterns.md
+++ b/.claude/memory/patterns.md
@@ -89,7 +89,7 @@ ApiLookupStatus, BatchLookupStatus, ComicStatus (buying/downloading/finished/sto
 | Enrichment/ | ConfidenceScorer, EnrichmentService |
 | Import/ | ImportService |
 | Lookup/Contract/ | ApiMessage, LookupProviderInterface, LookupResult… |
-| Lookup/Gemini/ | AbstractGeminiLookupProvider, GeminiClientPool, GeminiJsonParser, GeminiQueryService |
+| Lookup/Gemini/ | AbstractGeminiLookupProvider, GeminiCircuitBreaker, GeminiClientPool, GeminiJsonParser, GeminiQueryService |
 | Lookup/Provider/ | 12 providers: AniList, Bedetheque, BNF, ComicVine, Gemini, GoogleBooks, Jikan, Kitsu, MangaDex, OpenLibrary, Wikipedia + AbstractLookupProvider |
 | Lookup/Util/ | GoogleBooksUrlHelper, LookupTitleCleaner, TitleMatcher |
 | Lookup/ | BatchLookupService, LookupApplier, LookupOrchestrator |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 ### Fixed
 
 - **Recherche par ISBN (fiche série)** : un ISBN identifie un album précis. Pour une série multi-tomes, la recherche remplissait la fiche série avec les infos du **tome** (ex. ISBN du tome 1 d'« Akademy » → titre « La cour des grands » au lieu d'« Akademy »). Désormais : un ISBN one-shot remplit la série normalement ; un ISBN de tome ne modifie jamais le titre de la série et n'applique que les champs de série ; si le statut (one-shot ou non) ne peut être déterminé, la recherche est bloquée avec un message invitant à utiliser la recherche par titre.
+- **Enrichissement & quota Gemini** : quand toutes les clés Gemini sont en quota, l'enrichissement en arrière-plan ne gâche plus le quota ni ne met les messages en file d'échec. Un disjoncteur (`GeminiCircuitBreaker`) s'ouvre jusqu'au prochain reset quotidien Gemini (minuit, heure du Pacifique) et le message est reporté via `DelayStamp` au lieu d'être rejoué jusqu'à épuisement des tentatives. Le pool Gemini tourne désormais aussi sur les erreurs serveur transitoires (500/503, fréquentes avec le grounding Google Search) au lieu d'abandonner, et classe correctement un épuisement « quota » même si la dernière erreur est un 500. Le suivi d'épuisement en mémoire est borné dans le temps : un worker longue durée ne reste plus dégradé après une rafale d'erreurs.
 
 ## [v2.31.0] — 2026-06-07
 

--- a/backend/src/MessageHandler/EnrichSeriesHandler.php
+++ b/backend/src/MessageHandler/EnrichSeriesHandler.php
@@ -8,10 +8,13 @@ use App\Enum\LookupMode;
 use App\Message\EnrichSeriesMessage;
 use App\Repository\ComicSeriesRepository;
 use App\Service\Enrichment\EnrichmentService;
+use App\Service\Lookup\Gemini\GeminiCircuitBreaker;
 use App\Service\Lookup\LookupOrchestrator;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 /**
  * Handler pour l'enrichissement asynchrone d'une série.
@@ -19,12 +22,17 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 final readonly class EnrichSeriesHandler
 {
+    /** Délai de repli si le disjoncteur ne fournit pas de durée (5 minutes, en ms). */
+    private const int FALLBACK_REDISPATCH_DELAY_MS = 300_000;
+
     public function __construct(
         private ComicSeriesRepository $comicSeriesRepository,
         private EntityManagerInterface $entityManager,
         private EnrichmentService $enrichmentService,
+        private GeminiCircuitBreaker $circuitBreaker,
         private LoggerInterface $logger,
         private LookupOrchestrator $lookupOrchestrator,
+        private MessageBusInterface $messageBus,
     ) {
     }
 
@@ -49,14 +57,33 @@ final readonly class EnrichSeriesHandler
             return;
         }
 
+        // Disjoncteur ouvert (quota Gemini épuisé) : reporter sans appeler l'API
+        // ni consommer définitivement le message.
+        if ($this->circuitBreaker->isOpen()) {
+            $this->redispatchLater($message);
+            $this->logger->info('Disjoncteur Gemini ouvert — enrichissement de "{title}" reporté', [
+                'title' => $series->getTitle(),
+            ]);
+
+            return;
+        }
+
         $result = $this->lookupOrchestrator->lookupByTitle(
             $series->getTitle(),
             $series->getType(),
         );
 
-        // Rate limit → relancer le message (Messenger réessaiera)
+        // Quota Gemini épuisé : ouvrir le disjoncteur et reporter le message
+        // jusqu'au prochain reset quotidien (pas de mise en file d'échec).
         if ($this->lookupOrchestrator->hasRateLimitError()) {
-            throw new \RuntimeException(\sprintf('Rate limit atteint pour la série "%s" — le message sera réessayé', $series->getTitle()));
+            $until = $this->circuitBreaker->open();
+            $this->redispatchLater($message);
+            $this->logger->warning('Quota Gemini épuisé — disjoncteur ouvert jusqu\'à {until}, série "{title}" reportée', [
+                'title' => $series->getTitle(),
+                'until' => $until->format(\DateTimeInterface::ATOM),
+            ]);
+
+            return;
         }
 
         if (null !== $result) {
@@ -78,5 +105,16 @@ final readonly class EnrichSeriesHandler
 
         $series->setLookupCompletedAt(new \DateTimeImmutable());
         $this->entityManager->flush();
+    }
+
+    /**
+     * Redispatche le message avec un délai jusqu'au prochain reset Gemini.
+     */
+    private function redispatchLater(EnrichSeriesMessage $message): void
+    {
+        $delaySeconds = $this->circuitBreaker->retryAfterSeconds();
+        $delayMs = $delaySeconds > 0 ? $delaySeconds * 1000 : self::FALLBACK_REDISPATCH_DELAY_MS;
+
+        $this->messageBus->dispatch($message, [new DelayStamp($delayMs)]);
     }
 }

--- a/backend/src/Service/Lookup/Gemini/AbstractGeminiLookupProvider.php
+++ b/backend/src/Service/Lookup/Gemini/AbstractGeminiLookupProvider.php
@@ -195,6 +195,16 @@ abstract class AbstractGeminiLookupProvider extends AbstractLookupProvider
 
                 return $this->buildResult($data);
             });
+        } catch (GeminiAllKeysExhaustedException $e) {
+            $this->logger->error("Gemini ({$logName}) : toutes les clés épuisées", ['rateLimited' => $e->rateLimited]);
+
+            if ($e->rateLimited) {
+                $this->recordApiMessage(ApiLookupStatus::RATE_LIMITED, 'Toutes les clés API épuisées (quota)');
+            } else {
+                $this->recordApiMessage(ApiLookupStatus::ERROR, 'Toutes les clés API indisponibles');
+            }
+
+            return null;
         } catch (ErrorException $e) {
             $this->logger->error("Erreur Gemini API ({$logName}) : {error}", ['code' => $e->getErrorCode(), 'error' => $e->getMessage()]);
 

--- a/backend/src/Service/Lookup/Gemini/GeminiAllKeysExhaustedException.php
+++ b/backend/src/Service/Lookup/Gemini/GeminiAllKeysExhaustedException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Lookup\Gemini;
+
+/**
+ * Levée lorsque toutes les combinaisons clé × modèle Gemini ont échoué.
+ *
+ * `$rateLimited` distingue un épuisement par quota (au moins un 429 rencontré)
+ * d'une indisponibilité générale (uniquement des erreurs 500/503/auth).
+ */
+final class GeminiAllKeysExhaustedException extends \RuntimeException
+{
+    public function __construct(
+        public readonly bool $rateLimited,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct(
+            $rateLimited
+                ? 'Toutes les clés/modèles Gemini sont en quota.'
+                : 'Toutes les clés/modèles Gemini sont indisponibles.',
+            0,
+            $previous,
+        );
+    }
+}

--- a/backend/src/Service/Lookup/Gemini/GeminiCircuitBreaker.php
+++ b/backend/src/Service/Lookup/Gemini/GeminiCircuitBreaker.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Lookup\Gemini;
+
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Disjoncteur pour l'API Gemini : ouvert lorsque toutes les clés sont en quota.
+ *
+ * L'état est stocké dans un pool de cache partagé entre les conteneurs php et
+ * worker (volume `app_var`). La limite quotidienne (RPD) Gemini se réinitialise
+ * à minuit heure du Pacifique : le disjoncteur reste donc ouvert jusqu'à ce
+ * prochain reset, ce qui évite de marteler l'API et de gâcher du quota.
+ */
+class GeminiCircuitBreaker
+{
+    private const string CACHE_KEY = 'gemini_circuit_breaker_open_until';
+    private const string RESET_TIMEZONE = 'America/Los_Angeles';
+
+    public function __construct(
+        #[Autowire(service: 'gemini.cache')]
+        private readonly AdapterInterface $cache,
+        private readonly ClockInterface $clock,
+    ) {
+    }
+
+    /**
+     * Ferme le disjoncteur (réautorise les appels Gemini).
+     */
+    public function close(): void
+    {
+        $this->cache->deleteItem(self::CACHE_KEY);
+    }
+
+    /**
+     * Indique si le disjoncteur est actuellement ouvert.
+     */
+    public function isOpen(): bool
+    {
+        return null !== $this->openUntil();
+    }
+
+    /**
+     * Ouvre le disjoncteur jusqu'au prochain reset quotidien Gemini.
+     *
+     * @return \DateTimeImmutable Instant de réouverture
+     */
+    public function open(): \DateTimeImmutable
+    {
+        $until = $this->nextDailyReset();
+
+        $item = $this->cache->getItem(self::CACHE_KEY);
+        $item->set($until->getTimestamp());
+        $item->expiresAt($until);
+        $this->cache->save($item);
+
+        return $until;
+    }
+
+    /**
+     * Instant de réouverture si le disjoncteur est ouvert, sinon null.
+     */
+    public function openUntil(): ?\DateTimeImmutable
+    {
+        $item = $this->cache->getItem(self::CACHE_KEY);
+
+        if (!$item->isHit()) {
+            return null;
+        }
+
+        $value = $item->get();
+
+        if (!\is_int($value)) {
+            return null;
+        }
+
+        $until = $this->clock->now()->setTimestamp($value);
+
+        return $this->clock->now() < $until ? $until : null;
+    }
+
+    /**
+     * Nombre de secondes avant réouverture (0 si fermé).
+     */
+    public function retryAfterSeconds(): int
+    {
+        $until = $this->openUntil();
+
+        if (null === $until) {
+            return 0;
+        }
+
+        return \max(0, $until->getTimestamp() - $this->clock->now()->getTimestamp());
+    }
+
+    /**
+     * Calcule le prochain reset quotidien Gemini (minuit, heure du Pacifique).
+     */
+    private function nextDailyReset(): \DateTimeImmutable
+    {
+        $pacific = $this->clock->now()->setTimezone(new \DateTimeZone(self::RESET_TIMEZONE));
+        $nextMidnight = $pacific->setTime(0, 0)->modify('+1 day');
+
+        return $nextMidnight->setTimezone(new \DateTimeZone('UTC'));
+    }
+}

--- a/backend/src/Service/Lookup/Gemini/GeminiClientPool.php
+++ b/backend/src/Service/Lookup/Gemini/GeminiClientPool.php
@@ -10,17 +10,28 @@ use Gemini\Exceptions\ErrorException;
 use Psr\Log\LoggerInterface;
 
 /**
- * Pool de clients Gemini avec rotation clés × modèles sur erreur 400/401/403/404/429.
+ * Pool de clients Gemini avec rotation clés × modèles sur erreur 400/401/403/404/429/500/503.
  *
  * Itère modèles (outer) × clés (inner) : épuise toutes les clés sur le meilleur modèle d'abord.
- * Le suivi d'épuisement est en mémoire (suffisant pour les batchs et réinitialisé par requête web).
+ * Les 500/503 (erreurs serveur Gemini transitoires, fréquentes avec le grounding Google Search)
+ * déclenchent aussi une rotation au lieu d'avorter immédiatement.
+ *
+ * Le suivi d'épuisement est en mémoire et borné dans le temps ({@see self::EXHAUSTION_COOLDOWN_SECONDS}) :
+ * une combinaison en échec est ignorée brièvement puis réessayée, ce qui évite qu'un worker
+ * longue durée reste dégradé indéfiniment après une rafale d'erreurs.
  */
 class GeminiClientPool
 {
+    /** Codes HTTP déclenchant une rotation clé/modèle (le reste est relancé immédiatement). */
+    private const array RETRYABLE_CODES = [400, 401, 403, 404, 429, 500, 503];
+
+    /** Durée pendant laquelle une combinaison en échec est ignorée (secondes). */
+    private const float EXHAUSTION_COOLDOWN_SECONDS = 90.0;
+
     /** @var list<string> */
     private readonly array $apiKeys;
 
-    /** @var array<string, true> */
+    /** @var array<string, array{at: float, rateLimited: bool}> */
     private array $exhausted = [];
 
     /** @var list<string> */
@@ -56,32 +67,42 @@ class GeminiClientPool
      *
      * @return T
      *
-     * @throws ErrorException si toutes les combinaisons sont épuisées (dernière erreur retryable)
+     * @throws ErrorException                  pour un code non retryable (relancé immédiatement)
+     * @throws GeminiAllKeysExhaustedException si toutes les combinaisons ont échoué
      */
     public function executeWithRetry(callable $callback): mixed
     {
         $lastException = null;
+        $sawRateLimit = false;
+        $now = \microtime(true);
 
         foreach ($this->models as $model) {
             foreach ($this->apiKeys as $keyIndex => $apiKey) {
                 $comboKey = $keyIndex.':'.$model;
 
-                if (isset($this->exhausted[$comboKey])) {
+                $failure = $this->exhausted[$comboKey] ?? null;
+                if (null !== $failure && ($now - $failure['at']) < self::EXHAUSTION_COOLDOWN_SECONDS) {
+                    $sawRateLimit = $sawRateLimit || $failure['rateLimited'];
+
                     continue;
                 }
 
                 try {
                     $client = \Gemini::client($apiKey);
+                    $result = $callback($client, $model);
+                    unset($this->exhausted[$comboKey]);
 
-                    return $callback($client, $model);
+                    return $result;
                 } catch (ErrorException $e) {
                     $code = $e->getErrorCode();
 
-                    if (!\in_array($code, [400, 401, 403, 404, 429], true)) {
+                    if (!\in_array($code, self::RETRYABLE_CODES, true)) {
                         throw $e;
                     }
 
-                    $this->exhausted[$comboKey] = true;
+                    $isRateLimit = 429 === $code;
+                    $sawRateLimit = $sawRateLimit || $isRateLimit;
+                    $this->exhausted[$comboKey] = ['at' => \microtime(true), 'rateLimited' => $isRateLimit];
                     $lastException = $e;
                     $this->logger->warning('Gemini {code} sur clé {keyIndex} / modèle {model}, rotation…', [
                         'code' => $code,
@@ -92,6 +113,6 @@ class GeminiClientPool
             }
         }
 
-        throw $lastException ?? new \RuntimeException('Aucune combinaison clé/modèle disponible.');
+        throw new GeminiAllKeysExhaustedException(rateLimited: $sawRateLimit, previous: $lastException);
     }
 }

--- a/backend/tests/Unit/MessageHandler/EnrichSeriesHandlerTest.php
+++ b/backend/tests/Unit/MessageHandler/EnrichSeriesHandlerTest.php
@@ -13,36 +13,46 @@ use App\MessageHandler\EnrichSeriesHandler;
 use App\Repository\ComicSeriesRepository;
 use App\Service\Enrichment\EnrichmentService;
 use App\Service\Lookup\Contract\LookupResult;
+use App\Service\Lookup\Gemini\GeminiCircuitBreaker;
 use App\Service\Lookup\LookupOrchestrator;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 /**
  * Tests unitaires pour le handler d'enrichissement asynchrone.
  */
 final class EnrichSeriesHandlerTest extends TestCase
 {
+    private MockObject&GeminiCircuitBreaker $circuitBreaker;
     private MockObject&ComicSeriesRepository $comicSeriesRepository;
     private MockObject&EntityManagerInterface $entityManager;
     private MockObject&EnrichmentService $enrichmentService;
     private EnrichSeriesHandler $handler;
     private MockObject&LookupOrchestrator $lookupOrchestrator;
+    private MockObject&MessageBusInterface $messageBus;
 
     protected function setUp(): void
     {
+        $this->circuitBreaker = $this->createMock(GeminiCircuitBreaker::class);
         $this->comicSeriesRepository = $this->createMock(ComicSeriesRepository::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
         $this->enrichmentService = $this->createMock(EnrichmentService::class);
         $this->lookupOrchestrator = $this->createMock(LookupOrchestrator::class);
+        $this->messageBus = $this->createMock(MessageBusInterface::class);
 
         $this->handler = new EnrichSeriesHandler(
             $this->comicSeriesRepository,
             $this->entityManager,
             $this->enrichmentService,
+            $this->circuitBreaker,
             new NullLogger(),
             $this->lookupOrchestrator,
+            $this->messageBus,
         );
     }
 
@@ -60,6 +70,8 @@ final class EnrichSeriesHandlerTest extends TestCase
             ->with(42)
             ->willReturn($series);
 
+        $this->circuitBreaker->method('isOpen')->willReturn(false);
+
         $lookupResult = new LookupResult(description: 'Description', source: 'google');
 
         $this->lookupOrchestrator->expects(self::once())
@@ -67,6 +79,7 @@ final class EnrichSeriesHandlerTest extends TestCase
             ->with('One Piece', ComicType::MANGA)
             ->willReturn($lookupResult);
 
+        $this->lookupOrchestrator->method('hasRateLimitError')->willReturn(false);
         $this->lookupOrchestrator->method('getLastSources')->willReturn(['google']);
 
         $this->enrichmentService->expects(self::once())
@@ -93,6 +106,7 @@ final class EnrichSeriesHandlerTest extends TestCase
 
         $this->lookupOrchestrator->expects(self::never())->method('lookupByTitle');
         $this->enrichmentService->expects(self::never())->method('enrich');
+        $this->messageBus->expects(self::never())->method('dispatch');
 
         ($this->handler)(new EnrichSeriesMessage(999));
     }
@@ -111,9 +125,13 @@ final class EnrichSeriesHandlerTest extends TestCase
             ->with(10)
             ->willReturn($series);
 
+        $this->circuitBreaker->method('isOpen')->willReturn(false);
+
         $this->lookupOrchestrator->expects(self::once())
             ->method('lookupByTitle')
             ->willReturn(null);
+
+        $this->lookupOrchestrator->method('hasRateLimitError')->willReturn(false);
 
         $this->enrichmentService->expects(self::never())->method('enrich');
         $this->entityManager->expects(self::once())->method('flush');
@@ -140,7 +158,77 @@ final class EnrichSeriesHandlerTest extends TestCase
 
         $this->lookupOrchestrator->expects(self::never())->method('lookupByTitle');
         $this->enrichmentService->expects(self::never())->method('enrich');
+        $this->messageBus->expects(self::never())->method('dispatch');
 
         ($this->handler)(new EnrichSeriesMessage(5));
+    }
+
+    /**
+     * Teste que le disjoncteur ouvert reporte le message sans appeler l'API.
+     */
+    public function testHandlerRedispatchesWhenCircuitBreakerOpen(): void
+    {
+        $series = new ComicSeries();
+        $series->setTitle('En attente de quota');
+        $series->setType(ComicType::BD);
+
+        $this->comicSeriesRepository->expects(self::once())
+            ->method('find')
+            ->with(7)
+            ->willReturn($series);
+
+        $this->circuitBreaker->method('isOpen')->willReturn(true);
+        $this->circuitBreaker->method('retryAfterSeconds')->willReturn(3600);
+
+        $this->lookupOrchestrator->expects(self::never())->method('lookupByTitle');
+        $this->enrichmentService->expects(self::never())->method('enrich');
+        $this->entityManager->expects(self::never())->method('flush');
+
+        $message = new EnrichSeriesMessage(7);
+        $this->messageBus->expects(self::once())
+            ->method('dispatch')
+            ->with(
+                $message,
+                self::callback(static fn (array $stamps): bool => 1 === \count($stamps) && $stamps[0] instanceof DelayStamp),
+            )
+            ->willReturn(new Envelope($message));
+
+        ($this->handler)($message);
+
+        self::assertNull($series->getLookupCompletedAt());
+    }
+
+    /**
+     * Teste qu'un quota épuisé ouvre le disjoncteur et reporte le message.
+     */
+    public function testHandlerOpensBreakerAndRedispatchesOnRateLimit(): void
+    {
+        $series = new ComicSeries();
+        $series->setTitle('Quota épuisé');
+        $series->setType(ComicType::BD);
+
+        $this->comicSeriesRepository->expects(self::once())
+            ->method('find')
+            ->with(8)
+            ->willReturn($series);
+
+        $this->circuitBreaker->method('isOpen')->willReturn(false);
+        $this->circuitBreaker->expects(self::once())->method('open')->willReturn(new \DateTimeImmutable('+1 hour'));
+        $this->circuitBreaker->method('retryAfterSeconds')->willReturn(3600);
+
+        $this->lookupOrchestrator->expects(self::once())->method('lookupByTitle')->willReturn(null);
+        $this->lookupOrchestrator->method('hasRateLimitError')->willReturn(true);
+
+        $this->enrichmentService->expects(self::never())->method('enrich');
+        $this->entityManager->expects(self::never())->method('flush');
+
+        $message = new EnrichSeriesMessage(8);
+        $this->messageBus->expects(self::once())
+            ->method('dispatch')
+            ->willReturn(new Envelope($message));
+
+        ($this->handler)($message);
+
+        self::assertNull($series->getLookupCompletedAt());
     }
 }

--- a/backend/tests/Unit/Service/Lookup/Gemini/GeminiCircuitBreakerTest.php
+++ b/backend/tests/Unit/Service/Lookup/Gemini/GeminiCircuitBreakerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Lookup\Gemini;
+
+use App\Service\Lookup\Gemini\GeminiCircuitBreaker;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Clock\MockClock;
+
+/**
+ * Tests unitaires pour le disjoncteur Gemini.
+ */
+final class GeminiCircuitBreakerTest extends TestCase
+{
+    public function testClosedByDefault(): void
+    {
+        $breaker = new GeminiCircuitBreaker(new ArrayAdapter(), new MockClock('2026-06-07 12:00:00', new \DateTimeZone('UTC')));
+
+        self::assertFalse($breaker->isOpen());
+        self::assertNull($breaker->openUntil());
+        self::assertSame(0, $breaker->retryAfterSeconds());
+    }
+
+    public function testOpenStaysOpenUntilNextPacificMidnight(): void
+    {
+        // 2026-06-07 12:00 UTC = 05:00 heure du Pacifique (PDT, UTC-7).
+        // Le prochain reset est le 2026-06-08 00:00 PDT = 2026-06-08 07:00 UTC.
+        $clock = new MockClock('2026-06-07 12:00:00', new \DateTimeZone('UTC'));
+        $breaker = new GeminiCircuitBreaker(new ArrayAdapter(), $clock);
+
+        $until = $breaker->open();
+
+        self::assertTrue($breaker->isOpen());
+        self::assertSame('2026-06-08 07:00:00', $until->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'));
+        self::assertSame(19 * 3600, $breaker->retryAfterSeconds());
+    }
+
+    public function testReopensAfterResetTimePasses(): void
+    {
+        $clock = new MockClock('2026-06-07 12:00:00', new \DateTimeZone('UTC'));
+        $breaker = new GeminiCircuitBreaker(new ArrayAdapter(), $clock);
+
+        $breaker->open();
+        self::assertTrue($breaker->isOpen());
+
+        // Avance au-delà du reset.
+        $clock->modify('+20 hours');
+
+        self::assertFalse($breaker->isOpen());
+        self::assertNull($breaker->openUntil());
+    }
+
+    public function testCloseClearsState(): void
+    {
+        $clock = new MockClock('2026-06-07 12:00:00', new \DateTimeZone('UTC'));
+        $breaker = new GeminiCircuitBreaker(new ArrayAdapter(), $clock);
+
+        $breaker->open();
+        self::assertTrue($breaker->isOpen());
+
+        $breaker->close();
+
+        self::assertFalse($breaker->isOpen());
+    }
+}

--- a/backend/tests/Unit/Service/Lookup/Gemini/GeminiClientPoolTest.php
+++ b/backend/tests/Unit/Service/Lookup/Gemini/GeminiClientPoolTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Service\Lookup\Gemini;
 
+use App\Service\Lookup\Gemini\GeminiAllKeysExhaustedException;
 use App\Service\Lookup\Gemini\GeminiClientPool;
 use Gemini\Exceptions\ErrorException;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use RuntimeException;
 
 /**
  * Tests unitaires pour GeminiClientPool.
@@ -83,17 +83,62 @@ final class GeminiClientPoolTest extends TestCase
     }
 
     /**
-     * Teste que toutes les combinaisons épuisées relancent la dernière ErrorException 429.
+     * Teste que toutes les combinaisons en 429 lèvent une exception d'épuisement marquée quota.
      */
-    public function testAllCombosExhaustedThrows429(): void
+    public function testAllCombosExhaustedThrowsRateLimited(): void
     {
         $pool = new GeminiClientPool('key1,key2', $this->logger, 'model1,model2');
 
-        $this->expectException(ErrorException::class);
+        $caught = null;
 
-        $pool->executeWithRetry(static function ($client, $model): never {
-            throw new ErrorException(['code' => 429, 'message' => 'Resource exhausted', 'status' => 'RESOURCE_EXHAUSTED']);
+        try {
+            $pool->executeWithRetry($this->alwaysFailingCallback(429));
+        } catch (GeminiAllKeysExhaustedException $e) {
+            $caught = $e;
+        }
+
+        self::assertInstanceOf(GeminiAllKeysExhaustedException::class, $caught);
+        self::assertTrue($caught->rateLimited);
+    }
+
+    /**
+     * Teste qu'un 500 (erreur serveur transitoire) déclenche une rotation, pas un abandon.
+     */
+    public function testRotatesToSecondKeyOn500(): void
+    {
+        $pool = new GeminiClientPool('key1,key2', $this->logger, 'gemini-2.5-flash');
+
+        $callCount = 0;
+        $result = $pool->executeWithRetry(static function ($client, $model) use (&$callCount): string {
+            ++$callCount;
+            if (1 === $callCount) {
+                throw new ErrorException(['code' => 500, 'message' => 'Internal error', 'status' => 'INTERNAL']);
+            }
+
+            return 'ok_key2';
         });
+
+        self::assertSame('ok_key2', $result);
+        self::assertSame(2, $callCount);
+    }
+
+    /**
+     * Teste que des erreurs serveur seules (sans 429) ne sont pas marquées comme quota.
+     */
+    public function testAllCombos500ThrowsNotRateLimited(): void
+    {
+        $pool = new GeminiClientPool('key1,key2', $this->logger, 'gemini-2.5-flash');
+
+        $caught = null;
+
+        try {
+            $pool->executeWithRetry($this->alwaysFailingCallback(503));
+        } catch (GeminiAllKeysExhaustedException $e) {
+            $caught = $e;
+        }
+
+        self::assertInstanceOf(GeminiAllKeysExhaustedException::class, $caught);
+        self::assertFalse($caught->rateLimited);
     }
 
     /**
@@ -183,9 +228,9 @@ final class GeminiClientPoolTest extends TestCase
     }
 
     /**
-     * Teste qu'une erreur non retryable est relancée immédiatement sans rotation.
+     * Teste qu'un code non retryable (hors liste) est relancé immédiatement sans rotation.
      */
-    public function testNon429ErrorRethrowsImmediately(): void
+    public function testNonRetryableErrorRethrowsImmediately(): void
     {
         $pool = new GeminiClientPool('key1,key2', $this->logger, 'model1,model2');
 
@@ -194,7 +239,7 @@ final class GeminiClientPoolTest extends TestCase
         try {
             $pool->executeWithRetry(static function ($client, $model) use (&$callCount): never {
                 ++$callCount;
-                throw new ErrorException(['code' => 500, 'message' => 'Internal error', 'status' => 'INTERNAL']);
+                throw new ErrorException(['code' => 418, 'message' => 'Teapot', 'status' => 'UNKNOWN']);
             });
         } catch (ErrorException) {
             // Attendu
@@ -269,5 +314,20 @@ final class GeminiClientPoolTest extends TestCase
 
         // Un seul appel car key1 est déjà épuisée
         self::assertCount(1, $keysUsedInSecondCall);
+    }
+
+    /**
+     * Crée un callback qui échoue toujours avec le code HTTP donné.
+     *
+     * Le type de retour déclaré (string) évite que PHPStan infère « never »
+     * au site d'appel, ce qui marquerait à tort le code suivant comme mort.
+     *
+     * @return callable(\Gemini\Contracts\ClientContract, string): string
+     */
+    private function alwaysFailingCallback(int $code): callable
+    {
+        return static function ($client, $model) use ($code): string {
+            throw new ErrorException(['code' => $code, 'message' => 'fail', 'status' => 'ERROR']);
+        };
     }
 }


### PR DESCRIPTION
## Problème

Quand toutes les clés Gemini sont en quota (palier gratuit : **RPD = 20/jour par modèle**, reset quotidien), l'enrichissement asynchrone :
1. **gâchait le quota** — le worker (process longue durée) continuait d'appeler l'API à chaque message, et le suivi d'épuisement en mémoire restait collé jusqu'au redémarrage du conteneur ;
2. **mettait les messages en file d'échec** — le handler levait une exception ; après 3 tentatives Messenger (bien avant le reset quotidien), le message partait en `failed`. Constaté localement : **69 `EnrichSeriesMessage` dans la file d'échec** (« Rate limit atteint… le message sera réessayé »).

De plus, un **500/503** transitoire de Gemini (fréquent avec le grounding Google Search) interrompait la rotation des clés et masquait l'état réel de quota (`hasRateLimitError()` renvoyait `false`), si bien que la série était marquée enrichie avec des données dégradées.

## Correctif

- **`GeminiCircuitBreaker`** — disjoncteur partagé (pool de cache filesystem `gemini.cache`, sur le volume `app_var` commun aux conteneurs php et worker). S'ouvre jusqu'au **prochain reset quotidien Gemini (minuit, heure du Pacifique)**. `ClockInterface` injectable pour les tests.
- **`EnrichSeriesHandler`** — ne lève plus d'exception. Si le disjoncteur est ouvert *ou* si le lookup signale un quota épuisé : ouvre le disjoncteur et **reporte le message via `DelayStamp`** (jusqu'au reset). Jamais de dead-letter. La série n'est pas marquée enrichie (réessayée après reset).
- **`GeminiClientPool`** — rotation aussi sur **500/503** (au lieu d'abandonner) ; un épuisement est classé **quota** dès qu'un 429 a été rencontré, même si la dernière erreur est un 500 ; suivi d'épuisement **borné dans le temps** (cooldown) → plus de worker dégradé à vie.

Le message `EnrichSeriesMessage` est **inchangé** (aucun champ ajouté) → pas de risque de (dé)sérialisation worker↔dispatcher. Le report se fait via un stamp d'enveloppe.

## Vérification

- **Tests** : `GeminiCircuitBreakerTest` (reset Pacifique, ouverture/fermeture), `GeminiClientPoolTest` (rotation 500, classification quota), `EnrichSeriesHandlerTest` (report sur disjoncteur ouvert, ouverture sur quota). Suite backend complète : **1096 tests OK**, PHPStan niveau 9 OK, CS Fixer OK.
- **E2E local** (quota Gemini réellement épuisé) :
  - `Quota Gemini épuisé — disjoncteur ouvert jusqu'à 2026-06-08T07:00:00+00:00` (= minuit Pacifique) ;
  - message **acquitté** (pas d'échec), redispatché ;
  - message suivant **court-circuité sans appel API** ;
  - file `async` : messages en attente avec `available_at = 2026-06-08 07:00:00`.

## Note séparée

Ces 500/503 viennent de l'API Gemini elle-même (instabilité serveur, accentuée par le grounding et la charge), pas du quota — d'où la rotation au lieu de l'abandon.