### PR TITLE
feat: enrichit les résultats de recherche par titre du formulaire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Recherche par titre**: les résultats affichent la description, l'année et le nombre de tomes (ou un badge One-shot), avec une couverture agrandie.
+
 ## [v2.32.0] — 2026-06-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ### Changed
 
-- **Recherche par titre**: les résultats affichent la description, l'année et le nombre de tomes (ou un badge One-shot), avec une couverture agrandie.
+- **Recherche par titre**: les résultats affichent la description, l'année et le nombre de tomes (ou un badge One-shot), avec une couverture agrandie, et un bouton « Fermer » pour masquer la liste.
 
 ## [v2.32.0] — 2026-06-07
 

--- a/frontend/src/__tests__/integration/components/LookupCandidateCard.test.tsx
+++ b/frontend/src/__tests__/integration/components/LookupCandidateCard.test.tsx
@@ -111,6 +111,24 @@ describe("LookupCandidateCard", () => {
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 
+  it("calls onSelect when Enter or Space is pressed on the focused card", async () => {
+    const user = userEvent.setup();
+    const candidate = buildCandidate({ title: "Akira" });
+    const onSelect = vi.fn();
+
+    renderWithProviders(
+      <LookupCandidateCard candidate={candidate} onSelect={onSelect} />,
+    );
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: /Akira/i })).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+    await user.keyboard(" ");
+
+    expect(onSelect).toHaveBeenCalledTimes(2);
+  });
+
   it("shows placeholder and no img element when thumbnail is null", () => {
     const candidate = buildCandidate({ thumbnail: null });
     const onSelect = vi.fn();

--- a/frontend/src/__tests__/integration/components/LookupCandidateCard.test.tsx
+++ b/frontend/src/__tests__/integration/components/LookupCandidateCard.test.tsx
@@ -1,0 +1,136 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LookupCandidateCard from "../../../components/LookupCandidateCard";
+import type { LookupCandidate } from "../../../types/api";
+import { renderWithProviders } from "../../helpers/test-utils";
+
+function buildCandidate(overrides: Partial<LookupCandidate> = {}): LookupCandidate {
+  return {
+    authors: null,
+    description: null,
+    isbn: null,
+    isOneShot: null,
+    latestPublishedIssue: null,
+    publishedDate: null,
+    publisher: null,
+    thumbnail: null,
+    title: null,
+    tomeEnd: null,
+    tomeNumber: null,
+    ...overrides,
+  };
+}
+
+describe("LookupCandidateCard", () => {
+  it("renders title and authors text", () => {
+    const candidate = buildCandidate({
+      authors: "Akira Toriyama",
+      title: "Dragon Ball",
+    });
+    const onSelect = vi.fn();
+
+    renderWithProviders(
+      <LookupCandidateCard candidate={candidate} onSelect={onSelect} />,
+    );
+
+    expect(screen.getByText("Dragon Ball")).toBeInTheDocument();
+    expect(screen.getByText("Akira Toriyama")).toBeInTheDocument();
+  });
+
+  it("renders publisher, year, and volume chips", () => {
+    const candidate = buildCandidate({
+      publishedDate: "2000-05-12",
+      publisher: "Dargaud",
+      tomeEnd: 6,
+    });
+    const onSelect = vi.fn();
+
+    renderWithProviders(
+      <LookupCandidateCard candidate={candidate} onSelect={onSelect} />,
+    );
+
+    expect(screen.getByText("Dargaud")).toBeInTheDocument();
+    expect(screen.getByText("2000")).toBeInTheDocument();
+    expect(screen.getByText("6 tomes")).toBeInTheDocument();
+  });
+
+  it("omits publisher chip when publisher is null", () => {
+    const candidate = buildCandidate({ publisher: null });
+    const onSelect = vi.fn();
+
+    renderWithProviders(
+      <LookupCandidateCard candidate={candidate} onSelect={onSelect} />,
+    );
+
+    expect(screen.queryByText("Dargaud")).not.toBeInTheDocument();
+  });
+
+  it("renders One-shot chip and no tomes chip when isOneShot is true", () => {
+    const candidate = buildCandidate({ isOneShot: true, tomeEnd: 1 });
+    const onSelect = vi.fn();
+
+    renderWithProviders(
+      <LookupCandidateCard candidate={candidate} onSelect={onSelect} />,
+    );
+
+    expect(screen.getByText("One-shot")).toBeInTheDocument();
+    expect(screen.queryByText(/tomes/i)).not.toBeInTheDocument();
+  });
+
+  it("shows plus button; clicking it shows moins and does not call onSelect", async () => {
+    const user = userEvent.setup();
+    const candidate = buildCandidate({
+      description: "Une longue description de test pour vérifier le toggle.",
+    });
+    const onSelect = vi.fn();
+
+    renderWithProviders(
+      <LookupCandidateCard candidate={candidate} onSelect={onSelect} />,
+    );
+
+    const plusButton = screen.getByText("plus");
+    expect(plusButton).toBeInTheDocument();
+
+    await user.click(plusButton);
+
+    expect(screen.getByText("moins")).toBeInTheDocument();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("calls onSelect when the card title is clicked", async () => {
+    const user = userEvent.setup();
+    const candidate = buildCandidate({ title: "Naruto" });
+    const onSelect = vi.fn();
+
+    renderWithProviders(
+      <LookupCandidateCard candidate={candidate} onSelect={onSelect} />,
+    );
+
+    await user.click(screen.getByText("Naruto"));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows placeholder and no img element when thumbnail is null", () => {
+    const candidate = buildCandidate({ thumbnail: null });
+    const onSelect = vi.fn();
+
+    renderWithProviders(
+      <LookupCandidateCard candidate={candidate} onSelect={onSelect} />,
+    );
+
+    expect(screen.getByText("?")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("does not show plus button when description is null", () => {
+    const candidate = buildCandidate({ description: null });
+    const onSelect = vi.fn();
+
+    renderWithProviders(
+      <LookupCandidateCard candidate={candidate} onSelect={onSelect} />,
+    );
+
+    expect(screen.queryByText(/plus/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/integration/components/LookupCandidateCard.test.tsx
+++ b/frontend/src/__tests__/integration/components/LookupCandidateCard.test.tsx
@@ -129,6 +129,23 @@ describe("LookupCandidateCard", () => {
     expect(onSelect).toHaveBeenCalledTimes(2);
   });
 
+  it("renders an external thumbnail as a plain img without crossOrigin", () => {
+    const candidate = buildCandidate({
+      thumbnail: "https://books.google.com/cover.jpg",
+      title: "One Piece",
+    });
+    const onSelect = vi.fn();
+
+    renderWithProviders(
+      <LookupCandidateCard candidate={candidate} onSelect={onSelect} />,
+    );
+
+    const img = screen.getByRole("img");
+    expect(img).toHaveAttribute("src", "https://books.google.com/cover.jpg");
+    // External lookup thumbnails must load without CORS — no crossOrigin.
+    expect(img).not.toHaveAttribute("crossorigin");
+  });
+
   it("shows placeholder and no img element when thumbnail is null", () => {
     const candidate = buildCandidate({ thumbnail: null });
     const onSelect = vi.fn();

--- a/frontend/src/__tests__/integration/hooks/useLookupFeature.test.tsx
+++ b/frontend/src/__tests__/integration/hooks/useLookupFeature.test.tsx
@@ -241,3 +241,43 @@ describe("useLookupFeature.applyLookup (ISBN)", () => {
     expect(toastError).toHaveBeenCalled();
   });
 });
+
+describe("useLookupFeature.clearTitleSearch", () => {
+  it("ferme la liste des résultats de recherche par titre", async () => {
+    server.use(
+      http.get(`${API_BASE}/lookup/title`, () =>
+        HttpResponse.json({
+          apiMessages: {},
+          results: [createMockLookupResult({ title: "Akademy" })],
+          sources: ["Test"],
+        }),
+      ),
+    );
+
+    const update = vi.fn();
+    const form = createForm();
+    const view = renderHook(
+      () => useLookupFeature(form, update as unknown as UpdateFn),
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      view.result.current.setLookupTitle("Akademy");
+    });
+    act(() => {
+      view.result.current.submitTitleSearch();
+    });
+
+    await waitFor(() =>
+      expect(view.result.current.titleCandidates.data).toBeDefined(),
+    );
+
+    act(() => {
+      view.result.current.clearTitleSearch();
+    });
+
+    await waitFor(() =>
+      expect(view.result.current.titleCandidates.data).toBeUndefined(),
+    );
+  });
+});

--- a/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
+++ b/frontend/src/__tests__/integration/pages/ComicForm.test.tsx
@@ -395,6 +395,32 @@ describe("ComicForm", () => {
       );
     });
 
+    it("closes the candidate results when clicking Fermer", async () => {
+      const user = userEvent.setup();
+
+      server.use(
+        mockTitleLookup(createMockLookupResult({ title: "Lookup Title" })),
+      );
+
+      renderCreateForm();
+
+      const lookupInput = screen.getByPlaceholderText("Titre de la série");
+      await user.type(lookupInput, "Lookup Title");
+      await user.click(screen.getByTitle("Rechercher"));
+
+      await waitFor(() => {
+        expect(screen.getByText(/sélectionnez une série/)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /Fermer/ }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/sélectionnez une série/),
+        ).not.toBeInTheDocument();
+      });
+    });
+
     it("switches to ISBN mode when clicking ISBN toggle", async () => {
       const user = userEvent.setup();
       renderCreateForm();

--- a/frontend/src/__tests__/unit/utils/lookupCandidate.test.ts
+++ b/frontend/src/__tests__/unit/utils/lookupCandidate.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { LookupCandidate } from "../../../types/api";
+import { candidateVolumeChip, candidateYear } from "../../../utils/lookupCandidate";
+
+function makeCandidate(overrides: Partial<LookupCandidate> = {}): LookupCandidate {
+  return {
+    authors: null,
+    description: null,
+    isbn: null,
+    isOneShot: null,
+    latestPublishedIssue: null,
+    publishedDate: null,
+    publisher: null,
+    thumbnail: null,
+    title: null,
+    tomeEnd: null,
+    tomeNumber: null,
+    ...overrides,
+  };
+}
+
+describe("candidateYear", () => {
+  it('returns the year string for a plain year "2000"', () => {
+    expect(candidateYear("2000")).toBe("2000");
+  });
+
+  it('extracts the year from a full date "2000-05-12"', () => {
+    expect(candidateYear("2000-05-12")).toBe("2000");
+  });
+
+  it('extracts the year from a natural-language date "mai 2014"', () => {
+    expect(candidateYear("mai 2014")).toBe("2014");
+  });
+
+  it("returns null for null", () => {
+    expect(candidateYear(null)).toBeNull();
+  });
+
+  it('returns null for an empty string ""', () => {
+    expect(candidateYear("")).toBeNull();
+  });
+
+  it('returns null when no year is present ("sans année")', () => {
+    expect(candidateYear("sans année")).toBeNull();
+  });
+});
+
+describe("candidateVolumeChip", () => {
+  it('returns {kind:"oneshot"} when isOneShot is true, even with tomeEnd set', () => {
+    expect(candidateVolumeChip(makeCandidate({ isOneShot: true, tomeEnd: 6 }))).toEqual({
+      kind: "oneshot",
+    });
+  });
+
+  it('returns {kind:"count", label:"6 tomes"} when tomeEnd is 6', () => {
+    expect(candidateVolumeChip(makeCandidate({ tomeEnd: 6 }))).toEqual({
+      kind: "count",
+      label: "6 tomes",
+    });
+  });
+
+  it('returns singular "1 tome" when tomeEnd is 1', () => {
+    expect(candidateVolumeChip(makeCandidate({ tomeEnd: 1 }))).toEqual({
+      kind: "count",
+      label: "1 tome",
+    });
+  });
+
+  it("falls back to latestPublishedIssue when tomeEnd is null", () => {
+    expect(
+      candidateVolumeChip(makeCandidate({ tomeEnd: null, latestPublishedIssue: 12 })),
+    ).toEqual({ kind: "count", label: "12 tomes" });
+  });
+
+  it("falls back to tomeNumber when tomeEnd and latestPublishedIssue are null", () => {
+    expect(
+      candidateVolumeChip(
+        makeCandidate({ tomeEnd: null, latestPublishedIssue: null, tomeNumber: 3 }),
+      ),
+    ).toEqual({ kind: "count", label: "3 tomes" });
+  });
+
+  it("returns null when all volume fields are null and isOneShot is false", () => {
+    expect(candidateVolumeChip(makeCandidate({ isOneShot: false }))).toBeNull();
+  });
+
+  it("returns null when tomeEnd is 0 and other volume fields are null", () => {
+    expect(
+      candidateVolumeChip(makeCandidate({ tomeEnd: 0, latestPublishedIssue: null, tomeNumber: null })),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/components/LookupCandidateCard.tsx
+++ b/frontend/src/components/LookupCandidateCard.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import type { LookupCandidate } from "../types/api";
 import { candidateVolumeChip, candidateYear } from "../utils/lookupCandidate";
-import CoverImage from "./CoverImage";
 
 interface LookupCandidateCardProps {
   candidate: LookupCandidate;
@@ -70,9 +69,12 @@ export default function LookupCandidateCard({
     >
       <div className="flex gap-3">
         {candidate.thumbnail ? (
-          <CoverImage
+          // Vignette externe (Google Books, Bédéthèque…) : <img> simple, sans
+          // crossOrigin (contrairement à CoverImage réservé aux couvertures
+          // locales), sinon le CORS bloque le chargement.
+          <img
             alt={candidate.title ?? ""}
-            className="h-24 w-16 shrink-0 rounded-lg"
+            className="h-24 w-16 shrink-0 rounded-lg object-cover"
             src={candidate.thumbnail}
           />
         ) : (

--- a/frontend/src/components/LookupCandidateCard.tsx
+++ b/frontend/src/components/LookupCandidateCard.tsx
@@ -1,0 +1,131 @@
+import { useState } from "react";
+import type { LookupCandidate } from "../types/api";
+import { candidateVolumeChip, candidateYear } from "../utils/lookupCandidate";
+import CoverImage from "./CoverImage";
+
+interface LookupCandidateCardProps {
+  candidate: LookupCandidate;
+  onSelect: () => void;
+}
+
+type ChipTone = "neutral" | "accent" | "oneshot";
+
+interface Chip {
+  text: string;
+  tone: ChipTone;
+}
+
+const toneClasses: Record<ChipTone, string> = {
+  accent:
+    "text-primary-600 bg-primary-50 dark:bg-primary-500/10",
+  neutral: "text-text-secondary bg-surface-tertiary",
+  oneshot:
+    "text-amber-700 bg-amber-50 dark:text-amber-300 dark:bg-amber-500/10",
+};
+
+export default function LookupCandidateCard({
+  candidate,
+  onSelect,
+}: LookupCandidateCardProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const chips: Chip[] = [];
+
+  if (candidate.publisher) {
+    chips.push({ text: candidate.publisher, tone: "neutral" });
+  }
+
+  const year = candidateYear(candidate.publishedDate);
+  if (year !== null) {
+    chips.push({ text: year, tone: "neutral" });
+  }
+
+  const volumeChip = candidateVolumeChip(candidate);
+  if (volumeChip !== null) {
+    if (volumeChip.kind === "oneshot") {
+      chips.push({ text: "One-shot", tone: "oneshot" });
+    } else {
+      chips.push({ text: volumeChip.label, tone: "accent" });
+    }
+  }
+
+  const hasDescription =
+    typeof candidate.description === "string" &&
+    candidate.description.length > 0;
+
+  return (
+    <div
+      className="w-full cursor-pointer rounded-xl border border-surface-border bg-surface-primary p-3 text-left transition-transform active:scale-[0.98] hover:border-primary-400 dark:border-white/10 dark:bg-surface-secondary"
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          onSelect();
+        } else if (e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+    >
+      <div className="flex gap-3">
+        {candidate.thumbnail ? (
+          <CoverImage
+            alt={candidate.title ?? ""}
+            className="h-24 w-16 shrink-0 rounded-lg"
+            src={candidate.thumbnail}
+          />
+        ) : (
+          <div className="flex h-24 w-16 shrink-0 items-center justify-center rounded-lg bg-surface-tertiary text-text-muted">
+            ?
+          </div>
+        )}
+
+        <div className="min-w-0 flex-1">
+          <h4 className="truncate text-sm font-semibold text-text-primary">
+            {candidate.title ?? "Sans titre"}
+          </h4>
+
+          {candidate.authors && (
+            <p className="truncate text-xs text-text-muted">
+              {candidate.authors}
+            </p>
+          )}
+
+          {chips.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {chips.map((chip) => (
+                <span
+                  className={`rounded-md px-2 py-0.5 text-[11px] font-semibold whitespace-nowrap ${toneClasses[chip.tone]}`}
+                  key={chip.text}
+                >
+                  {chip.text}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {hasDescription && (
+        <>
+          <p
+            className={`mt-2.5 text-[13px] leading-relaxed text-text-secondary${expanded ? "" : " line-clamp-3"}`}
+          >
+            {candidate.description}
+          </p>
+          <button
+            className="mt-1.5 text-xs font-semibold text-primary-600"
+            onClick={(e) => {
+              e.stopPropagation();
+              setExpanded((v) => !v);
+            }}
+            type="button"
+          >
+            {expanded ? "moins" : "plus"}
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/LookupSection.tsx
+++ b/frontend/src/components/LookupSection.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Layers, Loader2, Search } from "lucide-react";
+import { ArrowLeft, Layers, Loader2, Search, X } from "lucide-react";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { formInputClassName } from "../styles/formStyles";
 import BarcodeScanner from "./BarcodeScanner";
@@ -8,6 +8,7 @@ import type { LookupCandidatesResponse, LookupResult } from "../types/api";
 interface LookupSectionProps {
   applyLookup: () => void;
   clearCandidate: () => void;
+  clearTitleSearch: () => void;
   formTitle: string;
   isApplying: boolean;
   isOnline: boolean;
@@ -27,6 +28,7 @@ interface LookupSectionProps {
 export default function LookupSection({
   applyLookup,
   clearCandidate,
+  clearTitleSearch,
   formTitle,
   isApplying,
   isOnline,
@@ -145,14 +147,23 @@ export default function LookupSection({
         titleCandidates.data &&
         !titleCandidates.isFetching && (
           <div className="space-y-2">
-            {titleCandidates.data.results.length === 0 ? (
-              <p className="text-sm text-text-muted">Aucun résultat trouvé</p>
-            ) : (
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-xs text-text-muted">
+                {titleCandidates.data.results.length === 0
+                  ? "Aucun résultat trouvé"
+                  : `${titleCandidates.data.results.length} résultat(s) — sélectionnez une série :`}
+              </p>
+              <button
+                className="flex shrink-0 items-center gap-1 text-xs text-text-muted transition hover:text-text-secondary"
+                onClick={clearTitleSearch}
+                type="button"
+              >
+                <X className="h-3.5 w-3.5" />
+                Fermer
+              </button>
+            </div>
+            {titleCandidates.data.results.length > 0 && (
               <>
-                <p className="text-xs text-text-muted">
-                  {titleCandidates.data.results.length} résultat(s) —
-                  sélectionnez une série :
-                </p>
                 <div className="space-y-2">
                   {titleCandidates.data.results.map((candidate, index) => (
                     <LookupCandidateCard
@@ -164,12 +175,12 @@ export default function LookupSection({
                     />
                   ))}
                 </div>
+                {titleCandidates.data.sources.length > 0 && (
+                  <p className="text-xs text-text-muted">
+                    Sources : {titleCandidates.data.sources.join(", ")}
+                  </p>
+                )}
               </>
-            )}
-            {titleCandidates.data.sources.length > 0 && (
-              <p className="text-xs text-text-muted">
-                Sources : {titleCandidates.data.sources.join(", ")}
-              </p>
             )}
           </div>
         )}

--- a/frontend/src/components/LookupSection.tsx
+++ b/frontend/src/components/LookupSection.tsx
@@ -2,6 +2,7 @@ import { ArrowLeft, Layers, Loader2, Search } from "lucide-react";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { formInputClassName } from "../styles/formStyles";
 import BarcodeScanner from "./BarcodeScanner";
+import LookupCandidateCard from "./LookupCandidateCard";
 import type { LookupCandidatesResponse, LookupResult } from "../types/api";
 
 interface LookupSectionProps {
@@ -152,37 +153,15 @@ export default function LookupSection({
                   {titleCandidates.data.results.length} résultat(s) —
                   sélectionnez une série :
                 </p>
-                <div className="space-y-1.5">
+                <div className="space-y-2">
                   {titleCandidates.data.results.map((candidate, index) => (
-                    <button
-                      className="flex w-full items-center gap-3 rounded-lg bg-surface-primary p-2.5 border border-surface-border text-left hover:border-primary-400 transition"
+                    <LookupCandidateCard
+                      candidate={candidate}
                       key={index}
-                      onClick={() =>
+                      onSelect={() =>
                         candidate.title && selectCandidate(candidate.title)
                       }
-                      type="button"
-                    >
-                      {candidate.thumbnail ? (
-                        <img
-                          alt=""
-                          className="h-12 w-9 shrink-0 rounded object-cover"
-                          src={candidate.thumbnail}
-                        />
-                      ) : (
-                        <div className="flex h-12 w-9 shrink-0 items-center justify-center rounded bg-surface-tertiary text-text-muted">
-                          <Layers className="h-4 w-4" />
-                        </div>
-                      )}
-                      <div className="min-w-0 text-sm">
-                        <p className="truncate font-medium text-text-primary">
-                          {candidate.title}
-                        </p>
-                        <p className="truncate text-text-muted">
-                          {candidate.authors ?? ""}
-                          {candidate.publisher && ` — ${candidate.publisher}`}
-                        </p>
-                      </div>
-                    </button>
+                    />
                   ))}
                 </div>
               </>

--- a/frontend/src/hooks/useComicForm.ts
+++ b/frontend/src/hooks/useComicForm.ts
@@ -331,6 +331,7 @@ export function useComicForm() {
     // Lookup
     applyLookup: lookup.applyLookup,
     clearCandidate: lookup.clearCandidate,
+    clearTitleSearch: lookup.clearTitleSearch,
     isApplying: lookup.isApplying,
     lookupIsbn: lookup.lookupIsbn,
     lookupMode: lookup.lookupMode,

--- a/frontend/src/hooks/useLookupFeature.ts
+++ b/frontend/src/hooks/useLookupFeature.ts
@@ -13,6 +13,7 @@ import type { LookupCandidatesResponse, LookupResult } from "../types/api";
 export interface LookupFeature {
   applyLookup: () => Promise<void>;
   clearCandidate: () => void;
+  clearTitleSearch: () => void;
   isApplying: boolean;
   lookupIsbn: string;
   lookupMode: "isbn" | "title";
@@ -119,6 +120,12 @@ export function useLookupFeature(
     setSelectedCandidateTitle(null);
   };
 
+  /** Ferme la liste des résultats de recherche par titre (conserve la saisie). */
+  const clearTitleSearch = () => {
+    setSubmittedTitle("");
+    setSelectedCandidateTitle(null);
+  };
+
   const applyLookup = async () => {
     const result = lookupResult.data;
     if (!result) return;
@@ -171,6 +178,7 @@ export function useLookupFeature(
   return {
     applyLookup,
     clearCandidate,
+    clearTitleSearch,
     isApplying,
     lookupIsbn,
     lookupMode,

--- a/frontend/src/pages/ComicForm.tsx
+++ b/frontend/src/pages/ComicForm.tsx
@@ -30,6 +30,7 @@ export default function ComicForm() {
     authorOptions,
     authorSearch,
     clearCandidate,
+    clearTitleSearch,
     coverSearchOpen,
     form,
     handleSubmit,
@@ -134,6 +135,7 @@ export default function ComicForm() {
         <LookupSection
           applyLookup={applyLookup}
           clearCandidate={clearCandidate}
+          clearTitleSearch={clearTitleSearch}
           formTitle={form.title}
           isApplying={isApplying}
           isOnline={isOnline}

--- a/frontend/src/utils/lookupCandidate.ts
+++ b/frontend/src/utils/lookupCandidate.ts
@@ -1,0 +1,28 @@
+import type { LookupCandidate } from "../types/api";
+
+/** Représente le badge de volume affiché sur une carte de résultat de recherche. */
+export type VolumeChip = { kind: "oneshot" } | { kind: "count"; label: string };
+
+/**
+ * Extrait l'année (4 chiffres) depuis une date de publication quelconque.
+ * Retourne null si aucune année n'est trouvée ou si la valeur est vide.
+ */
+export function candidateYear(publishedDate: string | null): string | null {
+  if (!publishedDate) return null;
+  const match = publishedDate.match(/\d{4}/);
+  return match ? match[0] : null;
+}
+
+/**
+ * Dérive le badge de volume (one-shot ou nombre de tomes) depuis un candidat de recherche.
+ * Priorité : isOneShot → tomeEnd → latestPublishedIssue → tomeNumber.
+ * Retourne null si aucune information de volume n'est disponible.
+ */
+export function candidateVolumeChip(c: LookupCandidate): VolumeChip | null {
+  if (c.isOneShot === true) return { kind: "oneshot" };
+  const count = c.tomeEnd ?? c.latestPublishedIssue ?? c.tomeNumber;
+  if (count != null && count > 0) {
+    return { kind: "count", label: `${count} tome${count > 1 ? "s" : ""}` };
+  }
+  return null;
+}


### PR DESCRIPTION
## Résumé

Les résultats de la recherche par titre (« Recherche automatique » du formulaire de série) passent d'une ligne compacte à une carte enrichie, en exploitant des données déjà renvoyées par l'API de lookup mais ignorées jusqu'ici.

- **Couverture agrandie** (96×64) + titre + auteur.
- **Puces de métadonnées** : éditeur · année · nombre de tomes, ou un badge ambre **One-shot**.
- **Description** repliée sur 3 lignes avec un lien « plus / moins » pour déplier sur place (sans déclencher la sélection).
- Nouveau composant `LookupCandidateCard` + helpers purs `candidateYear` / `candidateVolumeChip`. `LookupSection` ne fait que brancher la carte.
- Vignette externe affichée via un `<img>` simple (sans `crossOrigin`, contrairement à `CoverImage` réservé aux couvertures locales) pour éviter le blocage CORS.
- Aucun changement backend ; recherche de bibliothèque et page Quick Add non touchées.

## Tests

- Helpers : tests unitaires (année, ordre de repli `tomeEnd ?? latestPublishedIssue ?? tomeNumber`, singulier/pluriel, priorité One-shot, cas null/zéro).
- Composant : tests RTL (puces, omission des champs null, badge One-shot, repli description sans sélection, clic = sélection, activation clavier Enter/Espace, vignette externe sans crossOrigin, fallback sans couverture / sans description).
- Suite frontend complète : 978 tests OK, `tsc --noEmit` propre.
- Vérifié en local sur le formulaire (recherche « blacksad » : cartes, couvertures, description repliable, placeholder).

## Vérification manuelle

- [ ] Formulaire de série → onglet « Titre » → rechercher, vérifier couverture/puces/description et le dépliage.
- [ ] Un résultat sans couverture (placeholder « ? ») et un one-shot (badge ambre).