### PR TITLE
feat: self-heal failed messages with a daily retry

### DIFF
--- a/.claude/memory/patterns.md
+++ b/.claude/memory/patterns.md
@@ -123,6 +123,7 @@ ApiLookupStatus, BatchLookupStatus, ComicStatus (buying/downloading/finished/sto
 - Weekly Mon 3-8h: `app:check-author-releases`
 - Monthly 1st 1h: `app:purge-deleted`
 - Monthly 1st 2h: `app:purge-notifications`
+- Daily 9h: `messenger:failed:retry --force` (drain failed queue after Gemini quota reset)
 
 **Other commands**: `app:deploy:run-tasks` (exécute les tasks `deploy-tasks/Task*.php` one-shot), `app:import`, `app:invalidate-tokens`, `app:scan-nas`, `app:warm-thumbnails`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Added
+
+- **Rejeu auto de la file d'échec** : une tâche planifiée quotidienne (9h, après le reset du quota Gemini) rejoue les messages Messenger en file d'échec (`messenger:failed:retry --force`). Les échecs transitoires (quota, réseau) se résorbent seuls ; un échec définitif y revient et reste visible.
+
 ### Fixed
 
 - **Recherche par ISBN (fiche série)** : un ISBN identifie un album précis. Pour une série multi-tomes, la recherche remplissait la fiche série avec les infos du **tome** (ex. ISBN du tome 1 d'« Akademy » → titre « La cour des grands » au lieu d'« Akademy »). Désormais : un ISBN one-shot remplit la série normalement ; un ISBN de tome ne modifie jamais le titre de la série et n'applique que les champs de série ; si le statut (one-shot ou non) ne peut être déterminé, la recherche est bloquée avec un message invitant à utiliser la recherche par titre.

--- a/backend/src/Schedule.php
+++ b/backend/src/Schedule.php
@@ -43,6 +43,12 @@ final class Schedule implements ScheduleProviderInterface
         $schedule->add(RecurringMessage::cron('0 1 1 * *', new RunCommandMessage('app:purge-deleted')));
         $schedule->add(RecurringMessage::cron('0 2 1 * *', new RunCommandMessage('app:purge-notifications --days=90')));
 
+        // Quotidien 9h (après le reset quotidien du quota Gemini) — rejoue les
+        // messages en file d'échec pour qu'ils se résorbent d'eux-mêmes. Les
+        // échecs transitoires (quota, réseau) repartent ; un échec définitif
+        // (bug) y reviendra et restera visible.
+        $schedule->add(RecurringMessage::cron('0 9 * * *', new RunCommandMessage('messenger:failed:retry --force')));
+
         return $schedule;
     }
 }


### PR DESCRIPTION
## Problème

La file d'échec Messenger (`failed` transport) n'est **jamais vidée** automatiquement : le worker ne consomme que `async` + `scheduler_default`, et aucune tâche planifiée / script / cron ne rejoue la file. Les `EnrichSeriesMessage` tombés en échec (quota, avant le disjoncteur de #478) y restaient indéfiniment (constaté : ~66 messages parqués depuis avril).

## Correctif

Ajoute une tâche planifiée **quotidienne à 9h** (juste après le reset quotidien du quota Gemini = minuit Pacifique) qui rejoue la file d'échec :

```php
$schedule->add(RecurringMessage::cron('0 9 * * *', new RunCommandMessage('messenger:failed:retry --force')));
```

- Les échecs **transitoires** (quota résiduel, réseau) repartent et se résorbent — combiné au disjoncteur de #478, les messages reportés finissent par s'enrichir.
- Un échec **définitif** (bug) y reviendra et restera visible (pas de boucle serrée : rejeu une fois/jour).

## Vérification

- `debug:scheduler` liste bien la tâche : `0 9 * * * → messenger:failed:retry --force`.
- PHPStan niveau 9 OK, CS Fixer OK.

(Config du planificateur — pas de test unitaire, conformément aux conventions du projet.)