### PR TITLE
fix: de-flake two unreliable tests (indeterminate checkbox + Gemini breaker date)

### DIFF
--- a/backend/src/Service/Lookup/Gemini/GeminiCircuitBreaker.php
+++ b/backend/src/Service/Lookup/Gemini/GeminiCircuitBreaker.php
@@ -53,9 +53,14 @@ class GeminiCircuitBreaker
     {
         $until = $this->nextDailyReset();
 
+        // TTL relatif (et non `expiresAt($until)` absolu) : l'expiration du cache
+        // suit l'horloge réelle au moment du save, tandis que la décision
+        // ouvert/fermé reste pilotée par l'horloge injectée (cf. openUntil).
+        $ttl = \max(1, $until->getTimestamp() - $this->clock->now()->getTimestamp());
+
         $item = $this->cache->getItem(self::CACHE_KEY);
         $item->set($until->getTimestamp());
-        $item->expiresAt($until);
+        $item->expiresAfter($ttl);
         $this->cache->save($item);
 
         return $until;

--- a/frontend/src/__tests__/integration/pages/ComicDetailToggle.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicDetailToggle.test.tsx
@@ -485,7 +485,9 @@ describe("ComicDetail — inline tome toggle", () => {
     const headerCheckbox = screen.getByRole("checkbox", {
       name: /tout cocher acheté/i,
     }) as HTMLInputElement;
-    expect(headerCheckbox.indeterminate).toBe(true);
+    // `indeterminate` est posé dans un useEffect (après le rendu) : on attend
+    // qu'il soit appliqué plutôt que de le lire de façon synchrone (flaky).
+    await waitFor(() => expect(headerCheckbox.indeterminate).toBe(true));
     expect(headerCheckbox.checked).toBe(false);
   });
 


### PR DESCRIPTION
Deux tests instables corrigés.

## 1. `ComicDetailToggle › header checkbox is indeterminate` (flaky)

`indeterminate` est posé dans un `useEffect` (après le rendu) dans `ComicDetail.tsx` — il ne peut pas l'être en JSX. Le test l'attendait seulement via le texte « Tomes (2) » puis le lisait **synchronément** → sous charge CI, l'effet n'avait pas encore tourné → `expected false to be true`.
**Fix** : attendre la propriété via `waitFor`. Vérifié 12/12 sur 5 exécutions.

## 2. `GeminiCircuitBreakerTest` (date-dependent → CI rouge sur main aujourd'hui)

`GeminiCircuitBreaker::open()` posait une expiration **absolue** (`expiresAt($until)`). Le cache expire selon l'horloge **réelle**, mais le test gèle une `MockClock` à une date fixe (2026-06-07). Une fois la date réelle dépassée, l'item cache était expiré → `isOpen()` renvoyait `false` → 3 tests du disjoncteur échouaient. (Découvert parce que la CI de cette PR, lancée le lendemain, est tombée dessus.)
**Fix** : TTL **relatif** (`expiresAfter($until - now)`) — l'expiration du cache suit l'horloge réelle au save (toujours future), la décision ouvert/fermé reste pilotée par l'horloge injectée. **Comportement prod inchangé** (horloge = réelle) ; tests déterministes quelle que soit la date.

## Vérification

- Frontend : la CI Vitest passe (et 12/12 × 5 en local).
- Backend : suite complète **1096 tests OK**, PHPStan niveau 9 OK, CS Fixer OK.