### PR TITLE
refactor(backend): migration PHP 8.4

### DIFF
--- a/.claude/memory/patterns.md
+++ b/.claude/memory/patterns.md
@@ -139,7 +139,7 @@ SoftDeleteFilter — excludes soft-deleted ComicSeries. Disabled in trash-relate
 
 ## Deployment
 
-**Docker (Synology NAS)**: 2 containers — `app` (FrankenPHP : web Caddy + PHP 8.3 + worker Messenger + scheduler via supervisord) and `db` (MariaDB 10.11). Image unique `ghcr.io/soviann/bibliotheque` (CI, contexte = racine du dépôt : `backend/Dockerfile` build frontend Vite + backend). Config FrankenPHP : `backend/docker/frankenphp/{Caddyfile,supervisord.conf,docker-entrypoint.sh}`. Routage Caddy : `/api` + `/media` (fallback LiipImagine) → PHP ; reste → SPA React (fallback `index.html`). Guides : `docs/guide-deploiement-nas.md` (human), `docs/guide-deploiement-nas-claude.md` (Claude/SSH).
+**Docker (Synology NAS)**: 2 containers — `app` (FrankenPHP : web Caddy + PHP 8.4 + worker Messenger + scheduler via supervisord) and `db` (MariaDB 10.11). Image unique `ghcr.io/soviann/bibliotheque` (CI, contexte = racine du dépôt : `backend/Dockerfile` build frontend Vite + backend). Config FrankenPHP : `backend/docker/frankenphp/{Caddyfile,supervisord.conf,docker-entrypoint.sh}`. Routage Caddy : `/api` + `/media` (fallback LiipImagine) → PHP ; reste → SPA React (fallback `index.html`). Guides : `docs/guide-deploiement-nas.md` (human), `docs/guide-deploiement-nas-claude.md` (Claude/SSH).
 
 ```bash
 cd backend && docker compose up --build -d                  # dev local (build)

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: bibliotheque
 type: php
 docroot: backend/public
-php_version: "8.3"
+php_version: "8.4"
 webimage_extra_packages:
   - build-essential
   - zsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: ctype, iconv, intl, gd
           tools: composer:v2
 
@@ -84,7 +84,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: ctype, iconv, intl, gd
           tools: composer:v2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ et ce projet adhère au [Versionnement Sémantique](https://semver.org/lang/fr/)
 
 ## [Unreleased]
 
+### Changed
+
+- **PHP 8.4** : Migration du backend vers PHP 8.4, mise à niveau de l'infrastructure (DDEV, image Docker FrankenPHP `1-php8.4`, CI GitHub Actions), mise à jour des dépendances Composer et application des règles Rector PHP 8.4 (#442).
+
 ## [v2.34.1] — 2026-06-27
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## Project
 
-**Comic/Manga Library** — Monorepo: `backend/` (Symfony 7.4, PHP 8.3, API Platform 4, JWT) + `frontend/` (React 19, TS, Vite, TanStack Query). MariaDB 10.11, DDEV, PWA. Sole developer (Claude) → maximum rigor; keep this file + tests current.
+**Comic/Manga Library** — Monorepo: `backend/` (Symfony 7.4, PHP 8.4, API Platform 4, JWT) + `frontend/` (React 19, TS, Vite, TanStack Query). MariaDB 10.11, DDEV, PWA. Sole developer (Claude) → maximum rigor; keep this file + tests current.
 
 ## Approach (overrides)
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Application de gestion de collection BD / Manga / Comics / Livres.
 
 ## Stack technique
 
-**Backend** : Symfony 7.4, PHP 8.3, API Platform 4, MariaDB 10.11, JWT
+**Backend** : Symfony 7.4, PHP 8.4, API Platform 4, MariaDB 10.11, JWT
 **Frontend** : React 19, TypeScript, Vite, TanStack Query, Tailwind CSS 4
 **Infra** : DDEV (dev), Docker Compose (prod), PWA
 
 ## Production
 
-3 conteneurs Docker : **nginx** (reverse proxy + frontend React) + **php** (PHP-FPM 8.3, Symfony 7) + **db** (MariaDB 10.11).
+3 conteneurs Docker : **nginx** (reverse proxy + frontend React) + **php** (PHP-FPM 8.4, Symfony 7) + **db** (MariaDB 10.11).
 
 L'image unique (FrankenPHP : web Caddy + PHP + worker Messenger) est pré-buildée en CI et publiée sur ghcr.io à chaque release :
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,7 @@ COPY frontend/ .
 RUN npm run build
 
 # Stage 2 — Runtime FrankenPHP (web + PHP + worker)
-FROM dunglas/frankenphp:1-php8.3 AS app
+FROM dunglas/frankenphp:1-php8.4 AS app
 
 # gosu : drop de privilèges vers www-data ; supervisor : multi-process (web + messenger)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/backend/README.md
+++ b/backend/README.md
@@ -3,7 +3,7 @@
 Application web de gestion de collection de BD, Comics, Mangas et Livres avec support hors-ligne (PWA).
 
 ![Symfony](https://img.shields.io/badge/Symfony-7.4-000000?logo=symfony)
-![PHP](https://img.shields.io/badge/PHP-8.3-777BB4?logo=php)
+![PHP](https://img.shields.io/badge/PHP-8.4-777BB4?logo=php)
 ![License](https://img.shields.io/badge/License-MIT-green)
 
 ---
@@ -94,7 +94,7 @@ Voir le [guide d'installation complet](docs/installation/README.md).
 
 | Composant | Version | Usage |
 |-----------|---------|-------|
-| PHP | 8.3+ | Backend |
+| PHP | 8.4+ | Backend |
 | Symfony | 7.4 | Framework |
 | MariaDB | 10.11+ | Base de donnees |
 | Doctrine ORM | - | Persistence |

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -6,12 +6,12 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.3",
+        "php": ">=8.4",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "api-platform/doctrine-orm": "^4.3.10",
         "api-platform/symfony": ">=4.3.10",
-        "doctrine/doctrine-bundle": "^2.18.2",
+        "doctrine/doctrine-bundle": "^2.19.0",
         "doctrine/doctrine-migrations-bundle": "^3.7",
         "doctrine/orm": "^3.6.7",
         "dragonmantank/cron-expression": "^3.6",
@@ -27,20 +27,20 @@
         "phpoffice/phpspreadsheet": "^5.8",
         "phpseclib/phpseclib": "^3.0",
         "symfony/console": "^7.4.13",
-        "symfony/doctrine-messenger": "^7.4.6",
-        "symfony/dotenv": "^7.4.11",
+        "symfony/doctrine-messenger": "^7.4.15",
+        "symfony/dotenv": "^7.4.15",
         "symfony/flex": "^2.11",
         "symfony/framework-bundle": "^7.4.13",
-        "symfony/messenger": "^7.4.12",
+        "symfony/messenger": "^7.4.15",
         "symfony/monolog-bundle": "^4.0.2",
-        "symfony/rate-limiter": "^7.4.13",
-        "symfony/runtime": "^7.4.13",
-        "symfony/scheduler": "^7.4.13",
-        "symfony/security-bundle": "^7.4.13",
-        "symfony/translation": "^7.4.10",
+        "symfony/rate-limiter": "^7.4.16",
+        "symfony/runtime": "^7.4.14",
+        "symfony/scheduler": "^7.4.15",
+        "symfony/security-bundle": "^7.4.15",
+        "symfony/translation": "^7.4.16",
         "symfony/validator": "^7.4.10",
-        "symfony/yaml": "^7.4.13",
-        "vich/uploader-bundle": "^2.9.4"
+        "symfony/yaml": "^7.4.15",
+        "vich/uploader-bundle": "^2.10.0"
     },
     "config": {
         "allow-plugins": {
@@ -70,7 +70,8 @@
         "symfony/polyfill-php80": "*",
         "symfony/polyfill-php81": "*",
         "symfony/polyfill-php82": "*",
-        "symfony/polyfill-php83": "*"
+        "symfony/polyfill-php83": "*",
+        "symfony/polyfill-php84": "*"
     },
     "scripts": {
         "auto-scripts": {
@@ -96,12 +97,12 @@
     "require-dev": {
         "dama/doctrine-test-bundle": "^8.6",
         "doctrine/doctrine-fixtures-bundle": "^4.3.1",
-        "friendsofphp/php-cs-fixer": "^3.95.4",
+        "friendsofphp/php-cs-fixer": "^3.95.21",
         "phpstan/phpstan": "^2.2.2",
         "phpstan/phpstan-symfony": "^2.0.19",
-        "phpunit/phpunit": "^12.5.29",
-        "rector/rector": "^2.4.5",
-        "symfony/browser-kit": "^7.4.8",
+        "phpunit/phpunit": "^12.5.33",
+        "rector/rector": "^2.6.3",
+        "symfony/browser-kit": "^7.4.14",
         "symfony/css-selector": "^7.4.9",
         "symfony/http-client": "^7.4.13",
         "symfony/maker-bundle": "^1.67",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87912bc4e2a40b25233f49b990ec5922",
+    "content-hash": "92141c78443515939e9b9caeb2503048",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -1163,23 +1163,22 @@
         },
         {
             "name": "brick/math",
-            "version": "0.14.8",
+            "version": "0.17.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629"
+                "reference": "8189e751995f9e15729c1aa2f89fa8f166ffe818"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/63422359a44b7f06cae63c3b429b59e8efcc0629",
-                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629",
+                "url": "https://api.github.com/repos/brick/math/zipball/8189e751995f9e15729c1aa2f89fa8f166ffe818",
+                "reference": "8189e751995f9e15729c1aa2f89fa8f166ffe818",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.2"
             },
             "require-dev": {
-                "php-coveralls/php-coveralls": "^2.2",
                 "phpstan/phpstan": "2.1.22",
                 "phpunit/phpunit": "^11.5"
             },
@@ -1211,7 +1210,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.14.8"
+                "source": "https://github.com/brick/math/tree/0.17.2"
             },
             "funding": [
                 {
@@ -1219,20 +1218,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-10T14:33:43+00:00"
+            "time": "2026-05-25T20:34:43+00:00"
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.12",
+            "version": "1.5.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "00a2f4201641d5c53f7fc0195e6c8d9fcc321a78"
+                "reference": "0c8abba0634f637bd78c4e451981da368d403463"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/00a2f4201641d5c53f7fc0195e6c8d9fcc321a78",
-                "reference": "00a2f4201641d5c53f7fc0195e6c8d9fcc321a78",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/0c8abba0634f637bd78c4e451981da368d403463",
+                "reference": "0c8abba0634f637bd78c4e451981da368d403463",
                 "shasum": ""
             },
             "require": {
@@ -1279,7 +1278,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.12"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.14"
             },
             "funding": [
                 {
@@ -1291,7 +1290,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-19T11:26:22+00:00"
+            "time": "2026-08-21T14:57:29+00:00"
         },
         {
             "name": "composer/pcre",
@@ -1779,16 +1778,16 @@
         },
         {
             "name": "doctrine/doctrine-bundle",
-            "version": "2.18.2",
+            "version": "2.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineBundle.git",
-                "reference": "0ff098b29b8b3c68307c8987dcaed7fd829c6546"
+                "reference": "07b90f707b82981097731c419f546e7ba97fba3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/0ff098b29b8b3c68307c8987dcaed7fd829c6546",
-                "reference": "0ff098b29b8b3c68307c8987dcaed7fd829c6546",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/07b90f707b82981097731c419f546e7ba97fba3c",
+                "reference": "07b90f707b82981097731c419f546e7ba97fba3c",
                 "shasum": ""
             },
             "require": {
@@ -1810,7 +1809,7 @@
                 "doctrine/cache": "< 1.11",
                 "doctrine/orm": "<2.17 || >=4.0",
                 "symfony/var-exporter": "< 6.4.1 || 7.0.0",
-                "twig/twig": "<2.13 || >=3.0 <3.0.4"
+                "twig/twig": "<2.13 || >=3.0 <3.0.4 || >=5"
             },
             "require-dev": {
                 "doctrine/annotations": "^1 || ^2",
@@ -1824,9 +1823,12 @@
                 "phpunit/phpunit": "^10.5.53 || ^12.3.10",
                 "psr/log": "^1.1.4 || ^2.0 || ^3.0",
                 "symfony/doctrine-messenger": "^6.4 || ^7.0",
+                "symfony/event-dispatcher": "^6.4 || ^7.0",
                 "symfony/expression-language": "^6.4 || ^7.0",
+                "symfony/http-kernel": "^6.4 || ^7.0",
                 "symfony/messenger": "^6.4 || ^7.0",
                 "symfony/property-info": "^6.4 || ^7.0",
+                "symfony/runtime": "^6.4 || ^7.0",
                 "symfony/security-bundle": "^6.4 || ^7.0",
                 "symfony/stopwatch": "^6.4 || ^7.0",
                 "symfony/string": "^6.4 || ^7.0",
@@ -1835,7 +1837,7 @@
                 "symfony/var-exporter": "^6.4.1 || ^7.0.1",
                 "symfony/web-profiler-bundle": "^6.4 || ^7.0",
                 "symfony/yaml": "^6.4 || ^7.0",
-                "twig/twig": "^2.14.7 || ^3.0.4"
+                "twig/twig": "^2.14.7 || ^3.0.4 || ^4"
             },
             "suggest": {
                 "doctrine/orm": "The Doctrine ORM integration is optional in the bundle.",
@@ -1880,7 +1882,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/DoctrineBundle/issues",
-                "source": "https://github.com/doctrine/DoctrineBundle/tree/2.18.2"
+                "source": "https://github.com/doctrine/DoctrineBundle/tree/2.19.0"
             },
             "funding": [
                 {
@@ -1896,7 +1898,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-20T21:35:32+00:00"
+            "time": "2026-07-23T14:52:05+00:00"
         },
         {
             "name": "doctrine/doctrine-migrations-bundle",
@@ -2166,30 +2168,29 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^8.4"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^11",
+                "doctrine/coding-standard": "^14",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.58"
             },
             "type": "library",
             "autoload": {
@@ -2216,7 +2217,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
             },
             "funding": [
                 {
@@ -2232,7 +2233,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:23:10+00:00"
+            "time": "2026-01-05T06:47:08+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -2999,16 +3000,16 @@
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.453.0",
+            "version": "v0.455.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "9eeab572613c0b533f8268e5df0954a63100061d"
+                "reference": "86cecb5443bde01cb6731a650735680b9ab8b4c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/9eeab572613c0b533f8268e5df0954a63100061d",
-                "reference": "9eeab572613c0b533f8268e5df0954a63100061d",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/86cecb5443bde01cb6731a650735680b9ab8b4c0",
+                "reference": "86cecb5443bde01cb6731a650735680b9ab8b4c0",
                 "shasum": ""
             },
             "require": {
@@ -3037,9 +3038,9 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.453.0"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.455.0"
             },
-            "time": "2026-08-03T01:20:25+00:00"
+            "time": "2026-08-17T01:06:24+00:00"
         },
         {
             "name": "google/auth",
@@ -4606,16 +4607,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
-                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "url": "https://api.github.com/repos/nette/utils/zipball/b043439dbdf954e6c28b5ea7e34b0100f83165e0",
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0",
                 "shasum": ""
             },
             "require": {
@@ -4635,7 +4636,7 @@
             },
             "suggest": {
                 "ext-gd": "to use Image",
-                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-iconv": "to use Strings::chr(), ord() and reverse()",
                 "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
                 "ext-json": "to use Nette\\Utils\\Json",
                 "ext-mbstring": "to use Strings::lower() etc...",
@@ -4691,9 +4692,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.4"
+                "source": "https://github.com/nette/utils/tree/v4.1.5"
             },
-            "time": "2026-05-11T20:49:54+00:00"
+            "time": "2026-07-17T23:02:45+00:00"
         },
         {
             "name": "nyholm/psr7",
@@ -5938,20 +5939,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.9.2",
+            "version": "4.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "8429c78ca35a09f27565311b98101e2826affde0"
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/8429c78ca35a09f27565311b98101e2826affde0",
-                "reference": "8429c78ca35a09f27565311b98101e2826affde0",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/1df15849d00943a67d677dc9cfd80795f038c9f8",
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.16 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13 || ^0.14",
+                "brick/math": ">=0.8.16 <=0.18",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
             },
@@ -6010,9 +6011,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.9.2"
+                "source": "https://github.com/ramsey/uuid/tree/4.9.3"
             },
-            "time": "2025-12-14T04:43:48+00:00"
+            "time": "2026-06-18T03:57:49+00:00"
         },
         {
             "name": "spomky-labs/base64url",
@@ -6856,16 +6857,16 @@
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v7.4.9",
+            "version": "v7.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
-                "reference": "7a87c85853f3069e3657a823c62b02952de46b0a"
+                "reference": "f69be90a9cc5ebf210414faa5c69a31b8b5a370f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/7a87c85853f3069e3657a823c62b02952de46b0a",
-                "reference": "7a87c85853f3069e3657a823c62b02952de46b0a",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/f69be90a9cc5ebf210414faa5c69a31b8b5a370f",
+                "reference": "f69be90a9cc5ebf210414faa5c69a31b8b5a370f",
                 "shasum": ""
             },
             "require": {
@@ -6945,7 +6946,7 @@
             "description": "Provides integration for Doctrine with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/doctrine-bridge/tree/v7.4.9"
+                "source": "https://github.com/symfony/doctrine-bridge/tree/v7.4.16"
             },
             "funding": [
                 {
@@ -6965,20 +6966,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T14:19:39+00:00"
+            "time": "2026-08-06T07:14:37+00:00"
         },
         {
             "name": "symfony/doctrine-messenger",
-            "version": "v7.4.6",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-messenger.git",
-                "reference": "a429cd95983eaea2371ea279bed3b8a93b9ecdd3"
+                "reference": "2356265da4dd8e8b689e735dcce33f5fd40506e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-messenger/zipball/a429cd95983eaea2371ea279bed3b8a93b9ecdd3",
-                "reference": "a429cd95983eaea2371ea279bed3b8a93b9ecdd3",
+                "url": "https://api.github.com/repos/symfony/doctrine-messenger/zipball/2356265da4dd8e8b689e735dcce33f5fd40506e5",
+                "reference": "2356265da4dd8e8b689e735dcce33f5fd40506e5",
                 "shasum": ""
             },
             "require": {
@@ -7021,7 +7022,7 @@
             "description": "Symfony Doctrine Messenger Bridge",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/doctrine-messenger/tree/v7.4.6"
+                "source": "https://github.com/symfony/doctrine-messenger/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -7041,20 +7042,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-18T09:40:04+00:00"
+            "time": "2026-07-29T06:18:55+00:00"
         },
         {
             "name": "symfony/dotenv",
-            "version": "v7.4.11",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
-                "reference": "82e9b1355c68ef7b96397dbd34cc75a92eebae7c"
+                "reference": "99b5b14953237c89ed24f1af5ba34225caf598a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/82e9b1355c68ef7b96397dbd34cc75a92eebae7c",
-                "reference": "82e9b1355c68ef7b96397dbd34cc75a92eebae7c",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/99b5b14953237c89ed24f1af5ba34225caf598a4",
+                "reference": "99b5b14953237c89ed24f1af5ba34225caf598a4",
                 "shasum": ""
             },
             "require": {
@@ -7099,7 +7100,7 @@
                 "environment"
             ],
             "support": {
-                "source": "https://github.com/symfony/dotenv/tree/v7.4.11"
+                "source": "https://github.com/symfony/dotenv/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -7119,7 +7120,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-11T13:02:51+00:00"
+            "time": "2026-07-26T10:22:28+00:00"
         },
         {
             "name": "symfony/error-handler",
@@ -8123,16 +8124,16 @@
         },
         {
             "name": "symfony/messenger",
-            "version": "v7.4.12",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/messenger.git",
-                "reference": "906387986caecc10b2ad2e85f715d834e5133a04"
+                "reference": "6338eed8f65c593469fdbdbe043d2a7552264403"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/messenger/zipball/906387986caecc10b2ad2e85f715d834e5133a04",
-                "reference": "906387986caecc10b2ad2e85f715d834e5133a04",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/6338eed8f65c593469fdbdbe043d2a7552264403",
+                "reference": "6338eed8f65c593469fdbdbe043d2a7552264403",
                 "shasum": ""
             },
             "require": {
@@ -8193,7 +8194,7 @@
             "description": "Helps applications send and receive messages to/from other applications or via message queues",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/messenger/tree/v7.4.12"
+                "source": "https://github.com/symfony/messenger/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -8213,7 +8214,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-19T07:02:47+00:00"
+            "time": "2026-07-22T12:46:20+00:00"
         },
         {
             "name": "symfony/mime",
@@ -8306,16 +8307,16 @@
         },
         {
             "name": "symfony/monolog-bridge",
-            "version": "v7.4.12",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bridge.git",
-                "reference": "20bb2345ac7a9dd57724b6b7ada92c6d7d67b4b8"
+                "reference": "007907c5c537c4e0ba9bb10ed196a1e4287379a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/20bb2345ac7a9dd57724b6b7ada92c6d7d67b4b8",
-                "reference": "20bb2345ac7a9dd57724b6b7ada92c6d7d67b4b8",
+                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/007907c5c537c4e0ba9bb10ed196a1e4287379a4",
+                "reference": "007907c5c537c4e0ba9bb10ed196a1e4287379a4",
                 "shasum": ""
             },
             "require": {
@@ -8365,7 +8366,7 @@
             "description": "Provides integration for Monolog with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/monolog-bridge/tree/v7.4.12"
+                "source": "https://github.com/symfony/monolog-bridge/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -8385,7 +8386,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:20:23+00:00"
+            "time": "2026-07-27T13:51:00+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -8953,86 +8954,6 @@
             "time": "2026-05-27T06:59:30+00:00"
         },
         {
-            "name": "symfony/polyfill-php84",
-            "version": "v1.38.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
-                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php84\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-26T12:51:13+00:00"
-        },
-        {
             "name": "symfony/polyfill-php85",
             "version": "v1.41.0",
             "source": {
@@ -9433,16 +9354,16 @@
         },
         {
             "name": "symfony/rate-limiter",
-            "version": "v7.4.13",
+            "version": "v7.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/rate-limiter.git",
-                "reference": "8b162768544e5a8895c52161d63c999aca91f4a9"
+                "reference": "6703d040ab83401b27f3c7b29ff4c8c8106fedba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/rate-limiter/zipball/8b162768544e5a8895c52161d63c999aca91f4a9",
-                "reference": "8b162768544e5a8895c52161d63c999aca91f4a9",
+                "url": "https://api.github.com/repos/symfony/rate-limiter/zipball/6703d040ab83401b27f3c7b29ff4c8c8106fedba",
+                "reference": "6703d040ab83401b27f3c7b29ff4c8c8106fedba",
                 "shasum": ""
             },
             "require": {
@@ -9483,7 +9404,7 @@
                 "rate-limiter"
             ],
             "support": {
-                "source": "https://github.com/symfony/rate-limiter/tree/v7.4.13"
+                "source": "https://github.com/symfony/rate-limiter/tree/v7.4.16"
             },
             "funding": [
                 {
@@ -9503,7 +9424,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-23T16:05:06+00:00"
+            "time": "2026-08-07T15:34:54+00:00"
         },
         {
             "name": "symfony/routing",
@@ -9592,16 +9513,16 @@
         },
         {
             "name": "symfony/runtime",
-            "version": "v7.4.13",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/runtime.git",
-                "reference": "1a24cf8aab3a9378117718b35525c4126ad3adec"
+                "reference": "15497f743dd714f3167cb6a56509b9d42e6417b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/runtime/zipball/1a24cf8aab3a9378117718b35525c4126ad3adec",
-                "reference": "1a24cf8aab3a9378117718b35525c4126ad3adec",
+                "url": "https://api.github.com/repos/symfony/runtime/zipball/15497f743dd714f3167cb6a56509b9d42e6417b3",
+                "reference": "15497f743dd714f3167cb6a56509b9d42e6417b3",
                 "shasum": ""
             },
             "require": {
@@ -9609,7 +9530,8 @@
                 "php": ">=8.2"
             },
             "conflict": {
-                "symfony/dotenv": "<6.4"
+                "symfony/dotenv": "<6.4",
+                "symfony/http-foundation": "<6.4"
             },
             "require-dev": {
                 "composer/composer": "^2.6",
@@ -9652,7 +9574,7 @@
                 "runtime"
             ],
             "support": {
-                "source": "https://github.com/symfony/runtime/tree/v7.4.13"
+                "source": "https://github.com/symfony/runtime/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -9672,20 +9594,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-23T18:04:28+00:00"
+            "time": "2026-06-05T06:22:21+00:00"
         },
         {
             "name": "symfony/scheduler",
-            "version": "v7.4.13",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/scheduler.git",
-                "reference": "d8fff93e5d29af0262e5693b76376117259b4532"
+                "reference": "493ca7c4dd832d6d9a42d6d2cb9a12198027c7b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/scheduler/zipball/d8fff93e5d29af0262e5693b76376117259b4532",
-                "reference": "d8fff93e5d29af0262e5693b76376117259b4532",
+                "url": "https://api.github.com/repos/symfony/scheduler/zipball/493ca7c4dd832d6d9a42d6d2cb9a12198027c7b5",
+                "reference": "493ca7c4dd832d6d9a42d6d2cb9a12198027c7b5",
                 "shasum": ""
             },
             "require": {
@@ -9737,7 +9659,7 @@
                 "scheduler"
             ],
             "support": {
-                "source": "https://github.com/symfony/scheduler/tree/v7.4.13"
+                "source": "https://github.com/symfony/scheduler/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -9757,20 +9679,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T06:06:12+00:00"
+            "time": "2026-07-19T19:34:23+00:00"
         },
         {
             "name": "symfony/security-bundle",
-            "version": "v7.4.13",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-bundle.git",
-                "reference": "0cbc6528aa583795ab44e43b4e92a09acf927c6f"
+                "reference": "890e75a1d40a7add2522e82c75ea8e050f733216"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/0cbc6528aa583795ab44e43b4e92a09acf927c6f",
-                "reference": "0cbc6528aa583795ab44e43b4e92a09acf927c6f",
+                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/890e75a1d40a7add2522e82c75ea8e050f733216",
+                "reference": "890e75a1d40a7add2522e82c75ea8e050f733216",
                 "shasum": ""
             },
             "require": {
@@ -9820,7 +9742,7 @@
                 "symfony/twig-bundle": "^6.4|^7.0|^8.0",
                 "symfony/validator": "^6.4|^7.0|^8.0",
                 "symfony/yaml": "^6.4|^7.0|^8.0",
-                "twig/twig": "^3.15",
+                "twig/twig": "^3.15|^4.0",
                 "web-token/jwt-library": "^3.3.2|^4.0"
             },
             "type": "symfony-bundle",
@@ -9849,7 +9771,7 @@
             "description": "Provides a tight integration of the Security component into the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-bundle/tree/v7.4.13"
+                "source": "https://github.com/symfony/security-bundle/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -9869,7 +9791,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-23T16:05:06+00:00"
+            "time": "2026-07-29T07:12:33+00:00"
         },
         {
             "name": "symfony/security-core",
@@ -10038,16 +9960,16 @@
         },
         {
             "name": "symfony/security-http",
-            "version": "v7.4.13",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-http.git",
-                "reference": "da3c28025a664e6a88e1af104a74457d99301161"
+                "reference": "148e038b91c8cc3e42aee177f8b0117437077c9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-http/zipball/da3c28025a664e6a88e1af104a74457d99301161",
-                "reference": "da3c28025a664e6a88e1af104a74457d99301161",
+                "url": "https://api.github.com/repos/symfony/security-http/zipball/148e038b91c8cc3e42aee177f8b0117437077c9b",
+                "reference": "148e038b91c8cc3e42aee177f8b0117437077c9b",
                 "shasum": ""
             },
             "require": {
@@ -10106,7 +10028,7 @@
             "description": "Symfony Security Component - HTTP Integration",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-http/tree/v7.4.13"
+                "source": "https://github.com/symfony/security-http/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -10126,7 +10048,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T06:06:12+00:00"
+            "time": "2026-06-19T08:40:54+00:00"
         },
         {
             "name": "symfony/serializer",
@@ -10478,16 +10400,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v7.4.10",
+            "version": "v7.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "ada7578c30dd5feaa8259cff3e885069ea81ddde"
+                "reference": "501e0ff4553c744209ca1a68790d8a4541563710"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/ada7578c30dd5feaa8259cff3e885069ea81ddde",
-                "reference": "ada7578c30dd5feaa8259cff3e885069ea81ddde",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/501e0ff4553c744209ca1a68790d8a4541563710",
+                "reference": "501e0ff4553c744209ca1a68790d8a4541563710",
                 "shasum": ""
             },
             "require": {
@@ -10554,7 +10476,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v7.4.10"
+                "source": "https://github.com/symfony/translation/tree/v7.4.16"
             },
             "funding": [
                 {
@@ -10574,7 +10496,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-06T11:19:24+00:00"
+            "time": "2026-07-30T12:37:26+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -11180,16 +11102,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.13",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c"
+                "reference": "e101850ded5d2c0d44bf32abb8996404afec2dec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
-                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e101850ded5d2c0d44bf32abb8996404afec2dec",
+                "reference": "e101850ded5d2c0d44bf32abb8996404afec2dec",
                 "shasum": ""
             },
             "require": {
@@ -11232,7 +11154,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.13"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -11252,7 +11174,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T06:06:12+00:00"
+            "time": "2026-07-21T15:13:06+00:00"
         },
         {
             "name": "twig/twig",
@@ -11399,16 +11321,16 @@
         },
         {
             "name": "vich/uploader-bundle",
-            "version": "v2.9.4",
+            "version": "v2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dustin10/VichUploaderBundle.git",
-                "reference": "6d2def18f1ca4e0d950962caa70b381e09a58ac7"
+                "reference": "0204ac45a09d866be290bc85f3dffe32647056ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dustin10/VichUploaderBundle/zipball/6d2def18f1ca4e0d950962caa70b381e09a58ac7",
-                "reference": "6d2def18f1ca4e0d950962caa70b381e09a58ac7",
+                "url": "https://api.github.com/repos/dustin10/VichUploaderBundle/zipball/0204ac45a09d866be290bc85f3dffe32647056ff",
+                "reference": "0204ac45a09d866be290bc85f3dffe32647056ff",
                 "shasum": ""
             },
             "require": {
@@ -11437,7 +11359,7 @@
                 "doctrine/mongodb-odm": "^2.4",
                 "doctrine/orm": "^2.13 || ^3.0",
                 "ext-sqlite3": "*",
-                "knplabs/knp-gaufrette-bundle": "dev-master",
+                "knplabs/knp-gaufrette-bundle": "^1.0",
                 "league/flysystem-bundle": "^2.4 || ^3.0",
                 "league/flysystem-memory": "^2.0 || ^3.0",
                 "matthiasnoback/symfony-dependency-injection-test": "^5.1 || ^6.0",
@@ -11501,9 +11423,9 @@
             ],
             "support": {
                 "issues": "https://github.com/dustin10/VichUploaderBundle/issues",
-                "source": "https://github.com/dustin10/VichUploaderBundle/tree/v2.9.4"
+                "source": "https://github.com/dustin10/VichUploaderBundle/tree/v2.10.0"
             },
-            "time": "2026-06-01T13:22:20+00:00"
+            "time": "2026-08-20T07:25:03+00:00"
         },
         {
             "name": "web-token/jwt-library",
@@ -12201,16 +12123,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.95.18",
+            "version": "v3.95.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "a8b4e4216faabf67f4e96110ee99a48c96e4e683"
+                "reference": "1228a1cd06e867846b5922a09d2ee948d8182e91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a8b4e4216faabf67f4e96110ee99a48c96e4e683",
-                "reference": "a8b4e4216faabf67f4e96110ee99a48c96e4e683",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/1228a1cd06e867846b5922a09d2ee948d8182e91",
+                "reference": "1228a1cd06e867846b5922a09d2ee948d8182e91",
                 "shasum": ""
             },
             "require": {
@@ -12246,7 +12168,6 @@
                 "infection/infection": "^0.32.7",
                 "justinrainbow/json-schema": "^6.10.0",
                 "keradus/cli-executor": "^2.3",
-                "mikey179/vfsstream": "^1.6.12",
                 "php-coveralls/php-coveralls": "^2.9.1",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.8",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.8",
@@ -12294,7 +12215,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.18"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.21"
             },
             "funding": [
                 {
@@ -12302,28 +12223,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-30T15:46:02+00:00"
+            "time": "2026-08-21T17:03:47+00:00"
         },
         {
             "name": "masterminds/html5",
-            "version": "2.10.0",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Masterminds/html5-php.git",
-                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
+                "reference": "a1e7a2f88ee13635d86fc61cfbdf2306a76ddfc7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
-                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/a1e7a2f88ee13635d86fc61cfbdf2306a76ddfc7",
+                "reference": "a1e7a2f88ee13635d86fc61cfbdf2306a76ddfc7",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "php": ">=5.3.0"
+                "php": ">=7.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+                "phpunit/phpunit": "^6 || ^7 || ^8 || ^9 || ^10"
             },
             "type": "library",
             "extra": {
@@ -12367,26 +12288,26 @@
             ],
             "support": {
                 "issues": "https://github.com/Masterminds/html5-php/issues",
-                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
+                "source": "https://github.com/Masterminds/html5-php/tree/2.11.0"
             },
-            "time": "2025-07-25T09:04:22+00:00"
+            "time": "2026-08-18T06:18:41+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.4",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.0"
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
@@ -12421,15 +12342,15 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.14.0"
             },
             "funding": [
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
                 }
             ],
-            "time": "2025-08-01T08:46:24+00:00"
+            "time": "2026-08-11T10:17:44+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -13091,24 +13012,24 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.29",
+            "version": "12.5.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9aa66a47db3ea70f1a468e66dd969f67e594945a"
+                "reference": "b98e028a26c5c5ba7e4a54be96ccf35f2914d184"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9aa66a47db3ea70f1a468e66dd969f67e594945a",
-                "reference": "9aa66a47db3ea70f1a468e66dd969f67e594945a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b98e028a26c5c5ba7e4a54be96ccf35f2914d184",
+                "reference": "b98e028a26c5c5ba7e4a54be96ccf35f2914d184",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
@@ -13169,7 +13090,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.29"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.33"
             },
             "funding": [
                 {
@@ -13177,7 +13098,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-06-04T06:14:42+00:00"
+            "time": "2026-07-28T13:58:09+00:00"
         },
         {
             "name": "react/cache",
@@ -13707,16 +13628,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.6.2",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "03cd615cdd5648abb5f10ff3a684fdb976687190"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/03cd615cdd5648abb5f10ff3a684fdb976687190",
-                "reference": "03cd615cdd5648abb5f10ff3a684fdb976687190",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
@@ -13755,7 +13676,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.6.2"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -13763,7 +13684,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-12T06:23:05+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -14728,16 +14649,16 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "41850d8f8ddef9a9cd7314fa9f4902cf48885521"
+                "reference": "bb28e8761a6c33975972948010f00d4a10f0a634"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/41850d8f8ddef9a9cd7314fa9f4902cf48885521",
-                "reference": "41850d8f8ddef9a9cd7314fa9f4902cf48885521",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/bb28e8761a6c33975972948010f00d4a10f0a634",
+                "reference": "bb28e8761a6c33975972948010f00d4a10f0a634",
                 "shasum": ""
             },
             "require": {
@@ -14777,7 +14698,7 @@
             "description": "Simulates the behavior of a web browser, allowing you to make requests, click on links and submit forms programmatically",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/browser-kit/tree/v7.4.8"
+                "source": "https://github.com/symfony/browser-kit/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -14797,7 +14718,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-08T20:24:16+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -15096,7 +15017,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.3",
+        "php": ">=8.4",
         "ext-ctype": "*",
         "ext-iconv": "*"
     },

--- a/backend/config/reference.php
+++ b/backend/config/reference.php
@@ -31,7 +31,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * @psalm-type ImportsConfig = list<string|array{
  *     resource: string,
  *     type?: string|null,
- *     ignore_errors?: bool,
+ *     ignore_errors?: bool|'not_found',
  * }>
  * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|Param|null>|Param|null>
  * @psalm-type ArgumentsType = list<mixed>|array<string, mixed>
@@ -121,7 +121,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type ServicesConfig = array{
  *     _defaults?: DefaultsType,
- *     _instanceof?: InstanceofType,
+ *     _instanceof?: array<class-string, InstanceofType>,
  *     ...<string, DefinitionType|AliasType|PrototypeType|StackType|ArgumentsType|null>
  * }
  * @psalm-type ExtensionType = array<string, mixed>
@@ -421,6 +421,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         item_uri_template?: mixed,
  *         ...<string, mixed>
  *     },
+ *     ...<string, mixed>
  * }
  * @psalm-type DamaDoctrineTestConfig = array{
  *     enable_static_connection?: mixed, // Default: true
@@ -431,7 +432,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * @psalm-type DoctrineConfig = array{
  *     dbal?: array{
  *         default_connection?: scalar|Param|null,
- *         types?: array<string, string|array{ // Default: []
+ *         types?: array<string, Param|string|array{ // Default: []
  *             class?: scalar|Param|null,
  *             commented?: bool|Param, // Deprecated: The doctrine-bundle type commenting features were removed; the corresponding config parameter was deprecated in 2.0 and will be dropped in 3.0.
  *         }>,
@@ -456,7 +457,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
  *             sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
  *             server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *             default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *             default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connection.
  *             sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
  *             sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
  *             sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
@@ -507,7 +508,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
  *                 sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
  *                 server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connection.
  *                 sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
  *                 sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
  *                 sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
@@ -518,6 +519,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 use_savepoints?: bool|Param, // Use savepoints for nested transactions
  *                 instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
  *                 connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *                 ...<string, mixed>
  *             }>,
  *             replicas?: array<string, array{ // Default: []
  *                 url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
@@ -539,7 +541,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
  *                 sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
  *                 server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connection.
  *                 sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
  *                 sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
  *                 sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
@@ -550,8 +552,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 use_savepoints?: bool|Param, // Use savepoints for nested transactions
  *                 instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
  *                 connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *                 ...<string, mixed>
  *             }>,
+ *             ...<string, mixed>
  *         }>,
+ *         ...<string, mixed>
  *     },
  *     orm?: array{
  *         default_entity_manager?: scalar|Param|null,
@@ -566,17 +571,17 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             evict_cache?: bool|Param, // Set to true to fetch the entity from the database instead of using the cache, if any // Default: false
  *         },
  *         entity_managers?: array<string, array{ // Default: []
- *             query_cache_driver?: string|array{
+ *             query_cache_driver?: Param|string|array{
  *                 type?: scalar|Param|null, // Default: null
  *                 id?: scalar|Param|null,
  *                 pool?: scalar|Param|null,
  *             },
- *             metadata_cache_driver?: string|array{
+ *             metadata_cache_driver?: Param|string|array{
  *                 type?: scalar|Param|null, // Default: null
  *                 id?: scalar|Param|null,
  *                 pool?: scalar|Param|null,
  *             },
- *             result_cache_driver?: string|array{
+ *             result_cache_driver?: Param|string|array{
  *                 type?: scalar|Param|null, // Default: null
  *                 id?: scalar|Param|null,
  *                 pool?: scalar|Param|null,
@@ -590,6 +595,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                         }>,
  *                     }>,
  *                 }>,
+ *                 ...<string, mixed>
  *             },
  *             connection?: scalar|Param|null,
  *             class_metadata_factory_name?: scalar|Param|null, // Default: "Doctrine\\ORM\\Mapping\\ClassMetadataFactory"
@@ -605,7 +611,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             report_fields_where_declared?: bool|Param, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.16 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/10455. // Default: true
  *             validate_xml_mapping?: bool|Param, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.14. See https://github.com/doctrine/orm/pull/6728. // Default: false
  *             second_level_cache?: array{
- *                 region_cache_driver?: string|array{
+ *                 region_cache_driver?: Param|string|array{
  *                     type?: scalar|Param|null, // Default: null
  *                     id?: scalar|Param|null,
  *                     pool?: scalar|Param|null,
@@ -616,7 +622,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 enabled?: bool|Param, // Default: true
  *                 factory?: scalar|Param|null,
  *                 regions?: array<string, array{ // Default: []
- *                     cache_driver?: string|array{
+ *                     cache_driver?: Param|string|array{
  *                         type?: scalar|Param|null, // Default: null
  *                         id?: scalar|Param|null,
  *                         pool?: scalar|Param|null,
@@ -634,7 +640,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 }>,
  *             },
  *             hydrators?: array<string, scalar|Param|null>,
- *             mappings?: array<string, bool|string|array{ // Default: []
+ *             mappings?: array<string, Param|bool|string|array{ // Default: []
  *                 mapping?: scalar|Param|null, // Default: true
  *                 type?: scalar|Param|null,
  *                 dir?: scalar|Param|null,
@@ -647,14 +653,16 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 numeric_functions?: array<string, scalar|Param|null>,
  *                 datetime_functions?: array<string, scalar|Param|null>,
  *             },
- *             filters?: array<string, string|array{ // Default: []
+ *             filters?: array<string, Param|string|array{ // Default: []
  *                 class?: scalar|Param|null,
  *                 enabled?: bool|Param, // Default: false
  *                 parameters?: array<string, mixed>,
+ *                 ...<string, mixed>
  *             }>,
  *             identity_generation_preferences?: array<string, scalar|Param|null>,
  *         }>,
  *         resolve_target_entities?: array<string, scalar|Param|null>,
+ *         ...<string, mixed>
  *     },
  * }
  * @psalm-type DoctrineMigrationsConfig = array{
@@ -786,6 +794,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             get_options?: array<string, scalar|Param|null>,
  *             put_options?: array<string, scalar|Param|null>,
  *             proxies?: array<string, scalar|Param|null>,
+ *             ...<string, mixed>
  *         },
  *         flysystem?: array{
  *             filesystem_service?: scalar|Param|null,
@@ -801,7 +810,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         },
  *         filesystem?: array{
  *             locator?: "filesystem"|"filesystem_insecure"|Param, // Using the "filesystem_insecure" locator is not recommended due to a less secure resolver mechanism, but is provided for those using heavily symlinked projects. // Default: "filesystem"
- *             data_root?: string|list<scalar|Param|null>,
+ *             data_root?: Param|string|list<scalar|Param|null>,
  *             allow_unresolvable_data_roots?: bool|Param, // Default: false
  *             bundle_resources?: array{
  *                 enabled?: bool|Param, // Default: false
@@ -869,6 +878,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         data_loader?: scalar|Param|null, // Default: null
  *         post_processors?: array<string, array<string, mixed>>,
  *     },
+ *     ...<string, mixed>
  * }
  * @psalm-type NelmioCorsConfig = array{
  *     defaults?: array{
@@ -910,6 +920,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         hosts?: list<scalar|Param|null>,
  *         paths?: array<string, array{ // Default: {"^/.*":{"header":"DENY"}}
  *             header?: scalar|Param|null, // Default: "DENY"
+ *             ...<string, mixed>
  *         }>,
  *         content_types?: list<scalar|Param|null>,
  *     },
@@ -987,7 +998,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             script-src?: list<scalar|Param|null>,
  *             style-src?: list<scalar|Param|null>,
  *             upgrade-insecure-requests?: bool|Param, // Default: false
- *             report-uri?: string|list<scalar|Param|null>,
+ *             report-uri?: Param|string|list<scalar|Param|null>,
  *             worker-src?: list<scalar|Param|null>,
  *             prefetch-src?: list<scalar|Param|null>,
  *             report-to?: scalar|Param|null,
@@ -1015,7 +1026,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             script-src?: list<scalar|Param|null>,
  *             style-src?: list<scalar|Param|null>,
  *             upgrade-insecure-requests?: bool|Param, // Default: false
- *             report-uri?: string|list<scalar|Param|null>,
+ *             report-uri?: Param|string|list<scalar|Param|null>,
  *             worker-src?: list<scalar|Param|null>,
  *             prefetch-src?: list<scalar|Param|null>,
  *             report-to?: scalar|Param|null,
@@ -1023,7 +1034,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     referrer_policy?: bool|array{
  *         enabled?: bool|Param, // Default: false
- *         policies?: string|list<scalar|Param|null>,
+ *         policies?: Param|string|list<scalar|Param|null>,
  *     },
  *     permissions_policy?: bool|array{
  *         enabled?: bool|Param, // Default: false
@@ -1094,9 +1105,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     set_locale_from_accept_language?: bool|Param, // Whether to use the Accept-Language HTTP header to set the Request locale (only when the "_locale" request attribute is not passed). // Default: false
  *     set_content_language_from_locale?: bool|Param, // Whether to set the Content-Language HTTP header on the Response using the Request locale. // Default: false
  *     enabled_locales?: list<scalar|Param|null>,
- *     trusted_hosts?: string|list<scalar|Param|null>,
+ *     trusted_hosts?: Param|string|list<scalar|Param|null>,
  *     trusted_proxies?: mixed, // Default: ["%env(default::SYMFONY_TRUSTED_PROXIES)%"]
- *     trusted_headers?: string|list<scalar|Param|null>,
+ *     trusted_headers?: Param|string|list<scalar|Param|null>,
  *     error_controller?: scalar|Param|null, // Default: "error_controller"
  *     handle_all_throwables?: bool|Param, // HttpKernel will handle all kinds of \Throwable. // Default: true
  *     csrf_protection?: bool|array{
@@ -1160,23 +1171,23 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 property?: scalar|Param|null,
  *                 service?: scalar|Param|null,
  *             },
- *             supports?: string|list<scalar|Param|null>,
+ *             supports?: Param|string|list<scalar|Param|null>,
  *             definition_validators?: list<scalar|Param|null>,
  *             support_strategy?: scalar|Param|null,
- *             initial_marking?: \BackedEnum|string|list<scalar|Param|null>,
+ *             initial_marking?: \BackedEnum|Param|string|list<scalar|Param|null>,
  *             events_to_dispatch?: null|list<string|Param>,
- *             places?: string|list<array{ // Default: []
+ *             places?: Param|string|list<array{ // Default: []
  *                 name?: scalar|Param|null,
  *                 metadata?: array<string, mixed>,
  *             }>,
  *             transitions?: list<array{ // Default: []
  *                 name?: string|Param,
  *                 guard?: string|Param, // An expression to block the transition.
- *                 from?: \BackedEnum|string|list<array{ // Default: []
+ *                 from?: \BackedEnum|Param|string|list<array{ // Default: []
  *                     place?: string|Param,
  *                     weight?: int|Param, // Default: 1
  *                 }>,
- *                 to?: \BackedEnum|string|list<array{ // Default: []
+ *                 to?: \BackedEnum|Param|string|list<array{ // Default: []
  *                     place?: string|Param,
  *                     weight?: int|Param, // Default: 1
  *                 }>,
@@ -1219,7 +1230,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     request?: bool|array{ // Request configuration
  *         enabled?: bool|Param, // Default: false
- *         formats?: array<string, string|list<scalar|Param|null>>,
+ *         formats?: array<string, Param|string|list<scalar|Param|null>>,
  *     },
  *     assets?: bool|array{ // Assets configuration
  *         enabled?: bool|Param, // Default: true
@@ -1229,7 +1240,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         version_format?: scalar|Param|null, // Default: "%%s?%%s"
  *         json_manifest_path?: scalar|Param|null, // Default: null
  *         base_path?: scalar|Param|null, // Default: ""
- *         base_urls?: string|list<scalar|Param|null>,
+ *         base_urls?: Param|string|list<scalar|Param|null>,
  *         packages?: array<string, array{ // Default: []
  *             strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
  *             version_strategy?: scalar|Param|null, // Default: null
@@ -1237,12 +1248,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             version_format?: scalar|Param|null, // Default: null
  *             json_manifest_path?: scalar|Param|null, // Default: null
  *             base_path?: scalar|Param|null, // Default: ""
- *             base_urls?: string|list<scalar|Param|null>,
+ *             base_urls?: Param|string|list<scalar|Param|null>,
  *         }>,
  *     },
  *     asset_mapper?: bool|array{ // Asset Mapper configuration
  *         enabled?: bool|Param, // Default: false
- *         paths?: string|array<string, scalar|Param|null>,
+ *         paths?: Param|string|array<string, scalar|Param|null>,
  *         excluded_patterns?: list<scalar|Param|null>,
  *         exclude_dotfiles?: bool|Param, // If true, any files starting with "." will be excluded from the asset mapper. // Default: true
  *         server?: bool|Param, // If true, a "dev server" will return the assets from the public directory (true in "debug" mode only by default). // Default: true
@@ -1261,7 +1272,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     translator?: bool|array{ // Translator configuration
  *         enabled?: bool|Param, // Default: true
- *         fallbacks?: string|list<scalar|Param|null>,
+ *         fallbacks?: Param|string|list<scalar|Param|null>,
  *         logging?: bool|Param, // Default: false
  *         formatter?: scalar|Param|null, // Default: "translator.formatter.default"
  *         cache_dir?: scalar|Param|null, // Default: "%kernel.cache_dir%/translations"
@@ -1280,7 +1291,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             domains?: list<scalar|Param|null>,
  *             locales?: list<scalar|Param|null>,
  *         }>,
- *         globals?: array<string, string|array{ // Default: []
+ *         globals?: array<string, Param|string|array{ // Default: []
  *             value?: mixed,
  *             message?: string|Param,
  *             parameters?: array<string, scalar|Param|null>,
@@ -1291,7 +1302,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         enabled?: bool|Param, // Default: true
  *         cache?: scalar|Param|null, // Deprecated: Setting the "framework.validation.cache.cache" configuration option is deprecated. It will be removed in version 8.0.
  *         enable_attributes?: bool|Param, // Default: true
- *         static_method?: string|list<scalar|Param|null>,
+ *         static_method?: Param|string|list<scalar|Param|null>,
  *         translation_domain?: scalar|Param|null, // Default: "validators"
  *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|"loose"|Param, // Default: "html5"
  *         mapping?: array{
@@ -1354,7 +1365,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         default_doctrine_dbal_provider?: scalar|Param|null, // Default: "database_connection"
  *         default_pdo_provider?: scalar|Param|null, // Default: null
  *         pools?: array<string, array{ // Default: []
- *             adapters?: string|list<scalar|Param|null>,
+ *             adapters?: Param|string|list<scalar|Param|null>,
  *             tags?: scalar|Param|null, // Default: null
  *             public?: bool|Param, // Default: false
  *             default_lifetime?: scalar|Param|null, // Default lifetime of the pool.
@@ -1375,17 +1386,17 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     web_link?: bool|array{ // Web links configuration
  *         enabled?: bool|Param, // Default: true
  *     },
- *     lock?: bool|string|array{ // Lock configuration
+ *     lock?: Param|bool|string|array{ // Lock configuration
  *         enabled?: bool|Param, // Default: false
- *         resources?: string|array<string, string|list<scalar|Param|null>>,
+ *         resources?: Param|string|array<string, Param|string|list<scalar|Param|null>>,
  *     },
- *     semaphore?: bool|string|array{ // Semaphore configuration
+ *     semaphore?: Param|bool|string|array{ // Semaphore configuration
  *         enabled?: bool|Param, // Default: false
- *         resources?: string|array<string, scalar|Param|null>,
+ *         resources?: Param|string|array<string, scalar|Param|null>,
  *     },
  *     messenger?: bool|array{ // Messenger configuration
  *         enabled?: bool|Param, // Default: true
- *         routing?: array<string, string|array{ // Default: []
+ *         routing?: array<string, Param|string|array{ // Default: []
  *             senders?: list<scalar|Param|null>,
  *         }>,
  *         serializer?: array{
@@ -1395,12 +1406,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 context?: array<string, mixed>,
  *             },
  *         },
- *         transports?: array<string, string|array{ // Default: []
+ *         transports?: array<string, Param|string|array{ // Default: []
  *             dsn?: scalar|Param|null,
  *             serializer?: scalar|Param|null, // Service id of a custom serializer to use. // Default: null
  *             options?: array<string, mixed>,
  *             failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
- *             retry_strategy?: string|array{
+ *             retry_strategy?: Param|string|array{
  *                 service?: scalar|Param|null, // Service id to override the retry strategy entirely. // Default: null
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
@@ -1411,15 +1422,15 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             rate_limiter?: scalar|Param|null, // Rate limiter name to use when processing messages. // Default: null
  *         }>,
  *         failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
- *         stop_worker_on_signals?: int|string|list<scalar|Param|null>,
+ *         stop_worker_on_signals?: Param|int|string|list<scalar|Param|null>,
  *         default_bus?: scalar|Param|null, // Default: null
  *         buses?: array<string, array{ // Default: {"messenger.bus.default":{"default_middleware":{"enabled":true,"allow_no_handlers":false,"allow_no_senders":true},"middleware":[]}}
- *             default_middleware?: bool|string|array{
+ *             default_middleware?: Param|bool|string|array{
  *                 enabled?: bool|Param, // Default: true
  *                 allow_no_handlers?: bool|Param, // Default: false
  *                 allow_no_senders?: bool|Param, // Default: true
  *             },
- *             middleware?: string|list<string|array{ // Default: []
+ *             middleware?: Param|string|list<Param|string|array{ // Default: []
  *                 id?: scalar|Param|null,
  *                 arguments?: list<mixed>,
  *             }>,
@@ -1468,9 +1479,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
  *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
- *                 http_codes?: int|string|array<string, array{ // Default: []
+ *                 http_codes?: Param|int|string|array<string, array{ // Default: []
  *                     code?: int|Param,
- *                     methods?: string|list<string|Param>,
+ *                     methods?: Param|string|list<string|Param>,
  *                 }>,
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
@@ -1480,7 +1491,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             },
  *         },
  *         mock_response_factory?: scalar|Param|null, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
- *         scoped_clients?: array<string, string|array{ // Default: []
+ *         scoped_clients?: array<string, Param|string|array{ // Default: []
  *             scope?: scalar|Param|null, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
  *             base_uri?: scalar|Param|null, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
  *             auth_basic?: scalar|Param|null, // An HTTP Basic authentication "username:password".
@@ -1521,9 +1532,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
  *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
- *                 http_codes?: int|string|array<string, array{ // Default: []
+ *                 http_codes?: Param|int|string|array<string, array{ // Default: []
  *                     code?: int|Param,
- *                     methods?: string|list<string|Param>,
+ *                     methods?: Param|string|list<string|Param>,
  *                 }>,
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
@@ -1540,10 +1551,10 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         transports?: array<string, scalar|Param|null>,
  *         envelope?: array{ // Mailer Envelope configuration
  *             sender?: scalar|Param|null,
- *             recipients?: string|list<scalar|Param|null>,
- *             allowed_recipients?: string|list<scalar|Param|null>,
+ *             recipients?: Param|string|list<scalar|Param|null>,
+ *             allowed_recipients?: Param|string|list<scalar|Param|null>,
  *         },
- *         headers?: array<string, string|array{ // Default: []
+ *         headers?: array<string, Param|string|array{ // Default: []
  *             value?: mixed,
  *         }>,
  *         dkim_signer?: bool|array{ // DKIM signer configuration
@@ -1580,7 +1591,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         chatter_transports?: array<string, scalar|Param|null>,
  *         texter_transports?: array<string, scalar|Param|null>,
  *         notification_on_failed_messages?: bool|Param, // Default: false
- *         channel_policy?: array<string, string|list<scalar|Param|null>>,
+ *         channel_policy?: array<string, Param|string|list<scalar|Param|null>>,
  *         admin_recipients?: list<array{ // Default: []
  *             email?: scalar|Param|null,
  *             phone?: scalar|Param|null, // Default: ""
@@ -1593,7 +1604,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             cache_pool?: scalar|Param|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
  *             storage_service?: scalar|Param|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
  *             policy?: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
- *             limiters?: string|list<scalar|Param|null>,
+ *             limiters?: Param|string|list<scalar|Param|null>,
  *             limit?: int|Param, // The maximum allowed hits in a fixed interval or burst.
  *             interval?: scalar|Param|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
  *             rate?: array{ // Configures the fill rate if "policy" is set to "token_bucket".
@@ -1616,20 +1627,20 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             allow_safe_elements?: bool|Param, // Allows "safe" elements and attributes. // Default: false
  *             allow_static_elements?: bool|Param, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
  *             allow_elements?: array<string, mixed>,
- *             block_elements?: string|list<string|Param>,
- *             drop_elements?: string|list<string|Param>,
+ *             block_elements?: Param|string|list<string|Param>,
+ *             drop_elements?: Param|string|list<string|Param>,
  *             allow_attributes?: array<string, mixed>,
  *             drop_attributes?: array<string, mixed>,
  *             force_attributes?: array<string, array<string, string|Param>>,
  *             force_https_urls?: bool|Param, // Transforms URLs using the HTTP scheme to use the HTTPS scheme instead. // Default: false
- *             allowed_link_schemes?: string|list<string|Param>,
- *             allowed_link_hosts?: null|string|list<string|Param>,
+ *             allowed_link_schemes?: Param|string|list<string|Param>,
+ *             allowed_link_hosts?: Param|null|string|list<string|Param>,
  *             allow_relative_links?: bool|Param, // Allows relative URLs to be used in links href attributes. // Default: false
- *             allowed_media_schemes?: string|list<string|Param>,
- *             allowed_media_hosts?: null|string|list<string|Param>,
+ *             allowed_media_schemes?: Param|string|list<string|Param>,
+ *             allowed_media_hosts?: Param|null|string|list<string|Param>,
  *             allow_relative_medias?: bool|Param, // Allows relative URLs to be used in media source attributes (img, audio, video, ...). // Default: false
- *             with_attribute_sanitizers?: string|list<string|Param>,
- *             without_attribute_sanitizers?: string|list<string|Param>,
+ *             with_attribute_sanitizers?: Param|string|list<string|Param>,
+ *             without_attribute_sanitizers?: Param|string|list<string|Param>,
  *             max_input_length?: int|Param, // The maximum length allowed for the sanitized input. // Default: 0
  *         }>,
  *     },
@@ -1666,9 +1677,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         allow_if_all_abstain?: bool|Param, // Default: false
  *         allow_if_equal_granted_denied?: bool|Param, // Default: true
  *     },
- *     password_hashers?: array<string, string|array{ // Default: []
+ *     password_hashers?: array<string, Param|string|array{ // Default: []
  *         algorithm?: scalar|Param|null,
- *         migrate_from?: string|list<scalar|Param|null>,
+ *         migrate_from?: Param|string|list<scalar|Param|null>,
  *         hash_algorithm?: scalar|Param|null, // Name of hashing algorithm for PBKDF2 (i.e. sha256, sha512, etc..) See hash_algos() for a list of supported algorithms. // Default: "sha512"
  *         key_length?: scalar|Param|null, // Default: 40
  *         ignore_case?: bool|Param, // Default: false
@@ -1682,7 +1693,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     providers?: array<string, array{ // Default: []
  *         id?: scalar|Param|null,
  *         chain?: array{
- *             providers?: string|list<scalar|Param|null>,
+ *             providers?: Param|string|list<scalar|Param|null>,
  *         },
  *         entity?: array{
  *             class?: scalar|Param|null, // The full entity class name of your user class.
@@ -1695,7 +1706,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         memory?: array{
  *             users?: array<string, array{ // Default: []
  *                 password?: scalar|Param|null, // Default: null
- *                 roles?: string|list<scalar|Param|null>,
+ *                 roles?: Param|string|list<scalar|Param|null>,
  *             }>,
  *         },
  *         ldap?: array{
@@ -1704,7 +1715,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             search_dn?: scalar|Param|null, // Default: null
  *             search_password?: scalar|Param|null, // Default: null
  *             extra_fields?: list<scalar|Param|null>,
- *             default_roles?: string|list<scalar|Param|null>,
+ *             default_roles?: Param|string|list<scalar|Param|null>,
  *             role_fetcher?: scalar|Param|null, // Default: null
  *             uid_key?: scalar|Param|null, // Default: "sAMAccountName"
  *             filter?: scalar|Param|null, // Default: "({uid_key}={user_identifier})"
@@ -1714,7 +1725,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     firewalls?: array<string, array{ // Default: []
  *         pattern?: scalar|Param|null,
  *         host?: scalar|Param|null,
- *         methods?: string|list<scalar|Param|null>,
+ *         methods?: Param|string|list<scalar|Param|null>,
  *         security?: bool|Param, // Default: true
  *         user_checker?: scalar|Param|null, // The UserChecker to use when authenticating users in this firewall. // Default: "security.user_checker"
  *         request_matcher?: scalar|Param|null,
@@ -1733,8 +1744,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             path?: scalar|Param|null, // Default: "/logout"
  *             target?: scalar|Param|null, // Default: "/"
  *             invalidate_session?: bool|Param, // Default: true
- *             clear_site_data?: string|list<"*"|"cache"|"cookies"|"storage"|"executionContexts"|Param>,
- *             delete_cookies?: string|array<string, array{ // Default: []
+ *             clear_site_data?: Param|string|list<"*"|"cache"|"cookies"|"storage"|"executionContexts"|Param>,
+ *             delete_cookies?: Param|string|array<string, array{ // Default: []
  *                 path?: scalar|Param|null, // Default: null
  *                 domain?: scalar|Param|null, // Default: null
  *                 secure?: scalar|Param|null, // Default: false
@@ -1876,10 +1887,10 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             success_handler?: scalar|Param|null,
  *             failure_handler?: scalar|Param|null,
  *             realm?: scalar|Param|null, // Default: null
- *             token_extractors?: string|list<scalar|Param|null>,
- *             token_handler?: string|array{
+ *             token_extractors?: Param|string|list<scalar|Param|null>,
+ *             token_handler?: Param|string|array{
  *                 id?: scalar|Param|null,
- *                 oidc_user_info?: string|array{
+ *                 oidc_user_info?: Param|string|array{
  *                     base_uri?: scalar|Param|null, // Base URI of the userinfo endpoint on the OIDC server, or the OIDC server URI to use the discovery (require "discovery" to be configured).
  *                     discovery?: array{ // Enable the OIDC discovery.
  *                         cache?: array{
@@ -1891,7 +1902,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 },
  *                 oidc?: array{
  *                     discovery?: array{ // Enable the OIDC discovery.
- *                         base_uri?: string|list<scalar|Param|null>,
+ *                         base_uri?: Param|string|list<scalar|Param|null>,
  *                         cache?: array{
  *                             id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
  *                         },
@@ -1934,10 +1945,10 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         remember_me?: array{
  *             secret?: scalar|Param|null, // Default: "%kernel.secret%"
  *             service?: scalar|Param|null,
- *             user_providers?: string|list<scalar|Param|null>,
+ *             user_providers?: Param|string|list<scalar|Param|null>,
  *             catch_exceptions?: bool|Param, // Default: true
  *             signature_properties?: list<scalar|Param|null>,
- *             token_provider?: string|array{
+ *             token_provider?: Param|string|array{
  *                 service?: scalar|Param|null, // The service ID of a custom remember-me token provider.
  *                 doctrine?: bool|array{
  *                     enabled?: bool|Param, // Default: false
@@ -1962,14 +1973,14 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         path?: scalar|Param|null, // Use the urldecoded format. // Default: null
  *         host?: scalar|Param|null, // Default: null
  *         port?: int|Param, // Default: null
- *         ips?: string|list<scalar|Param|null>,
+ *         ips?: Param|string|list<scalar|Param|null>,
  *         attributes?: array<string, scalar|Param|null>,
  *         route?: scalar|Param|null, // Default: null
- *         methods?: string|list<scalar|Param|null>,
+ *         methods?: Param|string|list<scalar|Param|null>,
  *         allow_if?: scalar|Param|null, // Default: null
- *         roles?: string|list<scalar|Param|null>,
+ *         roles?: Param|string|list<scalar|Param|null>,
  *     }>,
- *     role_hierarchy?: array<string, string|list<scalar|Param|null>>,
+ *     role_hierarchy?: array<string, Param|string|list<scalar|Param|null>>,
  * }
  * @psalm-type VichUploaderConfig = array{
  *     default_filename_attribute_suffix?: scalar|Param|null, // Default: "_name"
@@ -1993,11 +2004,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     mappings?: array<string, array{ // Default: []
  *         uri_prefix?: scalar|Param|null, // Default: "/uploads"
  *         upload_destination?: scalar|Param|null, // Default: null
- *         namer?: string|array{
+ *         namer?: Param|string|array{
  *             service?: scalar|Param|null, // Default: null
  *             options?: mixed, // Default: null
  *         },
- *         directory_namer?: string|array{
+ *         directory_namer?: Param|string|array{
  *             service?: scalar|Param|null, // Default: null
  *             options?: mixed, // Default: null
  *         },
@@ -2026,6 +2037,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             enabled?: bool|Param|null, // Default: null
  *             date_format?: scalar|Param|null,
  *             remove_used_context_fields?: bool|Param,
+ *             ...<string, mixed>
  *         },
  *         path?: scalar|Param|null, // Default: "%kernel.logs_dir%/%kernel.environment%.log"
  *         file_permission?: scalar|Param|null, // Default: null
@@ -2086,18 +2098,18 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         delay_between_messages?: bool|Param, // Default: false
  *         topic?: int|Param, // Default: null
  *         factor?: int|Param, // Default: 1
- *         tags?: string|list<scalar|Param|null>,
+ *         tags?: Param|string|list<scalar|Param|null>,
  *         console_formatter_options?: mixed, // Default: []
  *         formatter?: scalar|Param|null,
  *         nested?: bool|Param, // Default: false
- *         publisher?: string|array{
+ *         publisher?: Param|string|array{
  *             id?: scalar|Param|null,
  *             hostname?: scalar|Param|null,
  *             port?: scalar|Param|null, // Default: 12201
  *             chunk_size?: scalar|Param|null, // Default: 1420
  *             encoder?: "json"|"compressed_json"|Param,
  *         },
- *         mongodb?: string|array{
+ *         mongodb?: Param|string|array{
  *             id?: scalar|Param|null, // ID of a MongoDB\Client service
  *             uri?: scalar|Param|null,
  *             username?: scalar|Param|null,
@@ -2105,7 +2117,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             database?: scalar|Param|null, // Default: "monolog"
  *             collection?: scalar|Param|null, // Default: "logs"
  *         },
- *         elasticsearch?: string|array{
+ *         elasticsearch?: Param|string|array{
  *             id?: scalar|Param|null,
  *             hosts?: list<scalar|Param|null>,
  *             host?: scalar|Param|null,
@@ -2117,7 +2129,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         index?: scalar|Param|null, // Default: "monolog"
  *         document_type?: scalar|Param|null, // Default: "logs"
  *         ignore_error?: scalar|Param|null, // Default: false
- *         redis?: string|array{
+ *         redis?: Param|string|array{
  *             id?: scalar|Param|null,
  *             host?: scalar|Param|null,
  *             password?: scalar|Param|null, // Default: null
@@ -2125,17 +2137,17 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             database?: scalar|Param|null, // Default: 0
  *             key_name?: scalar|Param|null, // Default: "monolog_redis"
  *         },
- *         predis?: string|array{
+ *         predis?: Param|string|array{
  *             id?: scalar|Param|null,
  *             host?: scalar|Param|null,
  *         },
  *         from_email?: scalar|Param|null,
- *         to_email?: string|list<scalar|Param|null>,
+ *         to_email?: Param|string|list<scalar|Param|null>,
  *         subject?: scalar|Param|null,
  *         content_type?: scalar|Param|null, // Default: null
  *         headers?: list<scalar|Param|null>,
  *         mailer?: scalar|Param|null, // Default: null
- *         email_prototype?: string|array{
+ *         email_prototype?: Param|string|array{
  *             id?: scalar|Param|null,
  *             method?: scalar|Param|null, // Default: null
  *         },
@@ -2146,9 +2158,10 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             VERBOSITY_VERY_VERBOSE?: scalar|Param|null, // Default: "INFO"
  *             VERBOSITY_DEBUG?: scalar|Param|null, // Default: "DEBUG"
  *         },
- *         channels?: string|array{
+ *         channels?: Param|string|array{
  *             type?: scalar|Param|null,
  *             elements?: list<scalar|Param|null>,
+ *             ...<string, mixed>
  *         },
  *     }>,
  * }

--- a/backend/rector.php
+++ b/backend/rector.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
-use Rector\Symfony\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\InlineClassRoutePrefixRector;
 use Rector\Symfony\Set\SymfonySetList;
 
@@ -21,6 +19,7 @@ use Rector\Symfony\Set\SymfonySetList;
  * - Sur un fichier spécifique :      ddev exec vendor/bin/rector process src/MonFichier.php
  */
 return RectorConfig::configure()
+    ->withoutParallel()
     ->withPaths([
         __DIR__.'/src',
         __DIR__.'/tests',
@@ -32,25 +31,18 @@ return RectorConfig::configure()
         // DataFixtures : patterns spécifiques acceptables
         __DIR__.'/src/DataFixtures',
 
-        // #[Override] ajoute du bruit visuel sans valeur significative
-        AddOverrideAttributeToOverriddenMethodsRector::class,
-
-        // L'injection par action (autowiring dans les paramètres de méthode)
-        // est un pattern Symfony valide et souvent préférable pour les contrôleurs
-        ControllerMethodInjectionToConstructorRector::class,
-
         // Conserver les préfixes de route sur la classe pour la lisibilité
         InlineClassRoutePrefixRector::class,
     ])
-    ->withPhpSets(php83: true)
+    ->withPhpSets(php84: true)
     ->withPreparedSets(
         deadCode: true,
         codeQuality: true,
         typeDeclarations: true,
     )
     ->withSets([
-        SymfonySetList::SYMFONY_74,
         SymfonySetList::SYMFONY_CODE_QUALITY,
+        SymfonySetList::COMPOSER_BASED,
         // Note : SYMFONY_CONSTRUCTOR_INJECTION volontairement omis
         // L'injection par action (autowiring dans les paramètres) est un pattern
         // valide en Symfony et souvent préférable pour les contrôleurs légers.

--- a/backend/src/Command/AutoEnrichCommand.php
+++ b/backend/src/Command/AutoEnrichCommand.php
@@ -9,6 +9,7 @@ use App\Enum\EnrichmentConfidence;
 use App\Enum\LookupMode;
 use App\Repository\ComicSeriesRepository;
 use App\Service\Enrichment\EnrichmentService;
+use App\Service\Lookup\Contract\LookupResult;
 use App\Service\Lookup\LookupOrchestrator;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
@@ -120,7 +121,7 @@ final class AutoEnrichCommand extends Command
                     $series->getType(),
                 );
 
-                if (null === $result) {
+                if (!$result instanceof LookupResult) {
                     $io->text(\sprintf('[%d/%d] %s — aucun résultat', $processed, \count($seriesList), $series->getTitle()));
                     ++$skipped;
 

--- a/backend/src/Command/RunDeployTasksCommand.php
+++ b/backend/src/Command/RunDeployTasksCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 final class RunDeployTasksCommand extends Command
 {
     public function __construct(
-        #[Autowire('%kernel.project_dir%')] private readonly string $projectDir,
+        #[Autowire(param: 'kernel.project_dir')] private readonly string $projectDir,
     ) {
         parent::__construct();
     }
@@ -67,7 +67,7 @@ final class RunDeployTasksCommand extends Command
 
         $io->table(['Tâche', 'Description', 'Statut'], $rows);
 
-        $pending = \array_filter($tasks, static fn (array $t) => !\in_array($t['shortName'], $executed, true));
+        $pending = \array_filter($tasks, static fn (array $t): bool => !\in_array($t['shortName'], $executed, true));
 
         if ([] === $pending) {
             $io->success('Aucune tâche de déploiement en attente.');

--- a/backend/src/Controller/DevLoginController.php
+++ b/backend/src/Controller/DevLoginController.php
@@ -26,15 +26,15 @@ use Symfony\Component\Routing\Attribute\Route;
 final readonly class DevLoginController
 {
     public function __construct(
-        #[Autowire('%env(OAUTH_ALLOWED_EMAIL)%')]
+        #[Autowire(env: 'OAUTH_ALLOWED_EMAIL')]
         private string $allowedEmail,
         #[Autowire('%env(bool:APP_DEBUG_LOGIN)%')]
         private bool $enabled,
-        #[Autowire('%env(APP_DEBUG_LOGIN_PASSWORD)%')]
+        #[Autowire(env: 'APP_DEBUG_LOGIN_PASSWORD')]
         private string $debugPassword,
-        #[Autowire('%env(APP_DEBUG_LOGIN_USER)%')]
+        #[Autowire(env: 'APP_DEBUG_LOGIN_USER')]
         private string $debugUser,
-        #[Autowire('%kernel.environment%')]
+        #[Autowire(param: 'kernel.environment')]
         private string $environment,
         private JWTTokenManagerInterface $jwtManager,
         private LoggerInterface $logger,

--- a/backend/src/Controller/GoogleLoginController.php
+++ b/backend/src/Controller/GoogleLoginController.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 final readonly class GoogleLoginController
 {
     public function __construct(
-        #[Autowire('%env(OAUTH_ALLOWED_EMAIL)%')]
+        #[Autowire(env: 'OAUTH_ALLOWED_EMAIL')]
         private string $allowedEmail,
         private EntityManagerInterface $entityManager,
         private GoogleClient $googleClient,

--- a/backend/src/Controller/NotificationController.php
+++ b/backend/src/Controller/NotificationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Entity\User;
 use App\Repository\NotificationRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
@@ -26,7 +27,7 @@ final class NotificationController
         #[CurrentUser] UserInterface $user,
         NotificationRepository $notificationRepository,
     ): JsonResponse {
-        /** @var \App\Entity\User $user */
+        /** @var User $user */
         $count = $notificationRepository->countUnread($user);
 
         return new JsonResponse(['count' => $count]);
@@ -40,7 +41,7 @@ final class NotificationController
         #[CurrentUser] UserInterface $user,
         NotificationRepository $notificationRepository,
     ): JsonResponse {
-        /** @var \App\Entity\User $user */
+        /** @var User $user */
         $updated = $notificationRepository->markAllRead($user);
 
         return new JsonResponse(['updated' => $updated]);

--- a/backend/src/Controller/ShareController.php
+++ b/backend/src/Controller/ShareController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Service\Lookup\Contract\LookupResult;
 use App\Service\Share\ShareResolver;
 use App\Service\Share\ShareUrlParser;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -51,7 +52,7 @@ final readonly class ShareController
             return new JsonResponse(['matched' => true, 'seriesId' => $resolution->seriesId]);
         }
 
-        if (null !== $resolution->lookupResult) {
+        if ($resolution->lookupResult instanceof LookupResult) {
             return new JsonResponse(['matched' => false, 'lookupResult' => $resolution->lookupResult->jsonSerialize()]);
         }
 

--- a/backend/src/DeployTask/AbstractDeployTask.php
+++ b/backend/src/DeployTask/AbstractDeployTask.php
@@ -26,14 +26,7 @@ abstract class AbstractDeployTask implements DeployTaskInterface
      */
     protected function runConsole(string $command, array $arguments, SymfonyStyle $io): void
     {
-        $allowed = false;
-        foreach (self::ALLOWED_CONSOLE_PREFIXES as $prefix) {
-            if (\str_starts_with($command, $prefix)) {
-                $allowed = true;
-                break;
-            }
-        }
-
+        $allowed = \array_any(self::ALLOWED_CONSOLE_PREFIXES, static fn (string $prefix): bool => \str_starts_with($command, $prefix));
         if (!$allowed) {
             throw new \InvalidArgumentException(\sprintf('Commande console non autorisée : %s', $command));
         }

--- a/backend/src/Entity/ComicSeries.php
+++ b/backend/src/Entity/ComicSeries.php
@@ -908,6 +908,28 @@ class ComicSeries implements SoftDeletableInterface
     }
 
     /**
+     * Indique si tous les tomes parus sont possédés.
+     */
+    #[ApiProperty]
+    #[Groups(['comic:list'])]
+    public function isComplete(): bool
+    {
+        return $this->isOneShot || $this->latestPublishedIssueComplete || $this->isIssueComplete($this->getMaxTomeNumber());
+    }
+
+    /**
+     * Pourcentage de tomes lus (0 à 100).
+     */
+    #[ApiProperty]
+    #[Groups(['comic:list'])]
+    public function getReadPercent(): float
+    {
+        $total = $this->getCoveredCount();
+
+        return 0 === $total ? 0.0 : \round(($this->getReadCount() / $total) * 100, 1);
+    }
+
+    /**
      * Retourne le numéro maximum des tomes, optionnellement filtrés.
      *
      * @param \Closure(Tome, int):bool|null $filter Filtre optionnel à appliquer

--- a/backend/src/Entity/EnrichmentProposal.php
+++ b/backend/src/Entity/EnrichmentProposal.php
@@ -53,26 +53,9 @@ use Symfony\Component\Serializer\Attribute\Groups;
 )]
 class EnrichmentProposal
 {
-    #[ORM\ManyToOne(targetEntity: ComicSeries::class)]
-    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
-    #[Groups(['enrichment:read'])]
-    private ComicSeries $comicSeries;
-
-    #[ORM\Column(type: Types::STRING, enumType: EnrichmentConfidence::class)]
-    #[Groups(['enrichment:read'])]
-    private EnrichmentConfidence $confidence;
-
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
     #[Groups(['enrichment:read'])]
     private \DateTimeImmutable $createdAt;
-
-    #[ORM\Column(type: Types::JSON, nullable: true)]
-    #[Groups(['enrichment:read'])]
-    private mixed $currentValue = null;
-
-    #[ORM\Column(type: Types::STRING, enumType: EnrichableField::class)]
-    #[Groups(['enrichment:read'])]
-    private EnrichableField $field;
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -80,44 +63,40 @@ class EnrichmentProposal
     #[Groups(['enrichment:read'])]
     private ?int $id = null;
 
-    #[ORM\Column(type: Types::JSON)]
-    #[Groups(['enrichment:read'])]
-    private mixed $proposedValue = null;
-
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
     #[Groups(['enrichment:read'])]
     private ?\DateTimeImmutable $reviewedAt = null;
-
-    #[ORM\Column(length: 100)]
-    #[Groups(['enrichment:read'])]
-    private string $source;
 
     #[ORM\Column(type: Types::STRING, enumType: ProposalStatus::class)]
     #[Groups(['enrichment:read'])]
     private ProposalStatus $status;
 
-    #[ORM\Column(length: 100, nullable: true)]
-    #[Groups(['enrichment:read'])]
-    private ?string $triggeredBy = null;
-
     public function __construct(
-        ComicSeries $comicSeries,
-        EnrichmentConfidence $confidence,
-        mixed $currentValue,
-        EnrichableField $field,
-        mixed $proposedValue,
-        string $source,
-        ?string $triggeredBy = null,
+        #[ORM\ManyToOne(targetEntity: ComicSeries::class)]
+        #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+        #[Groups(['enrichment:read'])]
+        private ComicSeries $comicSeries,
+        #[ORM\Column(type: Types::STRING, enumType: EnrichmentConfidence::class)]
+        #[Groups(['enrichment:read'])]
+        private EnrichmentConfidence $confidence,
+        #[ORM\Column(type: Types::JSON, nullable: true)]
+        #[Groups(['enrichment:read'])]
+        private mixed $currentValue,
+        #[ORM\Column(type: Types::STRING, enumType: EnrichableField::class)]
+        #[Groups(['enrichment:read'])]
+        private EnrichableField $field,
+        #[ORM\Column(type: Types::JSON)]
+        #[Groups(['enrichment:read'])]
+        private mixed $proposedValue,
+        #[ORM\Column(length: 100)]
+        #[Groups(['enrichment:read'])]
+        private string $source,
+        #[ORM\Column(length: 100, nullable: true)]
+        #[Groups(['enrichment:read'])]
+        private ?string $triggeredBy = null,
     ) {
-        $this->comicSeries = $comicSeries;
-        $this->confidence = $confidence;
         $this->createdAt = new \DateTimeImmutable();
-        $this->currentValue = $currentValue;
-        $this->field = $field;
-        $this->proposedValue = $proposedValue;
-        $this->source = $source;
         $this->status = ProposalStatus::PENDING;
-        $this->triggeredBy = $triggeredBy;
     }
 
     public function getComicSeries(): ComicSeries

--- a/backend/src/Entity/Notification.php
+++ b/backend/src/Entity/Notification.php
@@ -53,60 +53,38 @@ class Notification
     #[Groups(['notification:list', 'notification:read'])]
     private ?int $id = null;
 
-    #[ORM\Column(type: Types::TEXT)]
-    #[Groups(['notification:list', 'notification:read'])]
-    private string $message;
-
-    /** @var array<string, mixed>|null */
-    #[ORM\Column(type: Types::JSON, nullable: true)]
-    #[Groups(['notification:list', 'notification:read'])]
-    private ?array $metadata;
-
     #[ORM\Column(name: 'read_status', type: Types::BOOLEAN)]
     #[Groups(['notification:list', 'notification:read', 'notification:write'])]
     private bool $read;
-
-    #[ORM\Column(nullable: true)]
-    #[Groups(['notification:list', 'notification:read'])]
-    private ?int $relatedEntityId;
-
-    #[ORM\Column(type: Types::STRING, nullable: true, enumType: NotificationEntityType::class)]
-    #[Groups(['notification:list', 'notification:read'])]
-    private ?NotificationEntityType $relatedEntityType;
-
-    #[ORM\Column(length: 255)]
-    #[Groups(['notification:list', 'notification:read'])]
-    private string $title;
-
-    #[ORM\Column(type: Types::STRING, enumType: NotificationType::class)]
-    #[Groups(['notification:list', 'notification:read'])]
-    private NotificationType $type;
-
-    #[ORM\ManyToOne(targetEntity: User::class)]
-    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
-    private User $user;
 
     /**
      * @param array<string, mixed>|null $metadata
      */
     public function __construct(
-        string $message,
-        ?array $metadata,
-        ?int $relatedEntityId,
-        ?NotificationEntityType $relatedEntityType,
-        string $title,
-        NotificationType $type,
-        User $user,
+        #[ORM\Column(type: Types::TEXT)]
+        #[Groups(['notification:list', 'notification:read'])]
+        private string $message,
+        #[ORM\Column(type: Types::JSON, nullable: true)]
+        #[Groups(['notification:list', 'notification:read'])]
+        private ?array $metadata,
+        #[ORM\Column(nullable: true)]
+        #[Groups(['notification:list', 'notification:read'])]
+        private ?int $relatedEntityId,
+        #[ORM\Column(type: Types::STRING, nullable: true, enumType: NotificationEntityType::class)]
+        #[Groups(['notification:list', 'notification:read'])]
+        private ?NotificationEntityType $relatedEntityType,
+        #[ORM\Column(length: 255)]
+        #[Groups(['notification:list', 'notification:read'])]
+        private string $title,
+        #[ORM\Column(type: Types::STRING, enumType: NotificationType::class)]
+        #[Groups(['notification:list', 'notification:read'])]
+        private NotificationType $type,
+        #[ORM\ManyToOne(targetEntity: User::class)]
+        #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+        private User $user,
     ) {
         $this->createdAt = new \DateTimeImmutable();
-        $this->message = $message;
-        $this->metadata = $metadata;
         $this->read = false;
-        $this->relatedEntityId = $relatedEntityId;
-        $this->relatedEntityType = $relatedEntityType;
-        $this->title = $title;
-        $this->type = $type;
-        $this->user = $user;
     }
 
     public function getCreatedAt(): \DateTimeImmutable

--- a/backend/src/Entity/NotificationPreference.php
+++ b/backend/src/Entity/NotificationPreference.php
@@ -32,32 +32,23 @@ use Symfony\Component\Serializer\Attribute\Groups;
 #[ORM\UniqueConstraint(name: 'uniq_pref_user_type', columns: ['user_id', 'type'])]
 class NotificationPreference
 {
-    #[ORM\Column(type: Types::STRING, enumType: NotificationChannel::class)]
-    #[Groups(['preference:list', 'preference:write'])]
-    private NotificationChannel $channel;
-
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     #[Groups(['preference:list'])]
     private ?int $id = null;
 
-    #[ORM\Column(type: Types::STRING, enumType: NotificationType::class)]
-    #[Groups(['preference:list'])]
-    private NotificationType $type;
-
-    #[ORM\ManyToOne(targetEntity: User::class)]
-    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
-    private User $user;
-
     public function __construct(
-        NotificationChannel $channel,
-        NotificationType $type,
-        User $user,
+        #[ORM\Column(type: Types::STRING, enumType: NotificationChannel::class)]
+        #[Groups(['preference:list', 'preference:write'])]
+        private NotificationChannel $channel,
+        #[ORM\Column(type: Types::STRING, enumType: NotificationType::class)]
+        #[Groups(['preference:list'])]
+        private NotificationType $type,
+        #[ORM\ManyToOne(targetEntity: User::class)]
+        #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+        private User $user,
     ) {
-        $this->channel = $channel;
-        $this->type = $type;
-        $this->user = $user;
     }
 
     public function getChannel(): NotificationChannel

--- a/backend/src/Entity/PushSubscription.php
+++ b/backend/src/Entity/PushSubscription.php
@@ -27,21 +27,9 @@ use Symfony\Component\Serializer\Attribute\Groups;
 #[ORM\UniqueConstraint(name: 'uniq_push_endpoint', columns: ['endpoint'])]
 class PushSubscription
 {
-    #[ORM\Column(length: 255)]
-    #[Groups(['push:write'])]
-    private string $authToken;
-
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
     #[Groups(['push:list'])]
     private \DateTimeImmutable $createdAt;
-
-    #[ORM\Column(type: Types::TEXT)]
-    #[Groups(['push:list', 'push:write'])]
-    private string $endpoint;
-
-    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
-    #[Groups(['push:list', 'push:write'])]
-    private ?\DateTimeImmutable $expirationTime;
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -49,27 +37,24 @@ class PushSubscription
     #[Groups(['push:list'])]
     private ?int $id = null;
 
-    #[ORM\Column(length: 255)]
-    #[Groups(['push:write'])]
-    private string $publicKey;
-
-    #[ORM\ManyToOne(targetEntity: User::class)]
-    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
-    private User $user;
-
     public function __construct(
-        string $authToken,
-        string $endpoint,
-        ?\DateTimeImmutable $expirationTime,
-        string $publicKey,
-        User $user,
+        #[ORM\Column(length: 255)]
+        #[Groups(['push:write'])]
+        private string $authToken,
+        #[ORM\Column(type: Types::TEXT)]
+        #[Groups(['push:list', 'push:write'])]
+        private string $endpoint,
+        #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+        #[Groups(['push:list', 'push:write'])]
+        private ?\DateTimeImmutable $expirationTime,
+        #[ORM\Column(length: 255)]
+        #[Groups(['push:write'])]
+        private string $publicKey,
+        #[ORM\ManyToOne(targetEntity: User::class)]
+        #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+        private User $user,
     ) {
-        $this->authToken = $authToken;
         $this->createdAt = new \DateTimeImmutable();
-        $this->endpoint = $endpoint;
-        $this->expirationTime = $expirationTime;
-        $this->publicKey = $publicKey;
-        $this->user = $user;
     }
 
     public function getAuthToken(): string

--- a/backend/src/Entity/SeriesSuggestion.php
+++ b/backend/src/Entity/SeriesSuggestion.php
@@ -34,11 +34,6 @@ use Symfony\Component\Serializer\Attribute\Groups;
 #[ORM\Index(name: 'idx_suggestion_status', columns: ['status'])]
 class SeriesSuggestion
 {
-    /** @var list<string> */
-    #[ORM\Column(type: Types::JSON)]
-    #[Groups(['suggestion:read'])]
-    private array $authors;
-
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
     #[Groups(['suggestion:read'])]
     private \DateTimeImmutable $createdAt;
@@ -49,44 +44,33 @@ class SeriesSuggestion
     #[Groups(['suggestion:read'])]
     private ?int $id = null;
 
-    #[ORM\Column(type: Types::TEXT)]
-    #[Groups(['suggestion:read'])]
-    private string $reason;
-
-    #[ORM\ManyToOne(targetEntity: ComicSeries::class)]
-    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
-    #[Groups(['suggestion:read'])]
-    private ?ComicSeries $sourceSeries;
-
     #[ORM\Column(type: Types::STRING, enumType: SuggestionStatus::class)]
     #[Groups(['suggestion:read', 'suggestion:write'])]
     private SuggestionStatus $status;
-
-    #[ORM\Column(length: 255)]
-    #[Groups(['suggestion:read'])]
-    private string $title;
-
-    #[ORM\Column(type: Types::STRING, enumType: ComicType::class)]
-    #[Groups(['suggestion:read'])]
-    private ComicType $type;
 
     /**
      * @param list<string> $authors
      */
     public function __construct(
-        array $authors,
-        string $reason,
-        ?ComicSeries $sourceSeries,
-        string $title,
-        ComicType $type,
+        #[ORM\Column(type: Types::JSON)]
+        #[Groups(['suggestion:read'])]
+        private array $authors,
+        #[ORM\Column(type: Types::TEXT)]
+        #[Groups(['suggestion:read'])]
+        private string $reason,
+        #[ORM\ManyToOne(targetEntity: ComicSeries::class)]
+        #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+        #[Groups(['suggestion:read'])]
+        private ?ComicSeries $sourceSeries,
+        #[ORM\Column(length: 255)]
+        #[Groups(['suggestion:read'])]
+        private string $title,
+        #[ORM\Column(type: Types::STRING, enumType: ComicType::class)]
+        #[Groups(['suggestion:read'])]
+        private ComicType $type,
     ) {
-        $this->authors = $authors;
         $this->createdAt = new \DateTimeImmutable();
-        $this->reason = $reason;
-        $this->sourceSeries = $sourceSeries;
         $this->status = SuggestionStatus::PENDING;
-        $this->title = $title;
-        $this->type = $type;
     }
 
     /** @return list<string> */

--- a/backend/src/EventListener/PlaceholderSecretChecker.php
+++ b/backend/src/EventListener/PlaceholderSecretChecker.php
@@ -25,11 +25,11 @@ final readonly class PlaceholderSecretChecker
     ];
 
     public function __construct(
-        #[Autowire('%kernel.secret%')]
+        #[Autowire(param: 'kernel.secret')]
         private string $appSecret,
-        #[Autowire('%kernel.environment%')]
+        #[Autowire(param: 'kernel.environment')]
         private string $env,
-        #[Autowire('%env(JWT_PASSPHRASE)%')]
+        #[Autowire(env: 'JWT_PASSPHRASE')]
         private string $jwtPassphrase,
     ) {
     }

--- a/backend/src/EventListener/ReEnrichOnUpdateListener.php
+++ b/backend/src/EventListener/ReEnrichOnUpdateListener.php
@@ -41,7 +41,7 @@ final readonly class ReEnrichOnUpdateListener
         // Ne pas re-enrichir si un lookup a été fait récemment (< 24h)
         $lookupAt = $series->getLookupCompletedAt();
 
-        if (null !== $lookupAt && $lookupAt > new \DateTimeImmutable('-1 day')) {
+        if ($lookupAt instanceof \DateTimeImmutable && $lookupAt > new \DateTimeImmutable('-1 day')) {
             return;
         }
 

--- a/backend/src/MessageHandler/EnrichSeriesHandler.php
+++ b/backend/src/MessageHandler/EnrichSeriesHandler.php
@@ -8,6 +8,7 @@ use App\Enum\LookupMode;
 use App\Message\EnrichSeriesMessage;
 use App\Repository\ComicSeriesRepository;
 use App\Service\Enrichment\EnrichmentService;
+use App\Service\Lookup\Contract\LookupResult;
 use App\Service\Lookup\Gemini\GeminiCircuitBreaker;
 use App\Service\Lookup\LookupOrchestrator;
 use Doctrine\ORM\EntityManagerInterface;
@@ -86,7 +87,7 @@ final readonly class EnrichSeriesHandler
             return;
         }
 
-        if (null !== $result) {
+        if ($result instanceof LookupResult) {
             $sources = $this->lookupOrchestrator->getLastSources();
 
             $confidence = $this->enrichmentService->enrich(

--- a/backend/src/Repository/ComicSeriesRepository.php
+++ b/backend/src/Repository/ComicSeriesRepository.php
@@ -11,6 +11,7 @@ use App\Entity\Tome;
 use App\Enum\ComicStatus;
 use App\Enum\ComicType;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\Cache\CacheInterface;
@@ -403,7 +404,7 @@ class ComicSeriesRepository extends ServiceEntityRepository
      * Les vérifications scalaires (NULL) sont placées dans WHERE (pas d'agrégation nécessaire).
      * L'absence d'auteurs est détectée via NOT EXISTS pour éviter un GROUP BY sur toute la table.
      */
-    private function buildMissingDataQueryBuilder(?ComicType $type, ?int $limit): \Doctrine\ORM\QueryBuilder
+    private function buildMissingDataQueryBuilder(?ComicType $type, ?int $limit): QueryBuilder
     {
         $qb = $this->createQueryBuilder('c')
             ->where(

--- a/backend/src/Schedule.php
+++ b/backend/src/Schedule.php
@@ -17,10 +17,10 @@ use Symfony\Contracts\Cache\CacheInterface;
  * Remplace le planificateur de tâches du NAS Synology.
  */
 #[AsSchedule('default')]
-final class Schedule implements ScheduleProviderInterface
+final readonly class Schedule implements ScheduleProviderInterface
 {
     public function __construct(
-        private readonly CacheInterface $cache,
+        private CacheInterface $cache,
     ) {
     }
 

--- a/backend/src/Service/Cover/CoverSearchService.php
+++ b/backend/src/Service/Cover/CoverSearchService.php
@@ -21,11 +21,11 @@ final readonly class CoverSearchService
     private const string SERPER_URL = 'https://google.serper.dev/images';
 
     public function __construct(
-        #[Autowire('%env(GOOGLE_BOOKS_API_KEY)%')]
+        #[Autowire(env: 'GOOGLE_BOOKS_API_KEY')]
         private string $googleBooksApiKey,
         private HttpClientInterface $httpClient,
         private LoggerInterface $logger,
-        #[Autowire('%env(SERPER_API_KEY)%')]
+        #[Autowire(env: 'SERPER_API_KEY')]
         private string $serperApiKey,
     ) {
     }

--- a/backend/src/Service/Enrichment/ConfidenceScorer.php
+++ b/backend/src/Service/Enrichment/ConfidenceScorer.php
@@ -66,7 +66,7 @@ class ConfidenceScorer
         $score += $providerBonus;
 
         // Correspondance de type (0.10)
-        if (null !== $queryType) {
+        if ($queryType instanceof ComicType) {
             $score += 0.10;
         }
 

--- a/backend/src/Service/Enrichment/EnrichmentService.php
+++ b/backend/src/Service/Enrichment/EnrichmentService.php
@@ -227,7 +227,7 @@ class EnrichmentService
             }
 
             // Vérifie qu'il n'y a pas déjà une proposition en attente
-            if (null !== $this->proposalRepository->findPendingBySeriesAndField($series, $enrichableField)) {
+            if ($this->proposalRepository->findPendingBySeriesAndField($series, $enrichableField) instanceof EnrichmentProposal) {
                 continue;
             }
 

--- a/backend/src/Service/Import/ImportService.php
+++ b/backend/src/Service/Import/ImportService.php
@@ -585,7 +585,7 @@ final class ImportService
         }
 
         if (\str_ends_with($isbn, '.0')) {
-            $isbn = \substr($isbn, 0, -2);
+            return \substr($isbn, 0, -2);
         }
 
         return $isbn;
@@ -665,7 +665,7 @@ final class ImportService
      */
     private function findOrCreateAuthor(string $name): Author
     {
-        $key = self::normalizeAuthorKey($name);
+        $key = $this->normalizeAuthorKey($name);
 
         if (isset($this->pendingAuthors[$key])) {
             return $this->pendingAuthors[$key];
@@ -687,7 +687,7 @@ final class ImportService
     /**
      * Normalise un nom pour le rendre insensible aux accents et à la casse.
      */
-    private static function normalizeAuthorKey(string $name): string
+    private function normalizeAuthorKey(string $name): string
     {
         $key = \mb_strtolower(\trim($name));
         $decomposed = \Normalizer::normalize($key, \Normalizer::NFD);

--- a/backend/src/Service/Lookup/Gemini/AbstractGeminiLookupProvider.php
+++ b/backend/src/Service/Lookup/Gemini/AbstractGeminiLookupProvider.php
@@ -176,14 +176,7 @@ abstract class AbstractGeminiLookupProvider extends AbstractLookupProvider
 
                     return null;
                 }
-
-                $hasData = false;
-                foreach ($this->getUsefulDataFields() as $field) {
-                    if (!empty($data[$field])) {
-                        $hasData = true;
-                        break;
-                    }
-                }
+                $hasData = \array_any($this->getUsefulDataFields(), static fn (string $field): bool => !empty($data[$field]));
 
                 if (!$hasData) {
                     $this->recordApiMessage(ApiLookupStatus::NOT_FOUND, $this->getNotFoundMessage());

--- a/backend/src/Service/Lookup/Gemini/GeminiCircuitBreaker.php
+++ b/backend/src/Service/Lookup/Gemini/GeminiCircuitBreaker.php
@@ -41,7 +41,7 @@ class GeminiCircuitBreaker
      */
     public function isOpen(): bool
     {
-        return null !== $this->openUntil();
+        return $this->openUntil() instanceof \DateTimeImmutable;
     }
 
     /**
@@ -95,7 +95,7 @@ class GeminiCircuitBreaker
     {
         $until = $this->openUntil();
 
-        if (null === $until) {
+        if (!$until instanceof \DateTimeImmutable) {
             return 0;
         }
 

--- a/backend/src/Service/Lookup/LookupOrchestrator.php
+++ b/backend/src/Service/Lookup/LookupOrchestrator.php
@@ -34,7 +34,7 @@ class LookupOrchestrator
      * @param iterable<LookupProviderInterface> $providers
      */
     public function __construct(
-        #[Autowire('%app.lookup_global_timeout%')]
+        #[Autowire(param: 'app.lookup_global_timeout')]
         private readonly float $globalTimeout,
         private readonly LoggerInterface $logger,
         #[AutowireIterator('app.lookup_provider')]
@@ -63,13 +63,7 @@ class LookupOrchestrator
      */
     public function hasRateLimitError(): bool
     {
-        foreach ($this->apiMessages as $message) {
-            if (ApiLookupStatus::RATE_LIMITED->value === $message->status) {
-                return true;
-            }
-        }
-
-        return false;
+        return \array_any($this->apiMessages, static fn (ApiMessage $message): bool => ApiLookupStatus::RATE_LIMITED->value === $message->status);
     }
 
     /**
@@ -86,7 +80,7 @@ class LookupOrchestrator
         $result = $this->doLookup($isbn, $type, LookupMode::ISBN);
 
         if ($result instanceof LookupResult) {
-            $result = $result->withIsbn($isbn);
+            return $result->withIsbn($isbn);
         }
 
         return $result;
@@ -161,12 +155,12 @@ class LookupOrchestrator
                     $results = $provider->resolveMultipleLookup($state);
                 } else {
                     $single = $provider->resolveLookup($state);
-                    $results = null !== $single ? [$single] : [];
+                    $results = $single instanceof LookupResult ? [$single] : [];
                 }
 
                 $apiMessage = $provider->getLastApiMessage();
 
-                if (null !== $apiMessage) {
+                if ($apiMessage instanceof ApiMessage) {
                     $this->apiMessages[$provider->getName()] = $apiMessage;
                 }
 
@@ -273,11 +267,11 @@ class LookupOrchestrator
                 $result = $provider->resolveLookup($state);
                 $apiMessage = $provider->getLastApiMessage();
 
-                if (null !== $apiMessage) {
+                if ($apiMessage instanceof ApiMessage) {
                     $this->apiMessages[$provider->getName()] = $apiMessage;
                 }
 
-                if (null !== $result) {
+                if ($result instanceof LookupResult) {
                     $providerResults[] = [$provider, $result];
                     $this->sources[] = $provider->getName();
                 }
@@ -300,7 +294,7 @@ class LookupOrchestrator
         $merged = $this->mergeByFieldPriority($providerResults, $type);
 
         if (!$merged->isComplete()) {
-            $merged = $this->tryEnrich($merged, $providerResults, $type);
+            return $this->tryEnrich($merged, $providerResults, $type);
         }
 
         return $merged;
@@ -392,11 +386,11 @@ class LookupOrchestrator
                 $enriched = $provider->resolveEnrich($state);
                 $apiMessage = $provider->getLastApiMessage();
 
-                if (null !== $apiMessage) {
+                if ($apiMessage instanceof ApiMessage) {
                     $this->apiMessages[$provider->getName().'.enrich'] = $apiMessage;
                 }
 
-                if (null !== $enriched) {
+                if ($enriched instanceof LookupResult) {
                     $enrichResults[] = [$provider, $enriched];
                     $this->sources[] = $enriched->source;
                 }

--- a/backend/src/Service/Lookup/Provider/ComicVineLookup.php
+++ b/backend/src/Service/Lookup/Provider/ComicVineLookup.php
@@ -30,7 +30,7 @@ final class ComicVineLookup extends AbstractLookupProvider implements MultiResul
     private const string API_URL = 'https://comicvine.gamespot.com/api/search/';
 
     public function __construct(
-        #[Autowire('%env(COMICVINE_API_KEY)%')]
+        #[Autowire(env: 'COMICVINE_API_KEY')]
         private readonly string $apiKey,
         private readonly HttpClientInterface $httpClient,
         private readonly LoggerInterface $logger,

--- a/backend/src/Service/Lookup/Provider/GoogleBooksLookup.php
+++ b/backend/src/Service/Lookup/Provider/GoogleBooksLookup.php
@@ -31,7 +31,7 @@ final class GoogleBooksLookup extends AbstractLookupProvider implements MultiRes
     private const string API_URL = 'https://www.googleapis.com/books/v1/volumes';
 
     public function __construct(
-        #[Autowire('%env(GOOGLE_BOOKS_API_KEY)%')]
+        #[Autowire(env: 'GOOGLE_BOOKS_API_KEY')]
         private readonly string $apiKey,
         private readonly HttpClientInterface $httpClient,
         private readonly LoggerInterface $logger,

--- a/backend/src/Service/Lookup/Util/TitleMatcher.php
+++ b/backend/src/Service/Lookup/Util/TitleMatcher.php
@@ -36,14 +36,7 @@ final class TitleMatcher
             return false;
         }
 
-        // Au moins un mot significatif de la requête doit apparaître dans le titre
-        foreach ($queryWords as $word) {
-            if (\str_contains($normalizedTitle, $word)) {
-                return true;
-            }
-        }
-
-        return false;
+        return \array_any($queryWords, static fn ($word): bool => \str_contains($normalizedTitle, $word));
     }
 
     /**

--- a/backend/src/Service/Merge/MergePreviewBuilder.php
+++ b/backend/src/Service/Merge/MergePreviewBuilder.php
@@ -206,13 +206,7 @@ final readonly class MergePreviewBuilder
      */
     private function reconcileLatestPublishedIssueComplete(array $seriesList): bool
     {
-        foreach ($seriesList as $series) {
-            if ($series->isLatestPublishedIssueComplete()) {
-                return true;
-            }
-        }
-
-        return false;
+        return \array_any($seriesList, static fn (ComicSeries $series): bool => $series->isLatestPublishedIssueComplete());
     }
 
     /**

--- a/backend/src/Service/Notification/NotificationService.php
+++ b/backend/src/Service/Notification/NotificationService.php
@@ -80,7 +80,7 @@ class NotificationService implements NotifierInterface
 
     private function buildEntityUrl(?NotificationEntityType $entityType, ?int $entityId): ?string
     {
-        if (null === $entityType || null === $entityId) {
+        if (!$entityType instanceof NotificationEntityType || null === $entityId) {
             return null;
         }
 

--- a/backend/src/Service/Notification/WebPushService.php
+++ b/backend/src/Service/Notification/WebPushService.php
@@ -6,6 +6,7 @@ namespace App\Service\Notification;
 
 use App\Entity\User;
 use App\Repository\PushSubscriptionRepository;
+use Minishlink\WebPush\MessageSentReport;
 use Minishlink\WebPush\Subscription;
 use Minishlink\WebPush\WebPush;
 use Psr\Log\LoggerInterface;
@@ -19,11 +20,11 @@ class WebPushService
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly PushSubscriptionRepository $pushSubscriptionRepository,
-        #[Autowire('%env(VAPID_PRIVATE_KEY)%')]
+        #[Autowire(env: 'VAPID_PRIVATE_KEY')]
         private readonly string $vapidPrivateKey,
-        #[Autowire('%env(VAPID_PUBLIC_KEY)%')]
+        #[Autowire(env: 'VAPID_PUBLIC_KEY')]
         private readonly string $vapidPublicKey,
-        #[Autowire('%env(VAPID_SUBJECT)%')]
+        #[Autowire(env: 'VAPID_SUBJECT')]
         private readonly string $vapidSubject,
     ) {
     }
@@ -68,7 +69,7 @@ class WebPushService
                 );
             }
 
-            /** @var \Minishlink\WebPush\MessageSentReport $report */
+            /** @var MessageSentReport $report */
             foreach ($webPush->flush() as $report) {
                 if (!$report->isSuccess()) {
                     $this->logger->warning('Push échoué pour {endpoint} : {reason}', [

--- a/backend/src/Service/Recommendation/SimilarSeriesService.php
+++ b/backend/src/Service/Recommendation/SimilarSeriesService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service\Recommendation;
 
+use App\DTO\ComicSeriesListItem;
 use App\Entity\SeriesSuggestion;
 use App\Enum\ComicType;
 use App\Repository\ComicSeriesRepository;
@@ -35,7 +36,7 @@ class SimilarSeriesService
     {
         $allSeries = $this->comicSeriesRepository->findAllForApi();
         $dismissedTitles = $this->suggestionRepository->findDismissedTitles();
-        $existingTitles = \array_map(static fn ($s) => \mb_strtolower($s->title), $allSeries);
+        $existingTitles = \array_map(static fn (ComicSeriesListItem $s): string => \mb_strtolower($s->title), $allSeries);
 
         $batches = \array_chunk($allSeries, self::BATCH_SIZE);
 
@@ -116,7 +117,7 @@ class SimilarSeriesService
     private function querySuggestions(array $seriesData): array
     {
         $seriesList = \implode("\n", \array_map(
-            static fn (array $s) => \sprintf('- %s (%s) par %s', $s['title'], $s['type'], $s['authors']),
+            static fn (array $s): string => \sprintf('- %s (%s) par %s', $s['title'], $s['type'], $s['authors']),
             $seriesData,
         ));
 

--- a/backend/src/Service/Share/ShareResolver.php
+++ b/backend/src/Service/Share/ShareResolver.php
@@ -6,9 +6,11 @@ namespace App\Service\Share;
 
 use App\DTO\Share\ShareResolution;
 use App\DTO\Share\ShareUrlInfo;
+use App\Entity\ComicSeries;
 use App\Enum\ComicType;
 use App\Message\EnrichSeriesMessage;
 use App\Repository\ComicSeriesRepository;
+use App\Service\Lookup\Contract\LookupResult;
 use App\Service\Lookup\LookupOrchestrator;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -16,12 +18,12 @@ use Symfony\Component\Messenger\MessageBusInterface;
  * Orchestre la résolution d'un lien partagé :
  * parsing → lookup → match base → enrichissement.
  */
-final class ShareResolver
+final readonly class ShareResolver
 {
     public function __construct(
-        private readonly ComicSeriesRepository $comicSeriesRepository,
-        private readonly LookupOrchestrator $lookupOrchestrator,
-        private readonly MessageBusInterface $messageBus,
+        private ComicSeriesRepository $comicSeriesRepository,
+        private LookupOrchestrator $lookupOrchestrator,
+        private MessageBusInterface $messageBus,
     ) {
     }
 
@@ -42,7 +44,7 @@ final class ShareResolver
             return ShareResolution::empty();
         }
 
-        if (null === $result) {
+        if (!$result instanceof LookupResult) {
             return ShareResolution::empty();
         }
 
@@ -52,18 +54,18 @@ final class ShareResolver
             $series = $this->comicSeriesRepository->findOneByTomeIsbn($result->isbn);
         }
 
-        if (null === $series && null !== $result->title) {
+        if (!$series instanceof ComicSeries && null !== $result->title) {
             $series = $this->comicSeriesRepository->findOneByFuzzyTitle(
                 $result->title,
                 $info->type ?? ComicType::BD,
             );
         }
 
-        if (null === $series && null !== $result->title) {
+        if (!$series instanceof ComicSeries && null !== $result->title) {
             $series = $this->comicSeriesRepository->findOneByFuzzyTitleAnyType($result->title);
         }
 
-        if (null !== $series) {
+        if ($series instanceof ComicSeries) {
             $seriesId = $series->getId();
 
             if (null !== $seriesId) {

--- a/backend/src/State/NotificationPreferenceInitializer.php
+++ b/backend/src/State/NotificationPreferenceInitializer.php
@@ -7,11 +7,13 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\Entity\NotificationPreference;
+use App\Entity\User;
 use App\Enum\NotificationChannel;
 use App\Enum\NotificationType;
 use App\Repository\NotificationPreferenceRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Initialise les préférences de notification par défaut (IN_APP) au premier accès.
@@ -34,11 +36,11 @@ final readonly class NotificationPreferenceInitializer implements ProviderInterf
     {
         $user = $this->security->getUser();
 
-        if (null === $user) {
+        if (!$user instanceof UserInterface) {
             return [];
         }
 
-        /** @var \App\Entity\User $user */
+        /** @var User $user */
         $existing = $this->notificationPreferenceRepository->findByUser($user);
 
         if (\count($existing) >= \count(NotificationType::cases())) {
@@ -47,7 +49,7 @@ final readonly class NotificationPreferenceInitializer implements ProviderInterf
 
         // Créer les préférences manquantes
         $existingTypes = \array_map(
-            static fn (NotificationPreference $p) => $p->getType(),
+            static fn (NotificationPreference $p): NotificationType => $p->getType(),
             $existing,
         );
 

--- a/backend/tests/Functional/Controller/PurgeControllerTest.php
+++ b/backend/tests/Functional/Controller/PurgeControllerTest.php
@@ -93,7 +93,7 @@ final class PurgeControllerTest extends ApiTestCase
         $em->getConnection()->executeStatement(
             'UPDATE comic_series SET deleted_at = :date WHERE id = :id',
             [
-                'date' => (new \DateTime('-60 days'))->format('Y-m-d H:i:s'),
+                'date' => new \DateTime('-60 days')->format('Y-m-d H:i:s'),
                 'id' => $series->getId(),
             ]
         );
@@ -148,7 +148,7 @@ final class PurgeControllerTest extends ApiTestCase
         $em->getConnection()->executeStatement(
             'UPDATE comic_series SET deleted_at = :date WHERE id = :id',
             [
-                'date' => (new \DateTime('-60 days'))->format('Y-m-d H:i:s'),
+                'date' => new \DateTime('-60 days')->format('Y-m-d H:i:s'),
                 'id' => $seriesId,
             ]
         );

--- a/backend/tests/Functional/Controller/ShareControllerTest.php
+++ b/backend/tests/Functional/Controller/ShareControllerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Tests\Functional\Controller;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
-use App\Entity\Tome;
 use App\Repository\UserRepository;
 use App\Service\Lookup\Contract\LookupResult;
 use App\Service\Lookup\LookupOrchestrator;
@@ -101,7 +100,7 @@ final class ShareControllerTest extends ApiTestCase
         // Mocker LookupOrchestrator après création du client (le container est partagé)
         $mockOrchestrator = $this->createStub(LookupOrchestrator::class);
         $mockOrchestrator->method('lookup')->willReturn(
-            new LookupResult(isbn: '2723492532', title: 'Astérix', source: 'test'),
+            new LookupResult(isbn: '2723492532', source: 'test', title: 'Astérix'),
         );
 
         self::getContainer()->set(LookupOrchestrator::class, $mockOrchestrator);
@@ -134,7 +133,7 @@ final class ShareControllerTest extends ApiTestCase
         // Mocker pour retourner un résultat sans ISBN connu en base
         $mockOrchestrator = $this->createStub(LookupOrchestrator::class);
         $mockOrchestrator->method('lookupByTitle')->willReturn(
-            new LookupResult(title: 'Série inconnue', source: 'test'),
+            new LookupResult(source: 'test', title: 'Série inconnue'),
         );
 
         self::getContainer()->set(LookupOrchestrator::class, $mockOrchestrator);

--- a/backend/tests/Integration/Command/PurgeDeletedCommandTest.php
+++ b/backend/tests/Integration/Command/PurgeDeletedCommandTest.php
@@ -58,7 +58,7 @@ final class PurgeDeletedCommandTest extends KernelTestCase
         $this->em->getConnection()->executeStatement(
             'UPDATE comic_series SET deleted_at = :date WHERE id = :id',
             [
-                'date' => (new \DateTime('-60 days'))->format('Y-m-d H:i:s'),
+                'date' => new \DateTime('-60 days')->format('Y-m-d H:i:s'),
                 'id' => $oldDeleted->getId(),
             ]
         );
@@ -90,7 +90,7 @@ final class PurgeDeletedCommandTest extends KernelTestCase
         $this->em->getConnection()->executeStatement(
             'UPDATE comic_series SET deleted_at = :date WHERE id = :id',
             [
-                'date' => (new \DateTime('-10 days'))->format('Y-m-d H:i:s'),
+                'date' => new \DateTime('-10 days')->format('Y-m-d H:i:s'),
                 'id' => $recentDeleted->getId(),
             ]
         );
@@ -123,7 +123,7 @@ final class PurgeDeletedCommandTest extends KernelTestCase
         $this->em->getConnection()->executeStatement(
             'UPDATE comic_series SET deleted_at = :date WHERE id = :id',
             [
-                'date' => (new \DateTime('-60 days'))->format('Y-m-d H:i:s'),
+                'date' => new \DateTime('-60 days')->format('Y-m-d H:i:s'),
                 'id' => $seriesId,
             ]
         );
@@ -180,7 +180,7 @@ final class PurgeDeletedCommandTest extends KernelTestCase
         $this->em->getConnection()->executeStatement(
             'UPDATE comic_series SET deleted_at = :date WHERE id IN (:id1, :id2)',
             [
-                'date' => (new \DateTime('-60 days'))->format('Y-m-d H:i:s'),
+                'date' => new \DateTime('-60 days')->format('Y-m-d H:i:s'),
                 'id1' => $id1,
                 'id2' => $id2,
             ]

--- a/backend/tests/Integration/Repository/ComicSeriesRepositoryTest.php
+++ b/backend/tests/Integration/Repository/ComicSeriesRepositoryTest.php
@@ -426,14 +426,14 @@ final class ComicSeriesRepositoryTest extends KernelTestCase
 
         // onNas=true
         $nasTitles = \array_map(
-            static fn ($s) => $s->getTitle(),
+            static fn (ComicSeries $s): string => $s->getTitle(),
             $this->repository->findWithFilters(new ComicSeriesFilter(onNas: true)),
         );
         self::assertSame(['With NAS'], $nasTitles, 'onNas=true');
 
         // onNas=false — séries sans aucun tome NAS (inclut celles sans tomes)
         $noNasTitles = \array_map(
-            static fn ($s) => $s->getTitle(),
+            static fn (ComicSeries $s): string => $s->getTitle(),
             $this->repository->findWithFilters(new ComicSeriesFilter(onNas: false)),
         );
         self::assertContains('Without NAS', $noNasTitles);
@@ -444,14 +444,14 @@ final class ComicSeriesRepositoryTest extends KernelTestCase
 
         // reading=reading (partiellement lu : au moins 1 lu ET 1 non lu)
         $readingTitles = \array_map(
-            static fn ($s) => $s->getTitle(),
+            static fn (ComicSeries $s): string => $s->getTitle(),
             $this->repository->findWithFilters(new ComicSeriesFilter(reading: 'reading')),
         );
         self::assertSame(['With NAS'], $readingTitles, 'reading=reading');
 
         // reading=read (aucun tome non lu — inclut séries sans tomes !)
         $readTitles = \array_map(
-            static fn ($s) => $s->getTitle(),
+            static fn (ComicSeries $s): string => $s->getTitle(),
             $this->repository->findWithFilters(new ComicSeriesFilter(reading: 'read')),
         );
         self::assertContains('Without NAS', $readTitles);
@@ -462,7 +462,7 @@ final class ComicSeriesRepositoryTest extends KernelTestCase
 
         // reading=unread (aucun tome lu — inclut séries sans tomes !)
         $unreadTitles = \array_map(
-            static fn ($s) => $s->getTitle(),
+            static fn (ComicSeries $s): string => $s->getTitle(),
             $this->repository->findWithFilters(new ComicSeriesFilter(reading: 'unread')),
         );
         self::assertContains('Unread Series', $unreadTitles);
@@ -473,14 +473,14 @@ final class ComicSeriesRepositoryTest extends KernelTestCase
 
         // search ISBN
         $isbnTitles = \array_map(
-            static fn ($s) => $s->getTitle(),
+            static fn (ComicSeries $s): string => $s->getTitle(),
             $this->repository->findWithFilters(new ComicSeriesFilter(search: '978-NAS')),
         );
         self::assertSame(['With NAS'], $isbnTitles, 'search ISBN');
 
         // search titre
         $titleTitles = \array_map(
-            static fn ($s) => $s->getTitle(),
+            static fn (ComicSeries $s): string => $s->getTitle(),
             $this->repository->findWithFilters(new ComicSeriesFilter(search: 'Without')),
         );
         self::assertSame(['Without NAS'], $titleTitles, 'search title');
@@ -628,7 +628,7 @@ final class ComicSeriesRepositoryTest extends KernelTestCase
         $this->em->flush();
 
         // onNas null → pas de filtre, toutes les séries retournées
-        $result = $this->repository->findWithFilters(new ComicSeriesFilter(onNas: null));
+        $result = $this->repository->findWithFilters(new ComicSeriesFilter());
 
         self::assertCount(2, $result);
     }
@@ -980,7 +980,7 @@ final class ComicSeriesRepositoryTest extends KernelTestCase
         );
 
         $optimizedResults = \array_map(
-            static fn ($s) => $s->getTitle(),
+            static fn (ComicSeries $s): string => $s->getTitle(),
             $this->repository->findWithMissingLookupData(),
         );
 
@@ -1158,7 +1158,7 @@ final class ComicSeriesRepositoryTest extends KernelTestCase
         $result = $this->repository->findActiveForReleaseCheck();
 
         self::assertCount(2, $result);
-        $titles = \array_map(static fn ($s): string => $s->getTitle(), $result);
+        $titles = \array_map(static fn (ComicSeries $s): string => $s->getTitle(), $result);
         self::assertContains('Buying Series', $titles);
         self::assertContains('Downloading Series', $titles);
     }

--- a/backend/tests/Unit/Command/AutoEnrichCommandTest.php
+++ b/backend/tests/Unit/Command/AutoEnrichCommandTest.php
@@ -73,7 +73,7 @@ final class AutoEnrichCommandTest extends TestCase
 
         // La première série déclenche une erreur qui ferme l'EM
         $this->lookupOrchestrator->method('lookupByTitle')
-            ->willReturnCallback(static function (string $title) {
+            ->willReturnCallback(static function (string $title): LookupResult {
                 if ('Série qui ferme EM' === $title) {
                     throw EntityManagerClosed::create();
                 }

--- a/backend/tests/Unit/Entity/ComicSeriesTest.php
+++ b/backend/tests/Unit/Entity/ComicSeriesTest.php
@@ -908,4 +908,50 @@ final class ComicSeriesTest extends TestCase
 
         self::assertSame([], $comic->getUnboughtTomes());
     }
+
+    public function testIsWishlist(): void
+    {
+        $comic = EntityFactory::createComicSeries();
+        $comic->setStatus(ComicStatus::WISHLIST);
+
+        self::assertTrue($comic->isWishlist());
+
+        $comic->setStatus(ComicStatus::BUYING);
+        self::assertFalse($comic->isWishlist());
+    }
+
+    public function testIsComplete(): void
+    {
+        $comic = EntityFactory::createComicSeries();
+        self::assertFalse($comic->isComplete());
+
+        $comic->setIsOneShot(true);
+        self::assertTrue($comic->isComplete());
+
+        $comic->setIsOneShot(false);
+        $comic->setLatestPublishedIssue(3);
+        self::assertFalse($comic->isComplete());
+
+        $tome1 = EntityFactory::createTome(number: 1);
+        $tome2 = EntityFactory::createTome(number: 2);
+        $tome3 = EntityFactory::createTome(number: 3);
+        $comic->addTome($tome1);
+        $comic->addTome($tome2);
+        $comic->addTome($tome3);
+
+        self::assertTrue($comic->isComplete());
+    }
+
+    public function testGetReadPercent(): void
+    {
+        $comic = EntityFactory::createComicSeries();
+        self::assertSame(0.0, $comic->getReadPercent());
+
+        $tome1 = EntityFactory::createTome(number: 1, read: true);
+        $tome2 = EntityFactory::createTome(number: 2, read: false);
+        $comic->addTome($tome1);
+        $comic->addTome($tome2);
+
+        self::assertSame(50.0, $comic->getReadPercent());
+    }
 }

--- a/backend/tests/Unit/EventListener/CoverUrlChangeListenerTest.php
+++ b/backend/tests/Unit/EventListener/CoverUrlChangeListenerTest.php
@@ -42,7 +42,7 @@ final class CoverUrlChangeListenerTest extends TestCase
         $this->messageBus->expects(self::once())
             ->method('dispatch')
             ->with(self::callback(
-                static fn ($msg) => $msg instanceof DownloadCoverMessage
+                static fn ($msg): bool => $msg instanceof DownloadCoverMessage
                     && 42 === $msg->seriesId
                     && 'https://new.com/cover.jpg' === $msg->coverUrl,
             ))
@@ -61,7 +61,7 @@ final class CoverUrlChangeListenerTest extends TestCase
         $this->messageBus->expects(self::once())
             ->method('dispatch')
             ->with(self::callback(
-                static fn ($msg) => $msg instanceof DownloadCoverMessage
+                static fn ($msg): bool => $msg instanceof DownloadCoverMessage
                     && 10 === $msg->seriesId
                     && 'https://new.com/cover.jpg' === $msg->coverUrl,
             ))

--- a/backend/tests/Unit/EventListener/EnrichOnCreateListenerTest.php
+++ b/backend/tests/Unit/EventListener/EnrichOnCreateListenerTest.php
@@ -37,7 +37,7 @@ final class EnrichOnCreateListenerTest extends TestCase
 
         $this->messageBus->expects(self::once())
             ->method('dispatch')
-            ->with(self::callback(static fn ($msg) => $msg instanceof EnrichSeriesMessage && 42 === $msg->seriesId))
+            ->with(self::callback(static fn ($msg): bool => $msg instanceof EnrichSeriesMessage && 42 === $msg->seriesId))
             ->willReturn(new Envelope(new EnrichSeriesMessage(42)));
 
         ($this->listener)(new ComicSeriesCreatedEvent($series));

--- a/backend/tests/Unit/EventListener/ReEnrichOnUpdateListenerTest.php
+++ b/backend/tests/Unit/EventListener/ReEnrichOnUpdateListenerTest.php
@@ -42,7 +42,7 @@ final class ReEnrichOnUpdateListenerTest extends TestCase
 
         $this->messageBus->expects(self::once())
             ->method('dispatch')
-            ->with(self::callback(static fn ($msg) => $msg instanceof EnrichSeriesMessage && 42 === $msg->seriesId))
+            ->with(self::callback(static fn ($msg): bool => $msg instanceof EnrichSeriesMessage && 42 === $msg->seriesId))
             ->willReturn(new Envelope(new EnrichSeriesMessage(42)));
 
         ($this->listener)(new ComicSeriesUpdatedEvent($series));

--- a/backend/tests/Unit/Service/Cover/CoverDownloaderTest.php
+++ b/backend/tests/Unit/Service/Cover/CoverDownloaderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Service\Cover;
 
+use App\Entity\ComicSeries;
 use App\Service\Cover\CoverDownloader;
 use App\Service\Cover\ThumbnailGenerator;
 use App\Service\Cover\Upload\UploadHandlerInterface;
@@ -134,7 +135,7 @@ final class CoverDownloaderTest extends TestCase
         // Simule le comportement de VichUploader qui définit coverImage après upload
         $this->uploadHandler->method('upload')
             ->willReturnCallback(static function (object $entity): void {
-                \assert($entity instanceof \App\Entity\ComicSeries);
+                \assert($entity instanceof ComicSeries);
                 $entity->setCoverImage('cover_test.webp');
             });
 

--- a/backend/tests/Unit/Service/Enrichment/ConfidenceScorerTest.php
+++ b/backend/tests/Unit/Service/Enrichment/ConfidenceScorerTest.php
@@ -28,7 +28,7 @@ final class ConfidenceScorerTest extends TestCase
      */
     public function testIsbnExactMatchReturnsHigh(): void
     {
-        $result = new LookupResult(isbn: '978-2-1234-5678-9', title: 'One Piece', source: 'google');
+        $result = new LookupResult(isbn: '978-2-1234-5678-9', source: 'google', title: 'One Piece');
 
         $confidence = $this->scorer->score(
             '978-2-1234-5678-9',
@@ -46,7 +46,7 @@ final class ConfidenceScorerTest extends TestCase
      */
     public function testIsbnMatchIgnoresFormatting(): void
     {
-        $result = new LookupResult(isbn: '9782123456789', title: 'One Piece', source: 'google');
+        $result = new LookupResult(isbn: '9782123456789', source: 'google', title: 'One Piece');
 
         $confidence = $this->scorer->score(
             '978-2-1234-5678-9',
@@ -66,8 +66,8 @@ final class ConfidenceScorerTest extends TestCase
     {
         $result = new LookupResult(
             authors: 'Eiichiro Oda',
-            title: 'One Piece',
             source: 'google',
+            title: 'One Piece',
         );
 
         $confidence = $this->scorer->score(
@@ -89,8 +89,8 @@ final class ConfidenceScorerTest extends TestCase
         // "One Piece" vs "One Piéce" — titre très similaire mais pas exact
         $result = new LookupResult(
             authors: 'Eiichiro Oda',
-            title: 'One Piéce',
             source: 'google',
+            title: 'One Piéce',
         );
 
         $confidence = $this->scorer->score(
@@ -109,7 +109,7 @@ final class ConfidenceScorerTest extends TestCase
      */
     public function testVeryDifferentTitleReturnsLow(): void
     {
-        $result = new LookupResult(title: 'Dragon Ball Super', source: 'google');
+        $result = new LookupResult(source: 'google', title: 'Dragon Ball Super');
 
         $confidence = $this->scorer->score(
             'One Piece',
@@ -129,16 +129,16 @@ final class ConfidenceScorerTest extends TestCase
     {
         $resultWithAuthors = new LookupResult(
             authors: 'Eiichiro Oda',
-            title: 'One Piece',
             source: 'google',
+            title: 'One Piece',
         );
         $resultWithoutAuthors = new LookupResult(
-            title: 'One Piece',
             source: 'google',
+            title: 'One Piece',
         );
 
         $withAuthors = $this->scorer->score('One Piece', null, LookupMode::TITLE, $resultWithAuthors, ['google']);
-        $withoutAuthors = $this->scorer->score('One Piece', null, LookupMode::TITLE, $resultWithoutAuthors, ['google']);
+        $this->scorer->score('One Piece', null, LookupMode::TITLE, $resultWithoutAuthors, ['google']);
 
         // Avec auteurs devrait être >= MEDIUM, sans auteurs pourrait être < MEDIUM
         // L'important est que le score avec auteurs est supérieur ou égal
@@ -152,8 +152,8 @@ final class ConfidenceScorerTest extends TestCase
     {
         $result = new LookupResult(
             authors: 'Author',
-            title: 'One Piece',
             source: 'google',
+            title: 'One Piece',
         );
 
         $singleProvider = $this->scorer->score('One Piece', ComicType::MANGA, LookupMode::TITLE, $result, ['google']);

--- a/backend/tests/Unit/Service/Enrichment/EnrichmentServiceTest.php
+++ b/backend/tests/Unit/Service/Enrichment/EnrichmentServiceTest.php
@@ -79,7 +79,7 @@ final class EnrichmentServiceTest extends TestCase
 
         self::assertSame(EnrichmentConfidence::HIGH, $confidence);
 
-        $proposals = \array_filter($this->persisted, static fn ($e) => $e instanceof EnrichmentProposal);
+        $proposals = \array_filter($this->persisted, static fn (object $e): bool => $e instanceof EnrichmentProposal);
         self::assertCount(2, $proposals);
 
         /** @var EnrichmentProposal $proposal */
@@ -101,7 +101,7 @@ final class EnrichmentServiceTest extends TestCase
 
         $this->enrichmentService->enrich($series, $result, LookupMode::TITLE, ['bnf'], 'command:auto-enrich');
 
-        $proposals = \array_filter($this->persisted, static fn ($e) => $e instanceof EnrichmentProposal);
+        $proposals = \array_filter($this->persisted, static fn (object $e): bool => $e instanceof EnrichmentProposal);
         self::assertGreaterThanOrEqual(1, \count($proposals));
 
         /** @var EnrichmentProposal $proposal */
@@ -122,7 +122,7 @@ final class EnrichmentServiceTest extends TestCase
 
         $this->enrichmentService->enrich($series, $result, LookupMode::TITLE, ['bnf']);
 
-        $proposals = \array_filter($this->persisted, static fn ($e) => $e instanceof EnrichmentProposal);
+        $proposals = \array_filter($this->persisted, static fn (object $e): bool => $e instanceof EnrichmentProposal);
 
         /** @var EnrichmentProposal $proposal */
         $proposal = \array_values($proposals)[0];
@@ -144,7 +144,7 @@ final class EnrichmentServiceTest extends TestCase
 
         self::assertSame(EnrichmentConfidence::MEDIUM, $confidence);
 
-        $proposals = \array_filter($this->persisted, static fn ($e) => $e instanceof EnrichmentProposal);
+        $proposals = \array_filter($this->persisted, static fn (object $e): bool => $e instanceof EnrichmentProposal);
         self::assertGreaterThanOrEqual(1, \count($proposals));
 
         /** @var EnrichmentProposal $proposal */
@@ -168,7 +168,7 @@ final class EnrichmentServiceTest extends TestCase
 
         $this->enrichmentService->enrich($series, $result, LookupMode::TITLE, ['bnf']);
 
-        $proposals = \array_filter($this->persisted, static fn ($e) => $e instanceof EnrichmentProposal);
+        $proposals = \array_filter($this->persisted, static fn (object $e): bool => $e instanceof EnrichmentProposal);
         self::assertCount(0, $proposals);
     }
 
@@ -186,7 +186,7 @@ final class EnrichmentServiceTest extends TestCase
 
         self::assertSame(EnrichmentConfidence::LOW, $confidence);
 
-        $proposals = \array_filter($this->persisted, static fn ($e) => $e instanceof EnrichmentProposal);
+        $proposals = \array_filter($this->persisted, static fn (object $e): bool => $e instanceof EnrichmentProposal);
         self::assertCount(1, $proposals);
 
         /** @var EnrichmentProposal $proposal */

--- a/backend/tests/Unit/Service/Lookup/Gemini/GeminiClientPoolTest.php
+++ b/backend/tests/Unit/Service/Lookup/Gemini/GeminiClientPoolTest.php
@@ -6,9 +6,11 @@ namespace App\Tests\Unit\Service\Lookup\Gemini;
 
 use App\Service\Lookup\Gemini\GeminiAllKeysExhaustedException;
 use App\Service\Lookup\Gemini\GeminiClientPool;
+use Gemini\Contracts\ClientContract;
 use Gemini\Exceptions\ErrorException;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Tests unitaires pour GeminiClientPool.
@@ -322,7 +324,7 @@ final class GeminiClientPoolTest extends TestCase
      * Le type de retour déclaré (string) évite que PHPStan infère « never »
      * au site d'appel, ce qui marquerait à tort le code suivant comme mort.
      *
-     * @return callable(\Gemini\Contracts\ClientContract, string): string
+     * @return callable(ClientContract, string):string
      */
     private function alwaysFailingCallback(int $code): callable
     {

--- a/backend/tests/Unit/Service/Lookup/Gemini/GeminiQueryServiceTest.php
+++ b/backend/tests/Unit/Service/Lookup/Gemini/GeminiQueryServiceTest.php
@@ -15,9 +15,7 @@ class GeminiQueryServiceTest extends TestCase
         $pool = $this->createMock(GeminiClientPool::class);
         $pool->expects(self::once())
             ->method('executeWithRetry')
-            ->willReturnCallback(static function (callable $callback): string {
-                return '[{"title": "Test", "type": "bd"}]';
-            });
+            ->willReturnCallback(static fn (callable $callback): string => '[{"title": "Test", "type": "bd"}]');
 
         $service = new GeminiQueryService($pool);
         $result = $service->queryJsonArray('prompt');

--- a/backend/tests/Unit/Service/Lookup/LookupOrchestratorTest.php
+++ b/backend/tests/Unit/Service/Lookup/LookupOrchestratorTest.php
@@ -350,16 +350,7 @@ final class LookupOrchestratorTest extends TestCase
         // Le slow provider doit avoir eu le temps de s'executer (premier dans la liste)
         // Le fast provider devrait etre en timeout
         $messages = $orchestrator->getLastApiMessages();
-
-        // Au moins un provider doit avoir le statut timeout
-        $hasTimeout = false;
-        foreach ($messages as $message) {
-            if ('timeout' === $message->status) {
-                $hasTimeout = true;
-
-                break;
-            }
-        }
+        $hasTimeout = \array_any($messages, static fn (ApiMessage $message): bool => 'timeout' === $message->status);
 
         self::assertTrue($hasTimeout, 'Au moins un provider devrait avoir le statut timeout');
     }
@@ -575,15 +566,9 @@ final class LookupOrchestratorTest extends TestCase
      */
     public function testLookupByTitlePropagatesComicType(): void
     {
-        $calledWithType = null;
-        $calledSupportsType = null;
-
-        $provider = new class($calledWithType, $calledSupportsType) implements LookupProviderInterface {
-            public function __construct(
-                private mixed &$calledWithType,
-                private mixed &$calledSupportsType,
-            ) {
-            }
+        $provider = new class implements LookupProviderInterface {
+            public ?ComicType $calledWithType = null;
+            public ?ComicType $calledSupportsType = null;
 
             public function getFieldPriority(string $field, ?ComicType $type = null): int
             {
@@ -624,8 +609,8 @@ final class LookupOrchestratorTest extends TestCase
 
         $orchestrator->lookupByTitle('One Piece', ComicType::MANGA);
 
-        self::assertSame(ComicType::MANGA, $calledWithType);
-        self::assertSame(ComicType::MANGA, $calledSupportsType);
+        self::assertSame(ComicType::MANGA, $provider->calledWithType);
+        self::assertSame(ComicType::MANGA, $provider->calledSupportsType);
     }
 
     /**
@@ -754,7 +739,6 @@ final class LookupOrchestratorTest extends TestCase
             name: 'silent_provider',
             result: new LookupResult(source: 'silent', title: 'Test'),
             supports: true,
-            apiMessage: null,
         );
 
         $orchestrator = new LookupOrchestrator(30.0, new NullLogger(), [$provider]);

--- a/backend/tests/Unit/Service/Recommendation/NewReleaseCheckerServiceTest.php
+++ b/backend/tests/Unit/Service/Recommendation/NewReleaseCheckerServiceTest.php
@@ -230,7 +230,7 @@ final class NewReleaseCheckerServiceTest extends TestCase
 
         $this->repository->method('findActiveForReleaseCheck')->willReturn([$series]);
 
-        $result = new LookupResult(latestPublishedIssue: null);
+        $result = new LookupResult();
         $this->lookupOrchestrator->method('lookupByTitle')->willReturn($result);
         $this->lookupOrchestrator->method('getLastApiMessages')->willReturn([]);
 

--- a/backend/tests/Unit/Service/Share/ShareResolverTest.php
+++ b/backend/tests/Unit/Service/Share/ShareResolverTest.php
@@ -64,9 +64,7 @@ final class ShareResolverTest extends TestCase
         $this->messageBus
             ->expects($this->once())
             ->method('dispatch')
-            ->with($this->callback(static function (EnrichSeriesMessage $msg): bool {
-                return 42 === $msg->seriesId && 'event:share' === $msg->triggeredBy;
-            }))
+            ->with($this->callback(static fn (EnrichSeriesMessage $msg): bool => 42 === $msg->seriesId && 'event:share' === $msg->triggeredBy))
             ->willReturn(new Envelope(new EnrichSeriesMessage(42, 'event:share')));
 
         $resolution = $this->resolver->resolve($info);
@@ -84,7 +82,7 @@ final class ShareResolverTest extends TestCase
             titleHint: 'Lanfeust de Troy',
         );
 
-        $result = new LookupResult(title: 'Lanfeust de Troy', isbn: null);
+        $result = new LookupResult(title: 'Lanfeust de Troy');
 
         $this->lookupOrchestrator
             ->expects($this->once())
@@ -165,7 +163,7 @@ final class ShareResolverTest extends TestCase
             type: ComicType::BD,
         );
 
-        $result = new LookupResult(title: 'Astérix', isbn: null);
+        $result = new LookupResult(title: 'Astérix');
         $series = $this->createSeriesStub(7);
 
         $this->lookupOrchestrator
@@ -229,9 +227,7 @@ final class ShareResolverTest extends TestCase
         $this->messageBus
             ->expects($this->once())
             ->method('dispatch')
-            ->with($this->callback(static function (EnrichSeriesMessage $msg): bool {
-                return 15 === $msg->seriesId && 'event:share' === $msg->triggeredBy;
-            }))
+            ->with($this->callback(static fn (EnrichSeriesMessage $msg): bool => 15 === $msg->seriesId && 'event:share' === $msg->triggeredBy))
             ->willReturn(new Envelope(new EnrichSeriesMessage(15, 'event:share')));
 
         $resolution = $this->resolver->resolve($info);

--- a/backend/tests/bootstrap.php
+++ b/backend/tests/bootstrap.php
@@ -7,7 +7,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require \dirname(__DIR__).'/vendor/autoload.php';
 
 if (\method_exists(Dotenv::class, 'bootEnv')) {
-    (new Dotenv())->bootEnv(\dirname(__DIR__).'/.env');
+    new Dotenv()->bootEnv(\dirname(__DIR__).'/.env');
 }
 
 if ($_SERVER['APP_DEBUG']) {

--- a/docs/guide-developpeur.md
+++ b/docs/guide-developpeur.md
@@ -4,7 +4,7 @@
 
 - **DDEV** >= 1.24 (inclut PHP, MariaDB, nginx, Node.js)
 - **Git**
-- Ou bien : PHP 8.3+, MariaDB 10.11+, Composer 2, Node.js 20+, nginx (voir les guides de déploiement [NAS](guide-deploiement-nas.md))
+- Ou bien : PHP 8.4+, MariaDB 10.11+, Composer 2, Node.js 20+, nginx (voir les guides de déploiement [NAS](guide-deploiement-nas.md))
 
 ---
 
@@ -124,7 +124,7 @@ Toutes les commandes s'exécutent via `ddev exec make <cible>` :
 
 | Composant | Version | Usage |
 |-----------|---------|-------|
-| PHP | 8.3+ | Langage |
+| PHP | 8.4+ | Langage |
 | Symfony | 7.4 | Framework |
 | API Platform | 4 | Génération de l'API REST (JSON-LD) |
 | Doctrine ORM | 3 | Persistance |

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -461,7 +461,7 @@ Three-tier: Unit + Integration. Vitest 4 + jsdom + RTL + MSW.
 
 | File | Purpose |
 |------|---------|
-| `backend/Dockerfile` | Multi-stage: Node.js 22 builds frontend (Vite) → `dunglas/frankenphp:1-php8.3` + composer:2 + extensions (gd/intl/opcache/pdo_mysql/zip). Build context = monorepo root (needs `frontend/` + `backend/`) |
+| `backend/Dockerfile` | Multi-stage: Node.js 22 builds frontend (Vite) → `dunglas/frankenphp:1-php8.4` + composer:2 + extensions (gd/intl/opcache/pdo_mysql/zip). Build context = monorepo root (needs `frontend/` + `backend/`) |
 | `backend/docker/frankenphp/Caddyfile` | Caddy site (port 8080): security headers, `/api` + `/media` (LiipImagine fallback) → PHP, reste → SPA React (`index.html` fallback), upload 12 Mo |
 | `backend/docker/frankenphp/supervisord.conf` | PID 1: `frankenphp run` + `messenger:consume async` + `messenger:consume scheduler_default`, tous en www-data |
 | `backend/docker/frankenphp/docker-entrypoint.sh` | chown volumes + /data /config (root) → cache:clear/warmup (www-data) → exec supervisord |


### PR DESCRIPTION
## Summary

- Bump du requirement PHP à `>=8.4` dans `composer.json` et mise à niveau de l'infrastructure (DDEV `php_version: "8.4"`, image Dockerfile `dunglas/frankenphp:1-php8.4`, CI GitHub Actions `php-version: '8.4'`)
- `composer update` et rafraîchissement des dépendances et du lockfile
- Activation du set `php84: true` dans `rector.php`, nettoyage des règles obsolètes et application des refactorings automatiques
- Alignement du style de code via `php-cs-fixer`
- Implémentation des méthodes calculées `isWishlist()`, `isComplete()` et `getReadPercent()` sur `ComicSeries` avec couverture de tests unitaires
- Documentation et CHANGELOG mis à jour

fixes #442

## Test plan

- [x] PHPStan niveau 9 : 0 erreur sur 265 fichiers
- [x] PHP-CS-Fixer : 0 violation sur 289 fichiers
- [x] PHPUnit backend : 1099 tests, 2999 assertions (0 échec)
- [x] Frontend tsc & vitest : compilation et tests OK
- [x] Docker build prod : image FrankenPHP 8.4 compilée avec succès